### PR TITLE
feat: add structured JSON logging to MCP server and scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ LLM clients send natural-language queries — `"how to register a tool"` should 
 
 More background in [`docs/research/context7-analysis.md`](docs/research/context7-analysis.md).
 
+## Debugging
+
+Both binaries emit structured JSON logs to **stderr** using `log/slog`. Stdout is reserved for the MCP JSON-RPC channel on `cmd/server`, so anything written there that isn't a valid JSON-RPC message disconnects the client — `cmd/scraper` follows the same convention for consistency.
+
+- **Scraper.** `just scrape` writes logs straight to your terminal. Look for `scraper.start`, one `scraper.fetch` per URL (with `bytes`, `duration_ms`, `docs_extracted`), `scraper.indexed` summaries, and a final `scraper.done`. The "silently stalls on one URL" failure mode shows up as a missing `scraper.fetch` event for that URL. Errors land as `scraper.fetch_failed` / `scraper.insert_failed` with the URL and wrapped error.
+- **Server.** `cmd/server`'s stderr is captured by the MCP client. In Claude Code that's the `~/Library/Logs/Claude/mcp-server-deadzone.log` file (macOS) or your client's equivalent — check the MCP client docs. On startup the server emits a `server.start` line with the embedder meta and the indexed `doc_count`; each `search_docs` call emits one `search_docs` line with `lib_id`, `tokens`, `results`, and `latency_ms`.
+- **Verbose mode.** Both binaries take `-verbose`. On the server it adds the raw `query` field to per-call logs (off by default because queries may contain user data). On the scraper it adds per-doc `scraper.doc_indexed` Debug lines, useful when debugging the parser on a new library.
+
 ## Roadmap
 
 Tracked on the [GitHub issues board](https://github.com/laradji/deadzone/issues). Open issues are scoped via the `mvp`, `feature`, `research`, and `post-mvp` labels.

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -3,11 +3,15 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	"fmt"
+	"log/slog"
 	"net/http"
+	"os"
+	"time"
 
 	"github.com/laradji/deadzone/internal/db"
 	"github.com/laradji/deadzone/internal/embed"
+	"github.com/laradji/deadzone/internal/logs"
 	"github.com/laradji/deadzone/internal/scraper"
 )
 
