### PR TITLE
ci: add GitHub Actions workflow for lint, build, and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go vet ./...
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go build ./...
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test ./... -race


### PR DESCRIPTION
## Summary

Adds a CI pipeline via GitHub Actions that runs on pushes to `main` and on pull requests.

## Jobs

- **lint** — runs `go vet ./...`
- **build** — runs `go build ./...`
- **test** — runs `go test ./... -race`

All jobs use the Go version from `go.mod` via `actions/setup-go@v5`.

<!-- emdash-issue-footer:start -->
Fixes #17
<!-- emdash-issue-footer:end -->