### PR TITLE
ci: cache hugot model and pre-download to avoid upstream race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,40 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    env:
+      # Pin the hugot model cache to a workspace-local path so the
+      # actions/cache step below can persist it across runs. The test
+      # helpers in internal/embed/embed_test.go honor this env var.
+      DEADZONE_HUGOT_CACHE: ${{ github.workspace }}/.deadzone-cache/models
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - run: go test ./... -race
+      # Cache the ~90 MB MiniLM ONNX weights across runs. Keyed on
+      # internal/embed/hugot.go so bumping DefaultHugotModel naturally
+      # invalidates the cache.
+      - name: Cache embedding model
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.DEADZONE_HUGOT_CACHE }}
+          key: hugot-model-${{ runner.os }}-${{ hashFiles('internal/embed/hugot.go') }}
+          restore-keys: |
+            hugot-model-${{ runner.os }}-
+      # Pre-download the embedding model without -race. The upstream
+      # gomlx/go-huggingface concurrent-download path has a data race
+      # (hub/files.go:250) that trips the race detector on a cold cache.
+      # Once the model is on disk, NewHugot loads it without spawning
+      # download goroutines, so the -race pass below never hits it.
+      # `-run '^$'` matches no test functions, so this only invokes
+      # TestMain → NewHugot → DownloadModel. On a warm cache this is
+      # a ~1s no-op.
+      - name: Pre-download embedding model
+        run: go test ./internal/embed/... -run '^$' -count=1
+      # -short skips TestEmbedLatencyBudget and TestSemanticAcceptance,
+      # both of which gate themselves on testing.Short() with comments
+      # saying "Skipped under -short so CI can opt out". Their cold/warm
+      # latency budgets (500ms / 100ms) target dev hardware and don't
+      # hold on shared GitHub runners.
+      - name: Run tests
+        run: go test ./... -race -short


### PR DESCRIPTION
## Summary

`main` is currently red — #42 merged the new CI workflow with a failing `test` job, and the post-merge `push` to main re-ran with the same failure (run `24265543189`). This PR fixes the test job. Refs #17.

## Failures observed

1. **`TestEmbedLatencyBudget`** — cold/warm budgets (500ms / 100ms) target dev hardware; `ubuntu-latest` measured 3.34s / 2.37s.
2. **Data race** in `gomlx/go-huggingface@v0.3.5/hub/files.go:250` — upstream concurrent file-download path. Cold-cache only; loading path is single-goroutine.

Both rooted in CI downloading the model fresh on every run while local dev has it cached.

## Fix (only `.github/workflows/ci.yml` is touched)

- **Cache the model** via `actions/cache@v4`, keyed on `hashFiles('internal/embed/hugot.go')` so bumping `DefaultHugotModel` auto-invalidates. Pinned via `DEADZONE_HUGOT_CACHE` — the test helpers were written for this exact purpose (`internal/embed/embed_test.go:38` literally says *"can pin the cache to a workspace-local path that gets restored from a Github Actions cache"*).
- **Pre-download step** runs `go test ./internal/embed/... -run '^\$' -count=1` **without** `-race`. The regex matches no test names, so only `TestMain` executes (downloading the model). The subsequent `-race -short` pass finds the model cached and never enters the racy code path. Sidesteps the upstream race without disabling `-race` for the project.
- **`-short`** on the main test pass. Both failing tests self-skip on `testing.Short()` with author comments saying *"Skipped under -short so CI can opt out"*. The test author designed this exact escape hatch.

Full design rationale and divergences-from-spec discussion: https://github.com/laradji/deadzone/issues/17#issuecomment-4227001992

## Verified locally

- Cold cache (`/tmp` fresh dir): pre-download populates 87 MB → all 6 model files present
- Warm cache: pre-download is 0.27s no-op → `go test ./... -race -short` is green across all 4 packages

## Follow-up

File the upstream race against `gomlx/go-huggingface` so the pre-download step can eventually be dropped.