@@ -28,18 +32,30 @@ var goSDKURLs = []string{
 }
 
 func main() {
+	if err := run(); err != nil {
+		slog.Error("scraper fatal", "err", err.Error())
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	dbPath := flag.String("db", "deadzone.db", "path to turso database file")
 	embedderKind := flag.String("embedder", embed.KindHugot, "embedder to use (valid: hugot)")
+	verbose := flag.Bool("verbose", false, "emit per-doc Debug log lines in addition to per-URL summaries")
 	flag.Parse()
+
+	// stderr-only JSON logging keeps the scraper consistent with
+	// cmd/server (which has a hard stdout-is-JSON-RPC constraint).
+	slog.SetDefault(logs.New(os.Stderr, *verbose))
 
 	e, err := embed.New(*embedderKind)
 	if err != nil {
-		log.Fatalf("embedder: %v", err)
+		return fmt.Errorf("embedder: %w", err)
 	}
 	if c, ok := e.(interface{ Close() error }); ok {
 		defer func() {
 			if err := c.Close(); err != nil {
-				log.Printf("embedder close: %v", err)
+				slog.Warn("embedder close", "err", err.Error())
 			}
 		}()
 	}
@@ -53,7 +69,7 @@ func main() {
 		ModelVersion: e.ModelVersion(),
 	})
 	if err != nil {
-		log.Fatalf("open db: %v", err)
+		return fmt.Errorf("open db: %w", err)
 	}
 	defer d.Close()
 
@@ -62,19 +78,88 @@ func main() {
 		URLs:  goSDKURLs,
 	}
 
-	log.Printf("scraping %d URLs for %s", len(src.URLs), src.LibID)
+	slog.Info("scraper.start",
+		"lib_id", src.LibID,
+		"url_count", len(src.URLs),
+		"db_path", *dbPath,
+		"embedder_kind", e.Kind(),
+		"embedding_dim", e.Dim(),
+		"model_version", e.ModelVersion(),
+	)
 
-	docs, err := scraper.Fetch(context.Background(), http.DefaultClient, src)
-	if err != nil {
-		log.Fatalf("fetch: %v", err)
-	}
+	ctx := context.Background()
+	runStart := time.Now()
+	var docsTotal int
 
-	for _, doc := range docs {
-		vec := e.Embed(doc.Title + "\n" + doc.Content)
-		if err := db.Insert(d, doc, vec); err != nil {
-			log.Fatalf("insert %q: %v", doc.Title, err)
+	for _, u := range src.URLs {
+		// Per-URL fetch — split out from the embed/insert loop so the
+		// "silently stalls on one URL" failure mode shows up as a
+		// missing scraper.fetch event for that URL.
+		fetchStart := time.Now()
+		res, err := scraper.FetchOne(ctx, http.DefaultClient, src.LibID, u)
+		fetchDur := time.Since(fetchStart)
+		if err != nil {
+			slog.Error("scraper.fetch_failed",
+				"lib_id", src.LibID,
+				"url", u,
+				"duration_ms", fetchDur.Milliseconds(),
+				"err", err.Error(),
+			)
+			return fmt.Errorf("fetch %s: %w", u, err)
 		}
+		slog.Info("scraper.fetch",
+			"lib_id", src.LibID,
+			"url", u,
+			"bytes", res.Bytes,
+			"duration_ms", fetchDur.Milliseconds(),
+			"docs_extracted", len(res.Docs),
+		)
+
+		// Embed and insert each doc, summing per-step latencies so the
+		// scraper.indexed line carries the timing breakdown for the
+		// URL without one log line per doc (gated on -verbose).
+		var embedTotal, insertTotal time.Duration
+		for _, doc := range res.Docs {
+			embedStart := time.Now()
+			vec := e.Embed(doc.Title + "\n" + doc.Content)
+			embedTotal += time.Since(embedStart)
+
+			insertStart := time.Now()
+			if err := db.Insert(d, doc, vec); err != nil {
+				slog.Error("scraper.insert_failed",
+					"lib_id", doc.LibID,
+					"title", doc.Title,
+					"url", u,
+					"err", err.Error(),
+				)
+				return fmt.Errorf("insert %q: %w", doc.Title, err)
+			}
+			insertTotal += time.Since(insertStart)
+
+			slog.Debug("scraper.doc_indexed",
+				"lib_id", doc.LibID,
+				"title", doc.Title,
+				"url", u,
+				"content_bytes", len(doc.Content),
+			)
+		}
+
+		slog.Info("scraper.indexed",
+			"lib_id", src.LibID,
+			"url", u,
+			"docs_inserted", len(res.Docs),
+			"embed_ms_total", embedTotal.Milliseconds(),
+			"insert_ms_total", insertTotal.Milliseconds(),
+		)
+
+		docsTotal += len(res.Docs)
 	}
 
-	log.Printf("indexed %d docs (embedder=%s dim=%d) for %s into %s", len(docs), e.Kind(), e.Dim(), src.LibID, *dbPath)
+	slog.Info("scraper.done",
+		"lib_id", src.LibID,
+		"docs_total", docsTotal,
+		"duration_ms", time.Since(runStart).Milliseconds(),
+		"db_path", *dbPath,
+	)
+	return nil
 }

--- a/cmd/server/acceptance_test.go
+++ b/cmd/server/acceptance_test.go
@@ -96,7 +96,7 @@ func TestSemanticAcceptance(t *testing.T) {
 		}
 	}
 
-	handler := makeSearchHandler(d, testEmbedder)
+	handler := makeSearchHandler(d, testEmbedder, false)
 
 	for _, query := range semanticAcceptanceQueries {
 		t.Run(query, func(t *testing.T) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,12 +3,18 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
 
 	"github.com/laradji/deadzone/internal/db"
 	"github.com/laradji/deadzone/internal/embed"
+	"github.com/laradji/deadzone/internal/logs"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+const serverVersion = "v0.1.0"
 
 // Library IDs follow the format /org/project (e.g. /hashicorp/terraform)
 type SearchDocsInput struct {
@@ -35,11 +41,14 @@ const (
 	searchK       = 10
 )
 
-func makeSearchHandler(d *db.DB, e embed.Embedder) func(context.Context, *mcp.CallToolRequest, SearchDocsInput) (*mcp.CallToolResult, SearchDocsOutput, error) {
+func makeSearchHandler(d *db.DB, e embed.Embedder, verbose bool) func(context.Context, *mcp.CallToolRequest, SearchDocsInput) (*mcp.CallToolResult, SearchDocsOutput, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input SearchDocsInput) (*mcp.CallToolResult, SearchDocsOutput, error) {
+		start := time.Now()
+
 		queryVec := e.Embed(input.Query)
 		docs, err := db.SearchByEmbedding(d, queryVec, input.LibID, searchK)
 		if err != nil {
+			slog.Error("search_docs failed", searchAttrs(input, verbose, "err", err.Error())...)
 			return nil, SearchDocsOutput{}, err
 		}
 
@@ -71,26 +80,59 @@ func makeSearchHandler(d *db.DB, e embed.Embedder) func(context.Context, *mcp.Ca
 			snippets = []Snippet{}
 		}
 
+		slog.Info("search_docs", searchAttrs(input, verbose,
+			"tokens", tokens,
+			"results", len(snippets),
+			"latency_ms", time.Since(start).Milliseconds(),
+		)...)
+
 		return nil, SearchDocsOutput{Snippets: snippets}, nil
 	}
 }
 
+// searchAttrs builds the slog key/value list shared between the success
+// and error log lines for search_docs. The verbose flag adds the raw
+// query text — gated because queries may contain user data routed
+// through the LLM and we don't want it in default logs.
+func searchAttrs(input SearchDocsInput, verbose bool, extra ...any) []any {
+	attrs := make([]any, 0, 4+len(extra))
+	attrs = append(attrs, "lib_id", input.LibID)
+	attrs = append(attrs, extra...)
+	if verbose {
+		attrs = append(attrs, "query", input.Query)
+	}
+	return attrs
+}
+
 func main() {
+	if err := run(); err != nil {
+		slog.Error("server fatal", "err", err.Error())
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	dbPath := flag.String("db", "deadzone.db", "path to turso database file")
 	embedderKind := flag.String("embedder", embed.KindHugot, "embedder to use (valid: hugot)")
+	verbose := flag.Bool("verbose", false, "include the raw query text in per-call logs")
 	flag.Parse()
+
+	// Wire slog before any other work so subsequent error paths emit
+	// structured JSON to stderr — never stdout, which is the MCP
+	// JSON-RPC channel.
+	slog.SetDefault(logs.New(os.Stderr, *verbose))
 
 	// db.Open validates the embedder's reported meta against whatever
 	// the database was created with; a mismatch fails fast and tells
 	// the user to rebuild against a fresh file.
 	e, err := embed.New(*embedderKind)
 	if err != nil {
-		log.Fatalf("embedder: %v", err)
+		return fmt.Errorf("embedder: %w", err)
 	}
 	if c, ok := e.(interface{ Close() error }); ok {
 		defer func() {
 			if err := c.Close(); err != nil {
-				log.Printf("embedder close: %v", err)
+				slog.Warn("embedder close", "err", err.Error())
 			}
 		}()
 	}
@@ -101,17 +143,36 @@ func main() {
 		ModelVersion: e.ModelVersion(),
 	})
 	if err != nil {
-		log.Fatalf("open db: %v", err)
+		return fmt.Errorf("open db: %w", err)
 	}
 	defer d.Close()
 
-	s := mcp.NewServer(&mcp.Implementation{Name: "deadzone", Version: "v0.1.0"}, nil)
+	// Read the doc count once at startup so operators see corpus size
+	// in the banner without having to run a separate query. Cheap on
+	// the corpora deadzone targets (a few hundred to a few thousand
+	// rows); revisit if this ever becomes hot.
+	var docCount int
+	if err := d.QueryRow(`SELECT count(*) FROM docs`).Scan(&docCount); err != nil {
+		return fmt.Errorf("count docs: %w", err)
+	}
+
+	slog.Info("server.start",
+		"version", serverVersion,
+		"db_path", *dbPath,
+		"embedder_kind", e.Kind(),
+		"embedding_dim", e.Dim(),
+		"model_version", e.ModelVersion(),
+		"doc_count", docCount,
+	)
+
+	s := mcp.NewServer(&mcp.Implementation{Name: "deadzone", Version: serverVersion}, nil)
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "search_docs",
 		Description: "Search documentation snippets for a library. Use lib_id in /org/project format to filter by library.",
-	}, makeSearchHandler(d, e))
+	}, makeSearchHandler(d, e, *verbose))
 
 	if err := s.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("mcp run: %w", err)
 	}
