### PR TITLE
feat(db,embed): add pluggable embedder metadata and mismatch detection

### DIFF
--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -29,15 +29,26 @@ var goSDKURLs = []string{
 
 func main() {
 	dbPath := flag.String("db", "deadzone.db", "path to turso database file")
+	embedderKind := flag.String("embedder", embed.KindStub, "embedder to use (valid: stub)")
 	flag.Parse()
 
-	d, err := db.Open(*dbPath)
+	e, err := embed.New(*embedderKind)
+	if err != nil {
+		log.Fatalf("embedder: %v", err)
+	}
+
+	// db.Open enforces meta consistency: if the database already exists
+	// and was indexed with a different embedder, it returns
+	// db.ErrEmbedderMismatch and we abort without touching the data.
+	d, err := db.Open(*dbPath, db.Meta{
+		EmbedderKind: e.Kind(),
+		EmbeddingDim: e.Dim(),
+		ModelVersion: e.ModelVersion(),
+	})
 	if err != nil {
 		log.Fatalf("open db: %v", err)
 	}
 	defer d.Close()
-
-	e := embed.NewStub()
 
 	src := scraper.Source{
 		LibID: goSDKLibID,
@@ -58,5 +69,5 @@ func main() {
 		}
 	}
 
-	log.Printf("indexed %d docs (dim=%d) for %s into %s", len(docs), embed.Dim, src.LibID, *dbPath)
+	log.Printf("indexed %d docs (embedder=%s dim=%d) for %s into %s", len(docs), e.Kind(), e.Dim(), src.LibID, *dbPath)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"flag"
 	"log"
 
@@ -36,7 +35,7 @@ const (
 	searchK       = 10
 )
 
-func makeSearchHandler(d *sql.DB, e embed.Embedder) func(context.Context, *mcp.CallToolRequest, SearchDocsInput) (*mcp.CallToolResult, SearchDocsOutput, error) {
+func makeSearchHandler(d *db.DB, e embed.Embedder) func(context.Context, *mcp.CallToolRequest, SearchDocsInput) (*mcp.CallToolResult, SearchDocsOutput, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input SearchDocsInput) (*mcp.CallToolResult, SearchDocsOutput, error) {
 		queryVec := e.Embed(input.Query)
 		docs, err := db.SearchByEmbedding(d, queryVec, input.LibID, searchK)
@@ -78,15 +77,27 @@ func makeSearchHandler(d *sql.DB, e embed.Embedder) func(context.Context, *mcp.C
 
 func main() {
 	dbPath := flag.String("db", "deadzone.db", "path to turso database file")
+	embedderKind := flag.String("embedder", embed.KindStub, "embedder to use (valid: stub)")
 	flag.Parse()
 
-	d, err := db.Open(*dbPath)
+	// Phase 1 only knows about "stub", so the embedder is fully
+	// determined by the flag. db.Open then validates the embedder's
+	// reported meta against whatever the database was created with;
+	// a mismatch fails fast and tells the user to rebuild.
+	e, err := embed.New(*embedderKind)
+	if err != nil {
+		log.Fatalf("embedder: %v", err)
+	}
+
+	d, err := db.Open(*dbPath, db.Meta{
+		EmbedderKind: e.Kind(),
+		EmbeddingDim: e.Dim(),
+		ModelVersion: e.ModelVersion(),
+	})
 	if err != nil {
 		log.Fatalf("open db: %v", err)
 	}
 	defer d.Close()
-
-	e := embed.NewStub()
 
 	s := mcp.NewServer(&mcp.Implementation{Name: "deadzone", Version: "v0.1.0"}, nil)
 	mcp.AddTool(s, &mcp.Tool{

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -11,13 +11,16 @@ import (
 )
 
 func TestHandleSearchDocs_ReturnsSnippets(t *testing.T) {
-	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	e := embed.NewStub()
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"), db.Meta{
+		EmbedderKind: e.Kind(),
+		EmbeddingDim: e.Dim(),
+		ModelVersion: e.ModelVersion(),
+	})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
 	defer d.Close()
-
-	e := embed.NewStub()
 	docs := []db.Doc{
 		{LibID: "/modelcontextprotocol/go-sdk", Title: "Tool registration", Content: "Use mcp.AddTool to register tools on the server."},
 		{LibID: "/modelcontextprotocol/go-sdk", Title: "Server setup", Content: "Create a server with mcp.NewServer."},

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,11 +1,19 @@
 // Package db manages the local turso database that backs deadzone's
-// vector-based semantic search. Documents are stored as TEXT alongside a
-// fixed-dimension F32_BLOB embedding column; queries are ranked by
-// vector_distance_cos against the query's embedding.
+// vector-based semantic search. Documents are stored as TEXT alongside an
+// F32_BLOB embedding column whose width is set at Open time from the
+// embedder's reported Dim, and queries are ranked by vector_distance_cos
+// against the query's embedding.
+//
+// The package is intentionally embedder-agnostic: it does not import
+// internal/embed, and the embedder's identity travels through the Meta
+// struct supplied by the caller. The meta table records this identity in
+// the database itself so a binary opening an existing file can detect
+// (and refuse) a mismatch with the embedder it was asked to use.
 package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -13,10 +21,34 @@ import (
 	_ "turso.tech/database/tursogo"
 )
 
-// Dim is the fixed embedding dimension stored in the docs.embedding column.
-// Must stay in sync with internal/embed.Dim. Duplicated here to keep the
-// package graph one-way (db does not import embed).
-const Dim = 64
+// ErrEmbedderMismatch is returned by Open when the meta stored in an
+// existing database disagrees with the Meta the caller passed in. Callers
+// should treat this as fatal: there is no safe way to mix vectors produced
+// by different embedders in the same docs table. Wrap with errors.Is to
+// detect.
+var ErrEmbedderMismatch = errors.New("embedder metadata mismatch")
+
+// Meta describes the embedder a database was created with. It is written
+// to the meta table the first time a fresh DB is opened and cross-checked
+// on every subsequent open.
+//
+// Equality is by value: every field must match exactly for a reopen to be
+// accepted. Bumping ModelVersion in the embedder is therefore the standard
+// way to invalidate previously-indexed databases.
+type Meta struct {
+	EmbedderKind string
+	EmbeddingDim int
+	ModelVersion string
+}
+
+// DB wraps *sql.DB with the Meta the database was opened with so that
+// Insert and SearchByEmbedding can validate vector lengths without
+// re-reading the meta table on every call. *sql.DB is embedded so callers
+// can still use QueryRow, Exec, Close, etc. directly on a *DB.
+type DB struct {
+	*sql.DB
+	Meta Meta
+}
 
 // Doc represents a documentation snippet stored in the docs table.
 type Doc struct {
@@ -26,11 +58,24 @@ type Doc struct {
 }
 
 // Open opens (or creates) a local turso database at path and ensures the
-// docs schema is in place. tursogo's DSN is a bare path — the "file:"
-// prefix used by libSQL is NOT stripped and would create a file literally
-// named "file:<path>".
-func Open(path string) (*sql.DB, error) {
-	d, err := sql.Open("turso", path)
+// schema is in place. The meta argument describes the embedder the caller
+// intends to use:
+//
+//   - On a fresh database, the meta is persisted and the docs table is
+//     created with an F32_BLOB column whose width matches meta.EmbeddingDim.
+//   - On an existing database, the stored meta must equal the supplied
+//     meta — otherwise ErrEmbedderMismatch is returned, wrapped with the
+//     conflicting values so the user knows what to do (typically: rebuild
+//     the database with a fresh file).
+//
+// tursogo's DSN is a bare path — the "file:" prefix used by libSQL is NOT
+// stripped and would create a file literally named "file:<path>".
+func Open(path string, meta Meta) (*DB, error) {
+	if err := validateMeta(meta); err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+
+	raw, err := sql.Open("turso", path)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
@@ -39,29 +84,67 @@ func Open(path string) (*sql.DB, error) {
 	// potential driver-level races. Harmless for the MCP server's
 	// one-query-at-a-time workload.
 	// TODO: revisit once tursogo reaches a stable release.
-	d.SetMaxOpenConns(1)
+	raw.SetMaxOpenConns(1)
 
-	if _, err := d.Exec(`CREATE TABLE IF NOT EXISTS docs (
+	// The meta table is created unconditionally on every Open so even a
+	// freshly-created file is queryable for its embedder identity.
+	if _, err := raw.Exec(`CREATE TABLE IF NOT EXISTS meta (
+		key   TEXT PRIMARY KEY,
+		value TEXT NOT NULL
+	)`); err != nil {
+		raw.Close()
+		return nil, fmt.Errorf("create meta table: %w", err)
+	}
+
+	stored, hasMeta, err := readMeta(raw)
+	if err != nil {
+		raw.Close()
+		return nil, fmt.Errorf("read meta: %w", err)
+	}
+
+	if hasMeta {
+		if stored != meta {
+			raw.Close()
+			return nil, fmt.Errorf("%w: stored=%+v requested=%+v; use a fresh database file or rebuild with the matching embedder",
+				ErrEmbedderMismatch, stored, meta)
+		}
+	} else {
+		if err := writeMeta(raw, meta); err != nil {
+			raw.Close()
+			return nil, fmt.Errorf("write meta: %w", err)
+		}
+	}
+
+	// The docs table's vector width is determined by meta.EmbeddingDim.
+	// CREATE TABLE IF NOT EXISTS is safe across reopens because the
+	// mismatch check above has already guaranteed the dim hasn't changed
+	// since the table was first created.
+	docsSchema := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS docs (
 		id INTEGER PRIMARY KEY,
 		lib_id TEXT NOT NULL,
 		title TEXT NOT NULL,
 		content TEXT NOT NULL,
-		embedding F32_BLOB(64) NOT NULL
-	)`); err != nil {
+		embedding F32_BLOB(%d) NOT NULL
+	)`, meta.EmbeddingDim)
+	if _, err := raw.Exec(docsSchema); err != nil {
+		raw.Close()
 		return nil, fmt.Errorf("create docs table: %w", err)
 	}
-	if _, err := d.Exec(`CREATE INDEX IF NOT EXISTS idx_docs_lib_id ON docs(lib_id)`); err != nil {
+	if _, err := raw.Exec(`CREATE INDEX IF NOT EXISTS idx_docs_lib_id ON docs(lib_id)`); err != nil {
+		raw.Close()
 		return nil, fmt.Errorf("create lib_id index: %w", err)
 	}
 
-	return d, nil
+	return &DB{DB: raw, Meta: meta}, nil
 }
 
 // Insert stores a Doc along with its precomputed embedding. The embedding
-// must have exactly Dim components.
-func Insert(db *sql.DB, doc Doc, embedding []float32) error {
-	if len(embedding) != Dim {
-		return fmt.Errorf("insert doc: embedding length %d, want %d", len(embedding), Dim)
+// must have exactly db.Meta.EmbeddingDim components — the dimension travels
+// with the *DB rather than being a package-level constant so a single
+// binary can support multiple embedder kinds.
+func Insert(db *DB, doc Doc, embedding []float32) error {
+	if len(embedding) != db.Meta.EmbeddingDim {
+		return fmt.Errorf("insert doc: embedding length %d, want %d", len(embedding), db.Meta.EmbeddingDim)
 	}
 	_, err := db.Exec(
 		`INSERT INTO docs(lib_id, title, content, embedding) VALUES (?, ?, ?, vector(?))`,
@@ -75,10 +158,11 @@ func Insert(db *sql.DB, doc Doc, embedding []float32) error {
 
 // SearchByEmbedding returns the top-k Docs ranked by cosine distance to
 // queryVec (lower = more similar). If libID is non-empty, results are
-// filtered to that library. k defaults to 10 if <= 0.
-func SearchByEmbedding(db *sql.DB, queryVec []float32, libID string, k int) ([]Doc, error) {
-	if len(queryVec) != Dim {
-		return nil, fmt.Errorf("search: query vector length %d, want %d", len(queryVec), Dim)
+// filtered to that library. k defaults to 10 if <= 0. The query vector
+// must have db.Meta.EmbeddingDim components.
+func SearchByEmbedding(db *DB, queryVec []float32, libID string, k int) ([]Doc, error) {
+	if len(queryVec) != db.Meta.EmbeddingDim {
+		return nil, fmt.Errorf("search: query vector length %d, want %d", len(queryVec), db.Meta.EmbeddingDim)
 	}
 	if k <= 0 {
 		k = 10
@@ -122,6 +206,99 @@ func SearchByEmbedding(db *sql.DB, queryVec []float32, libID string, k int) ([]D
 		results = append(results, d)
 	}
 	return results, rows.Err()
+}
+
+// Meta table key names. Defined as constants to keep the read/write paths
+// in sync and to give callers a single place to look for "what does the
+// meta table actually contain".
+const (
+	metaKeyEmbedderKind = "embedder_kind"
+	metaKeyEmbeddingDim = "embedding_dim"
+	metaKeyModelVersion = "model_version"
+)
+
+func validateMeta(m Meta) error {
+	if m.EmbedderKind == "" {
+		return errors.New("meta.EmbedderKind must not be empty")
+	}
+	if m.EmbeddingDim <= 0 {
+		return fmt.Errorf("meta.EmbeddingDim must be > 0, got %d", m.EmbeddingDim)
+	}
+	if m.ModelVersion == "" {
+		return errors.New("meta.ModelVersion must not be empty")
+	}
+	return nil
+}
+
+// readMeta returns the stored Meta and a boolean indicating whether any
+// meta rows were found. A partially-populated meta table (some keys
+// present, others missing) is treated as a corrupt database and returns
+// an error rather than silently filling the gaps from the caller.
+func readMeta(raw *sql.DB) (Meta, bool, error) {
+	rows, err := raw.Query(`SELECT key, value FROM meta`)
+	if err != nil {
+		return Meta{}, false, err
+	}
+	defer rows.Close()
+
+	values := map[string]string{}
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return Meta{}, false, err
+		}
+		values[k] = v
+	}
+	if err := rows.Err(); err != nil {
+		return Meta{}, false, err
+	}
+
+	if len(values) == 0 {
+		return Meta{}, false, nil
+	}
+
+	kind, hasKind := values[metaKeyEmbedderKind]
+	dimStr, hasDim := values[metaKeyEmbeddingDim]
+	version, hasVersion := values[metaKeyModelVersion]
+	if !hasKind || !hasDim || !hasVersion {
+		return Meta{}, false, fmt.Errorf("meta table has unexpected keys %v; expected %s, %s, %s",
+			keysOf(values), metaKeyEmbedderKind, metaKeyEmbeddingDim, metaKeyModelVersion)
+	}
+
+	dim, err := strconv.Atoi(dimStr)
+	if err != nil {
+		return Meta{}, false, fmt.Errorf("parse %s=%q: %w", metaKeyEmbeddingDim, dimStr, err)
+	}
+
+	return Meta{
+		EmbedderKind: kind,
+		EmbeddingDim: dim,
+		ModelVersion: version,
+	}, true, nil
+}
+
+func writeMeta(raw *sql.DB, m Meta) error {
+	rows := []struct {
+		key, value string
+	}{
+		{metaKeyEmbedderKind, m.EmbedderKind},
+		{metaKeyEmbeddingDim, strconv.Itoa(m.EmbeddingDim)},
+		{metaKeyModelVersion, m.ModelVersion},
+	}
+	for _, r := range rows {
+		if _, err := raw.Exec(`INSERT INTO meta(key, value) VALUES (?, ?)`, r.key, r.value); err != nil {
+			return fmt.Errorf("write %s: %w", r.key, err)
+		}
+	}
+	return nil
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 // formatVector encodes a []float32 as a JSON array literal understood by

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,13 +16,30 @@ func embedText(e embed.Embedder, d db.Doc) []float32 {
 	return e.Embed(d.Title + "\n" + d.Content)
 }
 
-func TestOpen_CreatesDocsTable(t *testing.T) {
+// metaFor extracts a db.Meta from an embed.Embedder. The same little
+// adapter is needed in cmd/scraper and cmd/server too; defining it as a
+// helper here keeps the tests readable.
+func metaFor(e embed.Embedder) db.Meta {
+	return db.Meta{
+		EmbedderKind: e.Kind(),
+		EmbeddingDim: e.Dim(),
+		ModelVersion: e.ModelVersion(),
+	}
+}
+
+func openStub(t *testing.T) *db.DB {
+	t.Helper()
 	path := filepath.Join(t.TempDir(), "test.db")
-	d, err := db.Open(path)
+	d, err := db.Open(path, metaFor(embed.NewStub()))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer d.Close()
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func TestOpen_CreatesDocsTable(t *testing.T) {
+	d := openStub(t)
 
 	// Verify the table exists by inserting through the real Insert path.
 	e := embed.NewStub()
@@ -32,12 +50,7 @@ func TestOpen_CreatesDocsTable(t *testing.T) {
 }
 
 func TestInsert(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "test.db")
-	d, err := db.Open(path)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer d.Close()
+	d := openStub(t)
 
 	e := embed.NewStub()
 	docs := []db.Doc{
@@ -62,26 +75,16 @@ func TestInsert(t *testing.T) {
 }
 
 func TestInsert_RejectsWrongDim(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "test.db")
-	d, err := db.Open(path)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer d.Close()
+	d := openStub(t)
 
-	err = db.Insert(d, db.Doc{LibID: "x", Title: "t", Content: "c"}, []float32{0.1, 0.2})
+	err := db.Insert(d, db.Doc{LibID: "x", Title: "t", Content: "c"}, []float32{0.1, 0.2})
 	if err == nil {
 		t.Fatal("expected error for wrong-dimension embedding, got nil")
 	}
 }
 
 func TestSearchByEmbedding_RanksRelevantFirst(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "test.db")
-	d, err := db.Open(path)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer d.Close()
+	d := openStub(t)
 
 	e := embed.NewStub()
 	docs := []db.Doc{
@@ -111,12 +114,7 @@ func TestSearchByEmbedding_RanksRelevantFirst(t *testing.T) {
 }
 
 func TestSearchByEmbedding_FiltersByLib(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "test.db")
-	d, err := db.Open(path)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer d.Close()
+	d := openStub(t)
 
 	e := embed.NewStub()
 	docs := []db.Doc{
@@ -148,12 +146,7 @@ func TestSearchByEmbedding_FiltersByLib(t *testing.T) {
 // semantic overlap (camelCase split + token bag), even though the query
 // uses natural language and the target snippet uses an identifier.
 func TestSearchByEmbedding_Acceptance(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "test.db")
-	d, err := db.Open(path)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer d.Close()
+	d := openStub(t)
 
 	e := embed.NewStub()
 	docs := []db.Doc{
@@ -179,6 +172,92 @@ func TestSearchByEmbedding_Acceptance(t *testing.T) {
 		for i, r := range results {
 			t.Logf("  #%d: [%s] %s", i+1, r.LibID, r.Title)
 		}
+	}
+}
+
+// TestDB_RejectsEmbedderMismatch is the meta-enforcement test from the
+// issue: a DB created with one embedder kind must refuse to be reopened
+// with a different one. The check fires at Open time so callers cannot
+// even reach an Insert with mismatched vectors.
+func TestDB_RejectsEmbedderMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.db")
+
+	stub := embed.NewStub()
+	d, err := db.Open(path, metaFor(stub))
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	// Indexing one doc to confirm we are exercising a real, populated DB
+	// and not a degenerate empty file.
+	doc := db.Doc{LibID: "x", Title: "t", Content: "c"}
+	if err := db.Insert(d, doc, embedText(stub, doc)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		meta db.Meta
+	}{
+		{
+			name: "different kind",
+			meta: db.Meta{EmbedderKind: "fake", EmbeddingDim: stub.Dim(), ModelVersion: stub.ModelVersion()},
+		},
+		{
+			name: "different dim",
+			meta: db.Meta{EmbedderKind: stub.Kind(), EmbeddingDim: stub.Dim() + 1, ModelVersion: stub.ModelVersion()},
+		},
+		{
+			name: "different model version",
+			meta: db.Meta{EmbedderKind: stub.Kind(), EmbeddingDim: stub.Dim(), ModelVersion: "stub-v2"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reopened, err := db.Open(path, tc.meta)
+			if err == nil {
+				reopened.Close()
+				t.Fatal("expected ErrEmbedderMismatch, got nil")
+			}
+			if !errors.Is(err, db.ErrEmbedderMismatch) {
+				t.Errorf("expected ErrEmbedderMismatch, got %v", err)
+			}
+		})
+	}
+}
+
+// TestDB_RoundtripsMeta verifies that the meta the embedder reports is
+// what gets persisted, and that reopening the DB exposes the same Meta
+// via the wrapper struct without the caller having to re-read the table.
+func TestDB_RoundtripsMeta(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.db")
+	stub := embed.NewStub()
+	want := metaFor(stub)
+
+	d, err := db.Open(path, want)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if d.Meta != want {
+		t.Errorf("first open Meta = %+v, want %+v", d.Meta, want)
+	}
+	doc := db.Doc{LibID: "lib", Title: "Title", Content: "Content"}
+	if err := db.Insert(d, doc, embedText(stub, doc)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := db.Open(path, want)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+	if reopened.Meta != want {
+		t.Errorf("reopened Meta = %+v, want %+v", reopened.Meta, want)
 	}
 }
 

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -7,22 +7,64 @@
 package embed
 
 import (
+	"fmt"
 	"hash/fnv"
 	"math"
 	"strings"
 	"unicode"
 )
 
-// Dim is the fixed embedding dimension. Must match the F32_BLOB(N) column
-// width in internal/db. Chosen to match upstream tursogo's
-// TestVectorOperations fixture size.
-const Dim = 64
+// KindStub is the Kind() value reported by the Stub embedder. It is the
+// only valid value for the -embedder flag in Phase 1.
+const KindStub = "stub"
+
+// stubDim is the Stub embedder's output dimension. Chosen to match upstream
+// tursogo's TestVectorOperations fixture size. Not exported because callers
+// must read it via Embedder.Dim() — there is no global "the dimension"
+// anymore now that the binary is meant to support multiple embedders.
+const stubDim = 64
+
+// stubModelVersion identifies this revision of the stub. Bump it when the
+// hashing or tokenization changes in a way that invalidates already-indexed
+// vectors so existing DBs are rejected at Open time.
+const stubModelVersion = "stub-v1"
 
 // Embedder turns text into a fixed-dimension embedding vector.
 // Implementations must be deterministic: the same input must always produce
 // the same output, so that indexed vectors and query vectors are comparable.
+//
+// Kind, Dim, and ModelVersion are written into the database's meta table on
+// first use and cross-checked on every subsequent open, so that a binary
+// running with embedder X cannot accidentally read or write a database that
+// was indexed with embedder Y.
 type Embedder interface {
+	// Embed returns a vector of length Dim() for the given text.
 	Embed(text string) []float32
+
+	// Kind identifies the embedder family (e.g. "stub", "real").
+	// Used for meta consistency checks between scraper and server runs.
+	Kind() string
+
+	// Dim is the output vector dimension. Must be constant for the
+	// lifetime of the Embedder.
+	Dim() int
+
+	// ModelVersion identifies the specific model producing the
+	// embeddings (e.g. "stub-v1", "all-MiniLM-L6-v2"). Stored in the
+	// DB meta table and cross-checked at open time.
+	ModelVersion() string
+}
+
+// New returns an Embedder for the given kind. Phase 1 only knows "stub";
+// unknown kinds return an error so cmd/scraper and cmd/server can fail
+// cleanly with a useful message.
+func New(kind string) (Embedder, error) {
+	switch kind {
+	case KindStub:
+		return NewStub(), nil
+	default:
+		return nil, fmt.Errorf("unknown embedder kind %q (valid: %s)", kind, KindStub)
+	}
 }
 
 // Stub is a deterministic bag-of-tokens embedder. Not semantically meaningful
@@ -30,20 +72,30 @@ type Embedder interface {
 // while a real model is under development.
 //
 // Tokens are lowercased, split on non-alphanumeric characters and on
-// camelCase boundaries, and hashed into dimensions modulo Dim. A 4-character
-// prefix of each token is also hashed with weight 0.5, which gives "tool"
-// and "tools" a small amount of soft overlap. The resulting vector is
-// L2-normalized so cosine distance is well-behaved.
+// camelCase boundaries, and hashed into dimensions modulo Dim(). A
+// 4-character prefix of each token is also hashed with weight 0.5, which
+// gives "tool" and "tools" a small amount of soft overlap. The resulting
+// vector is L2-normalized so cosine distance is well-behaved.
 type Stub struct{}
 
 // NewStub returns a Stub embedder. Zero-cost — the type has no state.
 func NewStub() Stub { return Stub{} }
 
+// Kind reports the embedder family. Always "stub".
+func (Stub) Kind() string { return KindStub }
+
+// Dim reports the output dimension. Always stubDim.
+func (Stub) Dim() int { return stubDim }
+
+// ModelVersion identifies the stub revision. Bump stubModelVersion when the
+// tokenization or hashing changes in a backwards-incompatible way.
+func (Stub) ModelVersion() string { return stubModelVersion }
+
 // Embed computes a deterministic embedding for text. The returned slice has
-// length Dim and is L2-normalized (unit-norm) for every input, including the
-// empty string.
+// length Dim() and is L2-normalized (unit-norm) for every input, including
+// the empty string.
 func (Stub) Embed(text string) []float32 {
-	vec := make([]float32, Dim)
+	vec := make([]float32, stubDim)
 	for _, tok := range tokenize(text) {
 		vec[hashToDim(tok)]++
 		if len(tok) > 4 {
@@ -89,7 +141,7 @@ func tokenize(text string) []string {
 func hashToDim(s string) int {
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(s))
-	return int(h.Sum32() % Dim)
+	return int(h.Sum32() % stubDim)
 }
 
 func normalize(v []float32) []float32 {

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -52,10 +52,41 @@ func TestStub_Dim(t *testing.T) {
 	cases := []string{"", "x", "hello world", "Register tools using mcp.AddTool"}
 	for _, c := range cases {
 		v := e.Embed(c)
-		if len(v) != embed.Dim {
-			t.Errorf("Embed(%q) len = %d, want %d", c, len(v), embed.Dim)
+		if len(v) != e.Dim() {
+			t.Errorf("Embed(%q) len = %d, want %d", c, len(v), e.Dim())
 		}
 	}
+}
+
+func TestStub_Metadata(t *testing.T) {
+	e := embed.NewStub()
+	if got := e.Kind(); got != "stub" {
+		t.Errorf("Kind() = %q, want %q", got, "stub")
+	}
+	if got := e.Dim(); got <= 0 {
+		t.Errorf("Dim() = %d, want > 0", got)
+	}
+	if got := e.ModelVersion(); got == "" {
+		t.Error("ModelVersion() returned empty string")
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Run("stub", func(t *testing.T) {
+		e, err := embed.New("stub")
+		if err != nil {
+			t.Fatalf("New(stub): %v", err)
+		}
+		if e.Kind() != "stub" {
+			t.Errorf("Kind() = %q, want %q", e.Kind(), "stub")
+		}
+	})
+
+	t.Run("unknown kind", func(t *testing.T) {
+		if _, err := embed.New("does-not-exist"); err == nil {
+			t.Fatal("expected error for unknown kind, got nil")
+		}
+	})
 }
 
 func TestStub_UnitNorm(t *testing.T) {
@@ -79,8 +110,8 @@ func TestStub_EmptyString(t *testing.T) {
 	if v == nil {
 		t.Fatal("Embed(\"\") returned nil")
 	}
-	if len(v) != embed.Dim {
-		t.Fatalf("Embed(\"\") len = %d, want %d", len(v), embed.Dim)
+	if len(v) != e.Dim() {
+		t.Fatalf("Embed(\"\") len = %d, want %d", len(v), e.Dim())
 	}
 	// All components must be finite (no NaN / Inf).
 	for i, x := range v {


### PR DESCRIPTION
## Summary

- Introduce `db.Meta` struct that records embedder identity (kind, dimension, model version) in a new `meta` table, persisted on first open and cross-checked on every subsequent open
- Return `db.ErrEmbedderMismatch` when an existing database was indexed with a different embedder, preventing silent vector corruption
- Expand the `Embedder` interface with `Kind()`, `Dim()`, and `ModelVersion()` methods so embedder metadata flows through the system without the db package importing embed
- Replace the hardcoded `Dim = 64` constant with per-embedder dimensions via the `DB` wrapper type
- Add `embed.New(kind)` factory and `-embedder` CLI flag to both scraper and server

## Motivation

Prepares the codebase for supporting multiple real embedder backends (Phase 2+) by making the embedder identity a first-class concept stored alongside the vectors. Without this, swapping embedders would silently produce garbage search results from mismatched vector spaces.

## Test plan

- `TestDB_RejectsEmbedderMismatch` — verifies Open fails with `ErrEmbedderMismatch` for differing kind, dim, and model version
- `TestDB_RoundtripsMeta` — confirms meta survives close/reopen cycle
- `TestStub_Metadata` — validates Kind, Dim, ModelVersion on the stub embedder
- `TestNew` — exercises the factory for known and unknown kinds
- All existing search and insert tests updated to use the new `db.Open` signature

<!-- emdash-issue-footer:start -->
Fixes #18
<!-- emdash-issue-footer:end -->