### PR TITLE
fix: surface Embed errors instead of polluting the index with a placeholder

### DIFF
--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -52,13 +52,11 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("embedder: %w", err)
 	}
-	if c, ok := e.(interface{ Close() error }); ok {
-		defer func() {
-			if err := c.Close(); err != nil {
-				slog.Warn("embedder close", "err", err.Error())
-			}
-		}()
-	}
+	defer func() {
+		if err := e.Close(); err != nil {
+			slog.Warn("embedder close", "err", err.Error())
+		}
+	}()
 
 	// db.Open enforces meta consistency: if the database already exists
 	// and was indexed with a different embedder, it returns
@@ -118,11 +116,27 @@ func run() error {
 		// Embed and insert each doc, summing per-step latencies so the
 		// scraper.indexed line carries the timing breakdown for the
 		// URL without one log line per doc (gated on -verbose).
+		//
+		// Embed failures are logged and the doc is skipped rather than
+		// aborting the whole run: a single bad doc shouldn't take down
+		// a multi-URL scrape, but the operator needs to see the count
+		// in the per-URL summary so silent doc loss is impossible.
 		var embedTotal, insertTotal time.Duration
+		var docsInserted, docsSkipped int
 		for _, doc := range res.Docs {
 			embedStart := time.Now()
-			vec := e.Embed(doc.Title + "\n" + doc.Content)
+			vec, err := e.Embed(doc.Title + "\n" + doc.Content)
 			embedTotal += time.Since(embedStart)
+			if err != nil {
+				docsSkipped++
+				slog.Warn("scraper.embed_failed",
+					"lib_id", doc.LibID,
+					"title", doc.Title,
+					"url", u,
+					"err", err.Error(),
+				)
+				continue
+			}
 
 			insertStart := time.Now()
 			if err := db.Insert(d, doc, vec); err != nil {
@@ -135,6 +149,7 @@ func run() error {
 				return fmt.Errorf("insert %q: %w", doc.Title, err)
 			}
 			insertTotal += time.Since(insertStart)
+			docsInserted++
 
 			slog.Debug("scraper.doc_indexed",
 				"lib_id", doc.LibID,
@@ -147,12 +162,13 @@ func run() error {
 		slog.Info("scraper.indexed",
 			"lib_id", src.LibID,
 			"url", u,
-			"docs_inserted", len(res.Docs),
+			"docs_inserted", docsInserted,
+			"docs_skipped", docsSkipped,
 			"embed_ms_total", embedTotal.Milliseconds(),
 			"insert_ms_total", insertTotal.Milliseconds(),
 		)
 
-		docsTotal += len(res.Docs)
+		docsTotal += docsInserted
 	}
 
 	slog.Info("scraper.done",

--- a/cmd/server/acceptance_test.go
+++ b/cmd/server/acceptance_test.go
@@ -90,7 +90,10 @@ func TestSemanticAcceptance(t *testing.T) {
 	defer d.Close()
 
 	for _, doc := range acceptanceCorpus {
-		vec := testEmbedder.Embed(doc.Title + "\n" + doc.Content)
+		vec, err := testEmbedder.Embed(doc.Title + "\n" + doc.Content)
+		if err != nil {
+			t.Fatalf("Embed %q: %v", doc.Title, err)
+		}
 		if err := db.Insert(d, doc, vec); err != nil {
 			t.Fatalf("Insert %q: %v", doc.Title, err)
 		}
@@ -160,8 +163,11 @@ func TestEmbedLatencyBudget(t *testing.T) {
 		defer fresh.Close()
 
 		start := time.Now()
-		v := fresh.Embed("how do I expose functions to the LLM")
+		v, err := fresh.Embed("how do I expose functions to the LLM")
 		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("Embed: %v", err)
+		}
 
 		if len(v) != fresh.Dim() {
 			t.Fatalf("Embed returned vector of len %d, want %d", len(v), fresh.Dim())
@@ -176,13 +182,18 @@ func TestEmbedLatencyBudget(t *testing.T) {
 		// Prime the shared embedder so the first sample is warm too —
 		// avoids contaminating the median with a one-off cache miss
 		// from whatever ran before this subtest.
-		_ = testEmbedder.Embed("warmup")
+		if _, err := testEmbedder.Embed("warmup"); err != nil {
+			t.Fatalf("warmup Embed: %v", err)
+		}
 
 		samples := make([]time.Duration, warmRuns)
 		for i := range samples {
 			start := time.Now()
-			_ = testEmbedder.Embed("how do I expose functions to the LLM")
+			_, err := testEmbedder.Embed("how do I expose functions to the LLM")
 			samples[i] = time.Since(start)
+			if err != nil {
+				t.Fatalf("warm sample %d Embed: %v", i, err)
+			}
 		}
 		sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
 		median := samples[len(samples)/2]

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,10 +45,14 @@ func makeSearchHandler(d *db.DB, e embed.Embedder, verbose bool) func(context.Co
 	return func(ctx context.Context, req *mcp.CallToolRequest, input SearchDocsInput) (*mcp.CallToolResult, SearchDocsOutput, error) {
 		start := time.Now()
 
-		queryVec := e.Embed(input.Query)
+		queryVec, err := e.Embed(input.Query)
+		if err != nil {
+			slog.Error("search_docs failed", searchAttrs(input, verbose, "stage", "embed", "err", err.Error())...)
+			return nil, SearchDocsOutput{}, fmt.Errorf("embed query: %w", err)
+		}
 		docs, err := db.SearchByEmbedding(d, queryVec, input.LibID, searchK)
 		if err != nil {
-			slog.Error("search_docs failed", searchAttrs(input, verbose, "err", err.Error())...)
+			slog.Error("search_docs failed", searchAttrs(input, verbose, "stage", "search", "err", err.Error())...)
 			return nil, SearchDocsOutput{}, err
 		}
 
@@ -129,13 +133,11 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("embedder: %w", err)
 	}
-	if c, ok := e.(interface{ Close() error }); ok {
-		defer func() {
-			if err := c.Close(); err != nil {
-				slog.Warn("embedder close", "err", err.Error())
-			}
-		}()
-	}
+	defer func() {
+		if err := e.Close(); err != nil {
+			slog.Warn("embedder close", "err", err.Error())
+		}
+	}()
 
 	d, err := db.Open(*dbPath, db.Meta{
 		EmbedderKind: e.Kind(),

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -59,7 +59,10 @@ func TestHandleSearchDocs_ReturnsSnippets(t *testing.T) {
 		{LibID: "/other/lib", Title: "Unrelated", Content: "Something about databases and queries."},
 	}
 	for _, doc := range docs {
-		vec := testEmbedder.Embed(doc.Title + "\n" + doc.Content)
+		vec, err := testEmbedder.Embed(doc.Title + "\n" + doc.Content)
+		if err != nil {
+			t.Fatalf("Embed %q: %v", doc.Title, err)
+		}
 		if err := db.Insert(d, doc, vec); err != nil {
 			t.Fatalf("Insert: %v", err)
 		}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -43,9 +43,16 @@ func hugotTestCacheDir() string {
 }
 
 // embedText is a small convenience that mirrors what the scraper and server
-// do in real life: embed "Title\nContent" into a single vector.
-func embedText(e embed.Embedder, d db.Doc) []float32 {
-	return e.Embed(d.Title + "\n" + d.Content)
+// do in real life: embed "Title\nContent" into a single vector. Tests call
+// it with t.Helper-style fatality so an embedder failure aborts the test
+// rather than silently passing nil through to db.Insert.
+func embedText(t *testing.T, e embed.Embedder, d db.Doc) []float32 {
+	t.Helper()
+	v, err := e.Embed(d.Title + "\n" + d.Content)
+	if err != nil {
+		t.Fatalf("Embed %q: %v", d.Title, err)
+	}
+	return v
 }
 
 // metaFor extracts a db.Meta from an embed.Embedder. The same little
@@ -75,7 +82,7 @@ func TestOpen_CreatesDocsTable(t *testing.T) {
 
 	// Verify the table exists by inserting through the real Insert path.
 	doc := db.Doc{LibID: "testlib", Title: "Hello World", Content: "some content"}
-	if err := db.Insert(d, doc, embedText(testEmbedder, doc)); err != nil {
+	if err := db.Insert(d, doc, embedText(t, testEmbedder, doc)); err != nil {
 		t.Fatalf("Insert: %v", err)
 	}
 }
@@ -90,7 +97,7 @@ func TestInsert(t *testing.T) {
 	}
 
 	for _, doc := range docs {
-		if err := db.Insert(d, doc, embedText(testEmbedder, doc)); err != nil {
+		if err := db.Insert(d, doc, embedText(t, testEmbedder, doc)); err != nil {
 			t.Fatalf("Insert %q: %v", doc.Title, err)
 		}
 	}
@@ -122,12 +129,16 @@ func TestSearchByEmbedding_RanksRelevantFirst(t *testing.T) {
 		{LibID: "libsql", Title: "Getting started", Content: "Open a database with sql.Open"},
 	}
 	for _, doc := range docs {
-		if err := db.Insert(d, doc, embedText(testEmbedder, doc)); err != nil {
+		if err := db.Insert(d, doc, embedText(t, testEmbedder, doc)); err != nil {
 			t.Fatalf("Insert: %v", err)
 		}
 	}
 
-	results, err := db.SearchByEmbedding(d, testEmbedder.Embed("create a server"), "", 10)
+	qv, err := testEmbedder.Embed("create a server")
+	if err != nil {
+		t.Fatalf("Embed query: %v", err)
+	}
+	results, err := db.SearchByEmbedding(d, qv, "", 10)
 	if err != nil {
 		t.Fatalf("SearchByEmbedding: %v", err)
 	}
@@ -150,12 +161,16 @@ func TestSearchByEmbedding_FiltersByLib(t *testing.T) {
 		{LibID: "libsql", Title: "SQL server", Content: "Connect to a database server"},
 	}
 	for _, doc := range docs {
-		if err := db.Insert(d, doc, embedText(testEmbedder, doc)); err != nil {
+		if err := db.Insert(d, doc, embedText(t, testEmbedder, doc)); err != nil {
 			t.Fatalf("Insert: %v", err)
 		}
 	}
 
-	results, err := db.SearchByEmbedding(d, testEmbedder.Embed("server"), "go-sdk", 10)
+	qv, err := testEmbedder.Embed("server")
+	if err != nil {
+		t.Fatalf("Embed query: %v", err)
+	}
+	results, err := db.SearchByEmbedding(d, qv, "go-sdk", 10)
 	if err != nil {
 		t.Fatalf("SearchByEmbedding: %v", err)
 	}
@@ -182,12 +197,16 @@ func TestSearchByEmbedding_Acceptance(t *testing.T) {
 		{LibID: "libsql", Title: "Getting started", Content: "Open a database with sql.Open"},
 	}
 	for _, doc := range docs {
-		if err := db.Insert(d, doc, embedText(testEmbedder, doc)); err != nil {
+		if err := db.Insert(d, doc, embedText(t, testEmbedder, doc)); err != nil {
 			t.Fatalf("Insert: %v", err)
 		}
 	}
 
-	results, err := db.SearchByEmbedding(d, testEmbedder.Embed("register a tool"), "", 10)
+	qv, err := testEmbedder.Embed("register a tool")
+	if err != nil {
+		t.Fatalf("Embed query: %v", err)
+	}
+	results, err := db.SearchByEmbedding(d, qv, "", 10)
 	if err != nil {
 		t.Fatalf("SearchByEmbedding: %v", err)
 	}
@@ -216,7 +235,7 @@ func TestDB_RejectsEmbedderMismatch(t *testing.T) {
 	// Indexing one doc to confirm we are exercising a real, populated DB
 	// and not a degenerate empty file.
 	doc := db.Doc{LibID: "x", Title: "t", Content: "c"}
-	if err := db.Insert(d, doc, embedText(testEmbedder, doc)); err != nil {
+	if err := db.Insert(d, doc, embedText(t, testEmbedder, doc)); err != nil {
 		t.Fatalf("Insert: %v", err)
 	}
 	if err := d.Close(); err != nil {
@@ -269,7 +288,7 @@ func TestDB_RoundtripsMeta(t *testing.T) {
 		t.Errorf("first open Meta = %+v, want %+v", d.Meta, want)
 	}
 	doc := db.Doc{LibID: "lib", Title: "Title", Content: "Content"}
-	if err := db.Insert(d, doc, embedText(testEmbedder, doc)); err != nil {
+	if err := db.Insert(d, doc, embedText(t, testEmbedder, doc)); err != nil {
 		t.Fatalf("Insert: %v", err)
 	}
 	if err := d.Close(); err != nil {

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -22,7 +22,10 @@ import "fmt"
 // was indexed with embedder Y.
 type Embedder interface {
 	// Embed returns a vector of length Dim() for the given text.
-	Embed(text string) []float32
+	// Implementations must surface inference errors instead of returning
+	// a placeholder vector: a silently corrupted embedding pollutes the
+	// cosine index permanently and is impossible to detect post-hoc.
+	Embed(text string) ([]float32, error)
 
 	// Kind identifies the embedder family (e.g. "hugot").
 	// Used for meta consistency checks between scraper and server runs.
@@ -36,6 +39,10 @@ type Embedder interface {
 	// embeddings (e.g. "sentence-transformers/all-MiniLM-L6-v2"). Stored
 	// in the DB meta table and cross-checked at open time.
 	ModelVersion() string
+
+	// Close releases any resources held by the embedder (model session,
+	// tokenizer, etc.). Safe to call once at process shutdown via defer.
+	Close() error
 }
 
 // New returns an Embedder for the given kind. Currently only KindHugot is

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -63,8 +63,14 @@ func TestHugot_Deterministic(t *testing.T) {
 		"Créer un serveur MCP",
 	}
 	for _, in := range inputs {
-		a := testEmbedder.Embed(in)
-		b := testEmbedder.Embed(in)
+		a, err := testEmbedder.Embed(in)
+		if err != nil {
+			t.Fatalf("Embed(%q): %v", in, err)
+		}
+		b, err := testEmbedder.Embed(in)
+		if err != nil {
+			t.Fatalf("Embed(%q): %v", in, err)
+		}
 		if !bytes.Equal(floatsToBytes(a), floatsToBytes(b)) {
 			t.Errorf("Embed(%q) not deterministic across calls", in)
 		}
@@ -74,7 +80,10 @@ func TestHugot_Deterministic(t *testing.T) {
 func TestHugot_Dim(t *testing.T) {
 	cases := []string{"x", "hello world", "Register tools using mcp.AddTool"}
 	for _, c := range cases {
-		v := testEmbedder.Embed(c)
+		v, err := testEmbedder.Embed(c)
+		if err != nil {
+			t.Fatalf("Embed(%q): %v", c, err)
+		}
 		if len(v) != testEmbedder.Dim() {
 			t.Errorf("Embed(%q) len = %d, want %d", c, len(v), testEmbedder.Dim())
 		}
@@ -99,7 +108,10 @@ func TestHugot_Metadata(t *testing.T) {
 func TestHugot_UnitNorm(t *testing.T) {
 	cases := []string{"a", "hello world", "Register tools using mcp.AddTool"}
 	for _, c := range cases {
-		v := testEmbedder.Embed(c)
+		v, err := testEmbedder.Embed(c)
+		if err != nil {
+			t.Fatalf("Embed(%q): %v", c, err)
+		}
 		var sumSq float64
 		for _, x := range v {
 			sumSq += float64(x) * float64(x)
@@ -120,9 +132,18 @@ func TestHugot_UnitNorm(t *testing.T) {
 // With a 384-dim sentence-transformers model this is the actual semantic
 // retrieval property we care about, not a hash-collision artifact.
 func TestHugot_SemanticOverlap(t *testing.T) {
-	query := testEmbedder.Embed("register a tool")
-	relevant := testEmbedder.Embed("Register tools using mcp.AddTool")
-	unrelated := testEmbedder.Embed("Open a database with sql.Open")
+	query, err := testEmbedder.Embed("register a tool")
+	if err != nil {
+		t.Fatalf("Embed query: %v", err)
+	}
+	relevant, err := testEmbedder.Embed("Register tools using mcp.AddTool")
+	if err != nil {
+		t.Fatalf("Embed relevant: %v", err)
+	}
+	unrelated, err := testEmbedder.Embed("Open a database with sql.Open")
+	if err != nil {
+		t.Fatalf("Embed unrelated: %v", err)
+	}
 
 	distRelevant := cosineDistance(query, relevant)
 	distUnrelated := cosineDistance(query, unrelated)
@@ -142,11 +163,7 @@ func TestNew(t *testing.T) {
 		// New returns a fresh Hugot — close it to release the
 		// session it just allocated. The package-level testEmbedder
 		// is unaffected.
-		defer func() {
-			if c, ok := e.(interface{ Close() error }); ok {
-				_ = c.Close()
-			}
-		}()
+		defer func() { _ = e.Close() }()
 		if e.Kind() != "hugot" {
 			t.Errorf("Kind() = %q, want %q", e.Kind(), "hugot")
 		}

--- a/internal/embed/hugot.go
+++ b/internal/embed/hugot.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -116,19 +115,22 @@ func NewHugot(modelName, cacheDir string) (*Hugot, error) {
 }
 
 // Embed runs text through the FeatureExtractionPipeline and returns the
-// resulting unit-norm vector. The Embedder interface has no error return,
-// so on the rare event of a runtime failure (e.g. tokenizer panic) we log
-// to stderr and return a deterministic fallback unit vector pointing in
-// dimension 0. The fallback keeps cosine distance well-defined and avoids
-// poisoning downstream NaN handling, at the cost of producing a meaningless
-// search result for that one input.
-func (h *Hugot) Embed(text string) []float32 {
+// resulting unit-norm vector. Errors are propagated so callers can decide
+// what to do — at index time the scraper logs and skips the doc, at query
+// time the server returns the error to the MCP client. Returning a
+// deterministic placeholder vector here used to silently pollute the
+// cosine index, since every fallback collapsed to the same point in vector
+// space and formed a synthetic attractor for any query aligned with that
+// dimension.
+func (h *Hugot) Embed(text string) ([]float32, error) {
 	out, err := h.pipeline.RunPipeline([]string{text})
-	if err != nil || out == nil || len(out.Embeddings) == 0 {
-		log.Printf("hugot: embed failed (text len=%d): %v", len(text), err)
-		return fallbackVector(h.dim)
+	if err != nil {
+		return nil, fmt.Errorf("hugot: run pipeline (text len=%d): %w", len(text), err)
 	}
-	return out.Embeddings[0]
+	if out == nil || len(out.Embeddings) == 0 {
+		return nil, fmt.Errorf("hugot: pipeline returned no embeddings (text len=%d)", len(text))
+	}
+	return out.Embeddings[0], nil
 }
 
 // Kind reports the embedder family. Always KindHugot.
@@ -153,17 +155,6 @@ func (h *Hugot) Close() error {
 	h.session = nil
 	h.pipeline = nil
 	return err
-}
-
-// fallbackVector returns a unit vector along dimension 0. Used when Embed
-// fails — keeps the result well-defined and L2-normalized so it doesn't
-// break vector_distance_cos.
-func fallbackVector(dim int) []float32 {
-	v := make([]float32, dim)
-	if dim > 0 {
-		v[0] = 1
-	}
-	return v
 }
 
 // DefaultCacheDir returns the cache directory used by NewHugot when the


### PR DESCRIPTION
Closes #38.

## Problem

`Embedder.Embed(text string) []float32` had no error return. On the rare event of a hugot pipeline failure (tokenizer panic, ONNX session crash, empty output), the implementation logged to stderr and returned a deterministic fallback unit vector `[1, 0, 0, …]`. That vector then:

- got indexed into the `docs.embedding F32_BLOB(384)` column at scrape time and became impossible to detect post-hoc, or
- got used as a query vector at search time and returned a meaningless top-K to the MCP client.

The deterministic fallback made it worse than a random vector would have been: every silent failure collapsed onto the **same point** in the cosine space, so two or more fallbacks formed a synthetic attractor that any query aligned with dimension 0 would pull as a cluster.

## Fix

Adopts the proposal from #38 with one bonus.

- **Interface change** (`internal/embed/embed.go`):
  ```go
  type Embedder interface {
      Embed(text string) ([]float32, error)
      Kind() string
      Dim() int
      ModelVersion() string
      Close() error
  }
  ```
  Adding `Close() error` to the interface drops the three `interface{ Close() error }` type assertions in `cmd/scraper/main.go`, `cmd/server/main.go`, and `internal/embed/embed_test.go` — they were a code smell from when `Close` only existed on `*Hugot`. The only implementation already has `Close() error`, so this is free.

- **Implementation** (`internal/embed/hugot.go`):
  - `Embed` now returns the error from `pipeline.RunPipeline`, with separate paths for "pipeline failed" vs "pipeline returned no embeddings". Both wrap the input length so log readers can correlate with the source doc.
  - `fallbackVector` deleted entirely. The unused `log` import goes with it.

- **Scraper** (`cmd/scraper/main.go`):
  - Embed failures log a `scraper.embed_failed` warn line, increment a `docs_skipped` counter, and `continue` to the next doc — a single weird snippet shouldn't take down a multi-URL scrape, but the count is surfaced in the per-URL `scraper.indexed` summary so silent doc loss is impossible.
  - `docs_inserted` is now the actual count of successful inserts (not `len(res.Docs)`), and `docsTotal` accumulates from there.
  - The `defer e.Close()` shape now relies on the interface guarantee instead of a runtime type assertion.

- **Server** (`cmd/server/main.go`):
  - Query embed failure logs a `search_docs failed` line with `stage=embed` and returns the wrapped error to the MCP client. The existing search-failure path now logs `stage=search` for symmetry.

- **Tests** (~17 call sites across `internal/embed/embed_test.go`, `internal/db/db_test.go`, `cmd/server/main_test.go`, `cmd/server/acceptance_test.go`):
  - Mechanical update to handle the new error return.
  - `embedText` helper in `db_test.go` now takes `*testing.T` so it can `t.Fatalf` on embed failure rather than passing nil through to `db.Insert`.
  - Latency benchmark (`TestEmbedLatencyBudget`) keeps `time.Since` *outside* the err check so the timing window stays accurate.

## Test plan

- [x] `mise exec -- just build` — clean
- [x] `mise exec -- just vet` — clean
- [x] `mise exec -- just test` — all packages green
- [x] `mise exec -- go test ./... -race -short` — race detector clean (matches CI)
- [ ] CI green on this branch