+	return nil
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -65,7 +65,7 @@ func TestHandleSearchDocs_ReturnsSnippets(t *testing.T) {
 		}
 	}
 
-	handler := makeSearchHandler(d, testEmbedder)
+	handler := makeSearchHandler(d, testEmbedder, false)
 
 	t.Run("returns relevant snippets for semantic query", func(t *testing.T) {
 		_, out, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchDocsInput{

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -1,0 +1,28 @@
+// Package logs centralises slog wiring for deadzone's binaries so the
+// MCP server and scraper produce consistent JSON-on-stderr output.
+//
+// Both cmd/server and cmd/scraper call New at startup with os.Stderr.
+// Server stdout is reserved for the MCP JSON-RPC channel — anything
+// written there that isn't a valid JSON-RPC message disconnects the
+// client — so logs MUST go to stderr. The scraper writes to stderr too
+// for consistency, even though it's a one-shot CLI without that
+// constraint.
+package logs
+
+import (
+	"io"
+	"log/slog"
+)
+
+// New returns a JSON slog.Logger writing to w.
+//
+// When verbose is true the minimum level is Debug, which both unlocks
+// per-doc traces in the scraper (slog.Debug) and lets binaries opt into
+// extra fields gated on the same flag. Otherwise the level is Info.
+func New(w io.Writer, verbose bool) *slog.Logger {
+	level := slog.LevelInfo
+	if verbose {
+		level = slog.LevelDebug
+	}
+	return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level}))
+}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -116,38 +116,62 @@ func ParseMarkdown(libID, sourceName, content string) []db.Doc {
 	return docs
 }
 
-// Fetch downloads each URL in src and returns the parsed Docs.
-// The provided http.Client is used so callers can inject test servers.
-func Fetch(ctx context.Context, client *http.Client, src Source) ([]db.Doc, error) {
-	var out []db.Doc
+// FetchOneResult bundles what FetchOne produces for a single URL: the
+// parsed docs plus the raw byte count of the response body. Bytes is
+// exposed so callers can log fetch volume per URL without holding on
+// to (or re-reading) the body.
+type FetchOneResult struct {
+	Docs  []db.Doc
+	Bytes int
+}
 
-	for _, u := range src.URLs {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
-		if err != nil {
-			return nil, fmt.Errorf("build request %s: %w", u, err)
-		}
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, fmt.Errorf("fetch %s: %w", u, err)
-		}
-
-		body, readErr := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if readErr != nil {
-			return nil, fmt.Errorf("read body %s: %w", u, readErr)
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("fetch %s: HTTP %d", u, resp.StatusCode)
-		}
-
-		// Derive source name from URL filename without extension.
-		sourceName := strings.TrimSuffix(path.Base(u), ".md")
-
-		docs := ParseMarkdown(src.LibID, sourceName, string(body))
-		out = append(out, docs...)
+// FetchOne downloads a single markdown URL with the given http.Client
+// and parses it into docs. Errors are wrapped with the URL so callers
+// can include them verbatim in structured logs.
+//
+// FetchOne is the per-URL primitive used by Fetch and by cmd/scraper,
+// which drives its own URL loop so it can emit per-URL log events
+// (scraper.fetch / scraper.fetch_failed) and time embedding/insertion
+// alongside the fetch.
+func FetchOne(ctx context.Context, client *http.Client, libID, url string) (FetchOneResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return FetchOneResult{}, fmt.Errorf("build request %s: %w", url, err)
 	}
 
+	resp, err := client.Do(req)
+	if err != nil {
+		return FetchOneResult{}, fmt.Errorf("fetch %s: %w", url, err)
+	}
+
+	body, readErr := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		return FetchOneResult{}, fmt.Errorf("read body %s: %w", url, readErr)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return FetchOneResult{}, fmt.Errorf("fetch %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	// Derive source name from URL filename without extension.
+	sourceName := strings.TrimSuffix(path.Base(url), ".md")
+
+	docs := ParseMarkdown(libID, sourceName, string(body))
+	return FetchOneResult{Docs: docs, Bytes: len(body)}, nil
+}
+
+// Fetch downloads each URL in src and returns the concatenated Docs.
+// Implemented as a thin loop over FetchOne so callers that just want
+// "give me everything" don't have to deal with per-URL bookkeeping.
+func Fetch(ctx context.Context, client *http.Client, src Source) ([]db.Doc, error) {
+	var out []db.Doc
+	for _, u := range src.URLs {
+		res, err := FetchOne(ctx, client, src.LibID, u)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res.Docs...)
+	}
 	return out, nil
 }


### PR DESCRIPTION
## Summary

Adds structured JSON logging (`log/slog`) to both `cmd/server` and `cmd/scraper`, replacing the previous `log.Fatal`/`log.Printf` calls. All log output goes to **stderr** to keep stdout reserved for the MCP JSON-RPC channel.

## Changes

- **`internal/logs`** — new package centralising slog wiring (JSON handler on stderr, `Debug` level when `-verbose` is set)
- **`cmd/scraper`** — per-URL structured events (`scraper.start`, `scraper.fetch`, `scraper.fetch_failed`, `scraper.indexed`, `scraper.done`) with timing breakdowns for fetch/embed/insert; refactored to `run() error` pattern
- **`cmd/server`** — startup banner (`server.start` with doc count, embedder meta) and per-call `search_docs` log line with `lib_id`, `tokens`, `results`, `latency_ms`; refactored to `run() error` pattern
- **`internal/scraper`** — extracted `FetchOne` from `Fetch` so the scraper can drive its own per-URL loop with timing and logging
- **`-verbose` flag** on both binaries — adds raw query text to server logs and per-doc `Debug` lines to the scraper
- **README** — new Debugging section documenting log events and where to find server logs

## Test plan

- Existing unit and acceptance tests updated for the new `makeSearchHandler` signature (`verbose bool`)
- Run `just scrape` and verify structured JSON lines appear on stderr
- Start the MCP server via Claude Code and check `~/Library/Logs/Claude/mcp-server-deadzone.log` for `server.start` and `search_docs` events
- Test `-verbose` flag on both binaries

<!-- emdash-issue-footer:start -->
Fixes #24
<!-- emdash-issue-footer:end -->