### PR TITLE
feat: add search_libraries MCP tool for lib_id resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Deadzone is a self-hosted alternative to [Context7](https://github.com/upstash/c
 
 ## What it does
 
-Deadzone exposes one MCP tool to clients (Claude Code, Cursor, etc.):
+Deadzone exposes two MCP tools to clients (Claude Code, Cursor, etc.):
 
 ```
 search_docs(query, lib_id?, topic?, tokens?) → []Snippet
@@ -33,6 +33,16 @@ search_docs(query, lib_id?, topic?, tokens?) → []Snippet
 - `lib_id` — optional `/org/project` filter (e.g. `/modelcontextprotocol/go-sdk`)
 - `topic` — optional section filter (not yet implemented)
 - `tokens` — response budget, default 5000, min 1000 (`~4 chars/token`)
+
+```
+search_libraries(name, limit?) → []LibraryHit
+```
+
+- `name` — free-text library name to resolve (e.g. `"terraform aws"`); empty returns the most-indexed libraries by `doc_count`
+- `limit` — max results, default 10, max 50
+- Each `LibraryHit` carries `lib_id`, `doc_count`, and a `match_score` in `[0, 1]` (1.0 = closest cosine match) so the LLM can pick a single canonical id or surface multiple candidates to the user.
+
+`search_libraries` is the resolver step: a free-text query like `"react"` is matched against a dedicated `libs` vector table and returns ranked canonical `lib_id` values. Pass one of those into `search_docs` to get the actual snippets.
 
 Documentation is fetched by a separate `scraper` CLI, embedded into vectors, and stored in a local Turso database file.
 
@@ -141,7 +151,7 @@ Add to your client's MCP config (Claude Code, Cursor, etc.):
 }
 ```
 
-Then call the `search_docs` tool from the client.
+Then call the `search_docs` or `search_libraries` tool from the client.
 
 ## Layout
 

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -123,6 +123,18 @@ func scrapeLib(
 		"url_count", len(src.URLs),
 	)
 
+	// Make sure the libs catalog row exists before we start indexing
+	// docs. UpsertLibIfNew is idempotent and skips the embed call when
+	// the row is already present, so the cost on a re-run is just one
+	// count(*); the actual doc_count is filled in at the end of this
+	// function once we know the real number. Each ResolvedSource has
+	// its own canonical lib_id (versioned libs already get distinct
+	// /org/project/version values from cfg.Resolve), so a single
+	// upsert per source is the correct grain.
+	if err := db.UpsertLibIfNew(d, src.LibID, e); err != nil {
+		return 0, fmt.Errorf("upsert lib %q: %w", src.LibID, err)
+	}
+
 	libStart := time.Now()
 	var docsTotal int
 
@@ -206,6 +218,22 @@ func scrapeLib(
 		)
 
 		docsTotal += docsInserted
+	}
+
+	// Update the libs catalog with the actual indexed doc count so
+	// search_libraries can rank by "how well-indexed is this lib". The
+	// scraper currently appends to docs without dedupe (see #28 for
+	// the per-lib artifact story), so docsTotal here is the new-rows
+	// count for this run, not the absolute table row count for the
+	// lib; callers re-running the scraper on a non-fresh DB are
+	// expected to drop & re-scrape per issue #44's migration story.
+	if err := db.UpdateLibCount(d, src.LibID, docsTotal); err != nil {
+		slog.Error("scraper.update_lib_count_failed",
+			"lib_id", src.LibID,
+			"docs_total", docsTotal,
+			"err", err.Error(),
+		)
+		return docsTotal, fmt.Errorf("update lib count %q: %w", src.LibID, err)
 	}
 
 	slog.Info("scraper.lib_done",

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/laradji/deadzone/internal/db"
@@ -108,6 +109,119 @@ func searchAttrs(input SearchDocsInput, verbose bool, extra ...any) []any {
 	return attrs
 }
 
+// SearchLibrariesInput is the JSON shape accepted by the search_libraries
+// MCP tool. Name is free-text — the handler embeds it with the same hugot
+// pipeline used at index time and matches against libs.embedding via
+// vector_distance_cos. An empty Name is the cheap "what's even in here"
+// path that returns the top-K libs by doc_count without an embedder
+// call.
+type SearchLibrariesInput struct {
+	Name  string `json:"name,omitempty" jsonschema:"free-text library name to resolve; empty returns top libs by doc count"`
+	Limit int    `json:"limit,omitempty" jsonschema:"max results, default 10, max 50"`
+}
+
+// LibraryHit is one ranked candidate returned by search_libraries.
+// MatchScore is 1 - cosine_distance(query, lib_embedding) so higher is
+// closer; the empty-name path returns 1.0 for every row (no query was
+// embedded). LLM clients can use the score to decide whether to commit
+// to a single result or surface multiple candidates to the user.
+type LibraryHit struct {
+	LibID      string  `json:"lib_id"`
+	DocCount   int     `json:"doc_count"`
+	MatchScore float32 `json:"match_score"`
+}
+
+// SearchLibrariesOutput is the wire envelope. The Libraries slice is
+// always non-nil (no matches → empty, never null) so MCP clients can
+// iterate without a nil-guard.
+type SearchLibrariesOutput struct {
+	Libraries []LibraryHit `json:"libraries"`
+}
+
+const (
+	defaultLibLimit = 10
+	maxLibLimit     = 50
+)
+
+// makeSearchLibrariesHandler closes over the DB and Embedder so the
+// MCP tool registration can stay a one-liner. The empty-name branch
+// goes straight to TopLibsByDocCount and skips e.Embed entirely; the
+// non-empty branch is symmetric with search_docs (embed once, query
+// once). The 1 - dist score conversion happens here so LibInfo's raw
+// distance never escapes the package.
+func makeSearchLibrariesHandler(d *db.DB, e embed.Embedder, verbose bool) func(context.Context, *mcp.CallToolRequest, SearchLibrariesInput) (*mcp.CallToolResult, SearchLibrariesOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input SearchLibrariesInput) (*mcp.CallToolResult, SearchLibrariesOutput, error) {
+		start := time.Now()
+
+		limit := input.Limit
+		if limit <= 0 {
+			limit = defaultLibLimit
+		}
+		if limit > maxLibLimit {
+			limit = maxLibLimit
+		}
+
+		name := strings.TrimSpace(input.Name)
+
+		var (
+			libs []db.LibInfo
+			err  error
+		)
+		if name == "" {
+			libs, err = db.TopLibsByDocCount(d, limit)
+			if err != nil {
+				slog.Error("search_libraries failed", libAttrs(input, name, limit, verbose, "stage", "top_libs", "err", err.Error())...)
+				return nil, SearchLibrariesOutput{}, err
+			}
+		} else {
+			queryVec, embedErr := e.Embed(name)
+			if embedErr != nil {
+				slog.Error("search_libraries failed", libAttrs(input, name, limit, verbose, "stage", "embed", "err", embedErr.Error())...)
+				return nil, SearchLibrariesOutput{}, fmt.Errorf("embed query: %w", embedErr)
+			}
+			libs, err = db.SearchLibsByEmbedding(d, queryVec, limit)
+			if err != nil {
+				slog.Error("search_libraries failed", libAttrs(input, name, limit, verbose, "stage", "search", "err", err.Error())...)
+				return nil, SearchLibrariesOutput{}, err
+			}
+		}
+
+		// make([]LibraryHit, 0, len(libs)) is the load-bearing call
+		// here: it guarantees a non-nil empty slice on the no-matches
+		// path, which is one of the issue's acceptance criteria.
+		hits := make([]LibraryHit, 0, len(libs))
+		for _, lib := range libs {
+			hits = append(hits, LibraryHit{
+				LibID:      lib.LibID,
+				DocCount:   lib.DocCount,
+				MatchScore: 1.0 - lib.Distance,
+			})
+		}
+
+		slog.Info("search_libraries", libAttrs(input, name, limit, verbose,
+			"results", len(hits),
+			"latency_ms", time.Since(start).Milliseconds(),
+		)...)
+
+		return nil, SearchLibrariesOutput{Libraries: hits}, nil
+	}
+}
+
+// libAttrs is the search_libraries equivalent of searchAttrs: a single
+// place to assemble the slog key/value list shared by success and
+// error paths. The raw name is gated behind -verbose for the same
+// reason search_docs gates query text — names may carry user data
+// routed through the LLM.
+func libAttrs(input SearchLibrariesInput, name string, limit int, verbose bool, extra ...any) []any {
+	attrs := make([]any, 0, 6+len(extra))
+	attrs = append(attrs, "name_len", len(name), "limit", limit)
+	attrs = append(attrs, extra...)
+	if verbose {
+		attrs = append(attrs, "name", input.Name)
+	}
+	return attrs
+}
+
 func main() {
 	if err := run(); err != nil {
 		slog.Error("server fatal", "err", err.Error())
@@ -172,6 +286,10 @@ func run() error {
 		Name:        "search_docs",
 		Description: "Search documentation snippets for a library. Use lib_id in /org/project format to filter by library.",
 	}, makeSearchHandler(d, e, *verbose))
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "search_libraries",
+		Description: "Resolve a free-text library name into a ranked list of canonical lib_id candidates that can be passed to search_docs. Pass an empty name to list the most-indexed libraries by doc_count.",
+	}, makeSearchLibrariesHandler(d, e, *verbose))
 
 	if err := s.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
 		return fmt.Errorf("mcp run: %w", err)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -118,3 +118,165 @@ func TestHandleSearchDocs_ReturnsSnippets(t *testing.T) {
 		}
 	})
 }
+
+// TestHandleSearchLibraries exercises the search_libraries handler end
+// to end against a hand-seeded libs catalog. The corpus is intentionally
+// small but heterogeneous (different doc_counts, different topics) so
+// every subtest can pin a single observable behavior without depending
+// on the others. The handler is the only public surface area for
+// search_libraries; if it works here, the wiring is correct.
+func TestHandleSearchLibraries(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"), db.Meta{
+		EmbedderKind: testEmbedder.Kind(),
+		EmbeddingDim: testEmbedder.Dim(),
+		ModelVersion: testEmbedder.ModelVersion(),
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	libs := []struct {
+		id    string
+		count int
+	}{
+		{"/hashicorp/terraform-provider-aws", 50},
+		{"/facebook/react", 200},
+		{"/expressjs/express", 75},
+	}
+	for _, l := range libs {
+		if err := db.UpsertLibIfNew(d, l.id, testEmbedder); err != nil {
+			t.Fatalf("UpsertLibIfNew %q: %v", l.id, err)
+		}
+		if err := db.UpdateLibCount(d, l.id, l.count); err != nil {
+			t.Fatalf("UpdateLibCount %q: %v", l.id, err)
+		}
+	}
+
+	handler := makeSearchLibrariesHandler(d, testEmbedder, false)
+
+	t.Run("ranks semantic match first", func(t *testing.T) {
+		_, out, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchLibrariesInput{
+			Name: "terraform aws",
+		})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if len(out.Libraries) == 0 {
+			t.Fatal("expected libraries, got none")
+		}
+		if out.Libraries[0].LibID != "/hashicorp/terraform-provider-aws" {
+			t.Errorf("expected /hashicorp/terraform-provider-aws first, got %q", out.Libraries[0].LibID)
+			for i, lib := range out.Libraries {
+				t.Logf("  #%d: %s (score=%v)", i+1, lib.LibID, lib.MatchScore)
+			}
+		}
+		// match_score is computed as 1 - distance, so it must lie in
+		// the documented [-1, 1] range and the top result should be
+		// strictly greater than the worst result.
+		if out.Libraries[0].MatchScore < out.Libraries[len(out.Libraries)-1].MatchScore {
+			t.Errorf("top match_score %v < bottom %v (rank/score inverted)",
+				out.Libraries[0].MatchScore, out.Libraries[len(out.Libraries)-1].MatchScore)
+		}
+	})
+
+	t.Run("empty name returns top by doc_count", func(t *testing.T) {
+		_, out, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchLibrariesInput{
+			Name: "",
+		})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if len(out.Libraries) != 3 {
+			t.Fatalf("got %d libraries, want 3", len(out.Libraries))
+		}
+		// /facebook/react has the highest doc_count, so it should
+		// lead the list even though no semantic match was performed.
+		if out.Libraries[0].LibID != "/facebook/react" {
+			t.Errorf("empty-name path: expected /facebook/react first, got %q", out.Libraries[0].LibID)
+		}
+		if out.Libraries[0].MatchScore != 1.0 {
+			t.Errorf("empty-name path: expected match_score=1.0, got %v", out.Libraries[0].MatchScore)
+		}
+	})
+
+	t.Run("whitespace-only name uses doc_count path", func(t *testing.T) {
+		// "  " is logically empty for an LLM-driven query; the handler
+		// should treat it as such and avoid embedding whitespace.
+		_, out, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchLibrariesInput{
+			Name: "   ",
+		})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if out.Libraries[0].LibID != "/facebook/react" {
+			t.Errorf("expected doc_count ordering, got top=%q", out.Libraries[0].LibID)
+		}
+	})
+
+	t.Run("limit is respected", func(t *testing.T) {
+		_, out, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchLibrariesInput{
+			Name:  "terraform aws",
+			Limit: 2,
+		})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if len(out.Libraries) != 2 {
+			t.Errorf("limit=2 returned %d libraries, want 2", len(out.Libraries))
+		}
+	})
+
+	t.Run("limit cap is enforced", func(t *testing.T) {
+		// Asking for 9999 must clamp to maxLibLimit (50). With only
+		// 3 libs in the catalog the cap is invisible at the result
+		// level, so this assertion is on "no error, normal output"
+		// rather than length.
+		_, out, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchLibrariesInput{
+			Name:  "terraform aws",
+			Limit: 9999,
+		})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if len(out.Libraries) > maxLibLimit {
+			t.Errorf("got %d libraries, want <= %d", len(out.Libraries), maxLibLimit)
+		}
+	})
+}
+
+// TestHandleSearchLibraries_NoMatches pins the "no matches → empty
+// non-nil slice" acceptance criterion. Empty libs catalog (no rows
+// inserted) is the easiest way to force the path; the handler must
+// return [] not null on the wire so MCP clients can iterate without a
+// nil-guard.
+func TestHandleSearchLibraries_NoMatches(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "empty.db"), db.Meta{
+		EmbedderKind: testEmbedder.Kind(),
+		EmbeddingDim: testEmbedder.Dim(),
+		ModelVersion: testEmbedder.ModelVersion(),
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	handler := makeSearchLibrariesHandler(d, testEmbedder, false)
+
+	for _, name := range []string{"anything", ""} {
+		t.Run("name="+name, func(t *testing.T) {
+			_, out, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchLibrariesInput{
+				Name: name,
+			})
+			if err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+			if out.Libraries == nil {
+				t.Error("Libraries should be non-nil empty slice, got nil")
+			}
+			if len(out.Libraries) != 0 {
+				t.Errorf("expected 0 libraries on empty catalog, got %d", len(out.Libraries))
+			}
+		})
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,6 +28,21 @@ import (
 // detect.
 var ErrEmbedderMismatch = errors.New("embedder metadata mismatch")
 
+// ErrSchemaMismatch is returned by Open when the database's stored schema
+// version does not match CurrentSchemaVersion. Callers should treat this
+// as fatal: the current code cannot read a database produced by a build
+// with a different table layout. Use a fresh database file (drop and
+// re-scrape) until an in-place migration is implemented. Wrap with
+// errors.Is to detect.
+var ErrSchemaMismatch = errors.New("database schema version mismatch")
+
+// CurrentSchemaVersion is the on-disk schema version written by this
+// build. Bump whenever the table layout changes in a non-backwards-
+// compatible way (e.g. a new required table like libs). Stored in the
+// meta table at first Open and cross-checked on every subsequent open
+// against this constant; a mismatch surfaces as ErrSchemaMismatch.
+const CurrentSchemaVersion = 2
+
 // Meta describes the embedder a database was created with. It is written
 // to the meta table the first time a fresh DB is opened and cross-checked
 // on every subsequent open.
@@ -96,13 +111,21 @@ func Open(path string, meta Meta) (*DB, error) {
 		return nil, fmt.Errorf("create meta table: %w", err)
 	}
 
-	stored, hasMeta, err := readMeta(raw)
+	stored, storedSchemaVersion, hasMeta, err := readMeta(raw)
 	if err != nil {
 		raw.Close()
 		return nil, fmt.Errorf("read meta: %w", err)
 	}
 
 	if hasMeta {
+		// Schema version is checked before embedder meta so that an old
+		// DB (with matching embedder but pre-libs schema) surfaces as a
+		// schema problem rather than a spurious embedder mismatch.
+		if storedSchemaVersion != CurrentSchemaVersion {
+			raw.Close()
+			return nil, fmt.Errorf("%w: stored=%d current=%d; use a fresh database file and re-scrape until an in-place migration is implemented",
+				ErrSchemaMismatch, storedSchemaVersion, CurrentSchemaVersion)
+		}
 		if stored != meta {
 			raw.Close()
 			return nil, fmt.Errorf("%w: stored=%+v requested=%+v; use a fresh database file or rebuild with the matching embedder",
@@ -133,6 +156,25 @@ func Open(path string, meta Meta) (*DB, error) {
 	if _, err := raw.Exec(`CREATE INDEX IF NOT EXISTS idx_docs_lib_id ON docs(lib_id)`); err != nil {
 		raw.Close()
 		return nil, fmt.Errorf("create lib_id index: %w", err)
+	}
+
+	// libs is a per-lib catalog table that backs search_libraries:
+	// one row per indexed library, holding an embedding of the lib_id
+	// text plus the corpus size for the lib. Vector width matches the
+	// docs table for the same reason — both columns have to be openable
+	// by the same Embedder, which the meta cross-check above guarantees.
+	libsSchema := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS libs (
+		lib_id    TEXT PRIMARY KEY,
+		doc_count INTEGER NOT NULL DEFAULT 0,
+		embedding F32_BLOB(%d) NOT NULL
+	)`, meta.EmbeddingDim)
+	if _, err := raw.Exec(libsSchema); err != nil {
+		raw.Close()
+		return nil, fmt.Errorf("create libs table: %w", err)
+	}
+	if _, err := raw.Exec(`CREATE INDEX IF NOT EXISTS libs_doc_count_idx ON libs(doc_count DESC)`); err != nil {
+		raw.Close()
+		return nil, fmt.Errorf("create libs_doc_count_idx: %w", err)
 	}
 
 	return &DB{DB: raw, Meta: meta}, nil
@@ -208,13 +250,180 @@ func SearchByEmbedding(db *DB, queryVec []float32, libID string, k int) ([]Doc, 
 	return results, rows.Err()
 }
 
+// LibEmbedder is the minimal subset of an embedder that UpsertLibIfNew
+// needs. Defining a local interface keeps the db package free of any
+// import on internal/embed (matching the package-level rule the docs
+// table already follows) while still letting tests pass a counting
+// wrapper that asserts the embed call is actually skipped on the
+// idempotent re-upsert path.
+type LibEmbedder interface {
+	Embed(text string) ([]float32, error)
+}
+
+// LibInfo is one row of the libs table as returned by SearchLibsByEmbedding
+// and TopLibsByDocCount. Distance is the raw cosine distance from the
+// query vector (lower is better, 0 is identical, 2 is maximally far);
+// callers convert it to a 1 - dist match score before serializing to
+// the wire so the LLM sees a monotonically-good number. The doc-count
+// path returns Distance = 0 (no query was issued), and the search path
+// fills it in from vector_distance_cos.
+type LibInfo struct {
+	LibID    string
+	DocCount int
+	Distance float32
+}
+
+// UpsertLibIfNew inserts a row into the libs table for libID iff one
+// doesn't already exist. The embedding is computed from the lib_id text
+// itself with "/" and "-" turned into spaces so MiniLM sees something
+// resembling natural language ("/hashicorp/terraform-provider-aws" →
+// "hashicorp terraform provider aws"). The lib_id is the primary key
+// and the embedding is immutable for the lifetime of the database, so
+// re-running this function for an existing lib is a fast no-op that
+// does NOT call e.Embed — the issue's "at most one Embed call per lib
+// per database" guarantee is enforced here, and verified by tests that
+// count the call against a wrapping LibEmbedder.
+func UpsertLibIfNew(d *DB, libID string, e LibEmbedder) error {
+	if libID == "" {
+		return errors.New("upsert lib: libID must not be empty")
+	}
+	var existing int
+	if err := d.QueryRow(`SELECT count(*) FROM libs WHERE lib_id = ?`, libID).Scan(&existing); err != nil {
+		return fmt.Errorf("upsert lib %q: check exists: %w", libID, err)
+	}
+	if existing > 0 {
+		return nil
+	}
+	vec, err := e.Embed(normalizeLibIDText(libID))
+	if err != nil {
+		return fmt.Errorf("upsert lib %q: embed: %w", libID, err)
+	}
+	if len(vec) != d.Meta.EmbeddingDim {
+		return fmt.Errorf("upsert lib %q: embedding length %d, want %d", libID, len(vec), d.Meta.EmbeddingDim)
+	}
+	if _, err := d.Exec(
+		`INSERT INTO libs (lib_id, doc_count, embedding) VALUES (?, 0, vector(?))`,
+		libID, formatVector(vec),
+	); err != nil {
+		return fmt.Errorf("upsert lib %q: insert: %w", libID, err)
+	}
+	return nil
+}
+
+// UpdateLibCount sets the doc_count for an existing libs row. The
+// scraper calls this once per lib at the end of a run with the actual
+// number of docs that were inserted, so search_libraries can surface
+// "how well-indexed is this lib" without recounting on every query.
+// Updating a row that does not exist is silently a no-op (zero rows
+// affected) — the scraper is responsible for calling UpsertLibIfNew
+// first.
+func UpdateLibCount(d *DB, libID string, count int) error {
+	if libID == "" {
+		return errors.New("update lib count: libID must not be empty")
+	}
+	if count < 0 {
+		return fmt.Errorf("update lib count: count must be >= 0, got %d", count)
+	}
+	if _, err := d.Exec(`UPDATE libs SET doc_count = ? WHERE lib_id = ?`, count, libID); err != nil {
+		return fmt.Errorf("update lib count %q: %w", libID, err)
+	}
+	return nil
+}
+
+// SearchLibsByEmbedding returns the top-`limit` libs ranked by cosine
+// distance to queryVec, breaking ties by doc_count desc so a
+// well-indexed lib outranks a barely-touched one when both score
+// equally on semantic match. The query vector must have
+// db.Meta.EmbeddingDim components — the same constraint as
+// SearchByEmbedding, for the same reason (cross-embedder vectors are
+// nonsense).
+func SearchLibsByEmbedding(d *DB, queryVec []float32, limit int) ([]LibInfo, error) {
+	if len(queryVec) != d.Meta.EmbeddingDim {
+		return nil, fmt.Errorf("search libs: query vector length %d, want %d", len(queryVec), d.Meta.EmbeddingDim)
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := d.Query(
+		`SELECT lib_id, doc_count, vector_distance_cos(embedding, vector(?)) AS dist
+		 FROM libs
+		 ORDER BY dist ASC, doc_count DESC
+		 LIMIT ?`,
+		formatVector(queryVec), limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("search libs: %w", err)
+	}
+	defer rows.Close()
+
+	results := make([]LibInfo, 0, limit)
+	for rows.Next() {
+		var (
+			info LibInfo
+			// turso returns vector_distance_cos as a REAL; scan into a
+			// float64 then narrow to float32 to match LibInfo.Distance
+			// (database/sql's Scan doesn't bind directly to *float32).
+			dist float64
+		)
+		if err := rows.Scan(&info.LibID, &info.DocCount, &dist); err != nil {
+			return nil, fmt.Errorf("search libs: scan: %w", err)
+		}
+		info.Distance = float32(dist)
+		results = append(results, info)
+	}
+	return results, rows.Err()
+}
+
+// TopLibsByDocCount returns the top-`limit` libs ranked by doc_count
+// descending. This is the cheap "no query" path that powers the empty-
+// name branch of search_libraries: an LLM exploring an unfamiliar
+// corpus gets a useful "what's even in here" answer without paying for
+// an embedder call. Distance is left at 0 (the row's match_score in
+// the wire format ends up at 1.0).
+func TopLibsByDocCount(d *DB, limit int) ([]LibInfo, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := d.Query(
+		`SELECT lib_id, doc_count FROM libs ORDER BY doc_count DESC LIMIT ?`,
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("top libs: %w", err)
+	}
+	defer rows.Close()
+
+	results := make([]LibInfo, 0, limit)
+	for rows.Next() {
+		var info LibInfo
+		if err := rows.Scan(&info.LibID, &info.DocCount); err != nil {
+			return nil, fmt.Errorf("top libs: scan: %w", err)
+		}
+		results = append(results, info)
+	}
+	return results, rows.Err()
+}
+
+// normalizeLibIDText turns a path-like lib_id into a string MiniLM can
+// embed as natural language: "/" and "-" become spaces, surrounding
+// whitespace is trimmed. The transformation is intentionally trivial
+// and lossy — the embedder's job is to project semantic content, not
+// to roundtrip the lib_id. Centroid-of-doc-embeddings was rejected in
+// the issue because it has no recompute-on-partial-rescrape problem
+// and the lib_id text alone gives MiniLM enough signal to handle
+// queries like "terraform aws" → "/hashicorp/terraform-provider-aws".
+func normalizeLibIDText(libID string) string {
+	return strings.TrimSpace(strings.NewReplacer("/", " ", "-", " ").Replace(libID))
+}
+
 // Meta table key names. Defined as constants to keep the read/write paths
 // in sync and to give callers a single place to look for "what does the
 // meta table actually contain".
 const (
-	metaKeyEmbedderKind = "embedder_kind"
-	metaKeyEmbeddingDim = "embedding_dim"
-	metaKeyModelVersion = "model_version"
+	metaKeyEmbedderKind  = "embedder_kind"
+	metaKeyEmbeddingDim  = "embedding_dim"
+	metaKeyModelVersion  = "model_version"
+	metaKeySchemaVersion = "schema_version"
 )
 
 func validateMeta(m Meta) error {
@@ -230,14 +439,16 @@ func validateMeta(m Meta) error {
 	return nil
 }
 
-// readMeta returns the stored Meta and a boolean indicating whether any
-// meta rows were found. A partially-populated meta table (some keys
-// present, others missing) is treated as a corrupt database and returns
-// an error rather than silently filling the gaps from the caller.
-func readMeta(raw *sql.DB) (Meta, bool, error) {
+// readMeta returns the stored Meta, the stored schema version (0 if the
+// schema_version key is absent — i.e. a pre-libs database), and a boolean
+// indicating whether any meta rows were found. A partially-populated meta
+// table (some required keys present, others missing) is treated as a
+// corrupt database and returns an error rather than silently filling the
+// gaps from the caller.
+func readMeta(raw *sql.DB) (Meta, int, bool, error) {
 	rows, err := raw.Query(`SELECT key, value FROM meta`)
 	if err != nil {
-		return Meta{}, false, err
+		return Meta{}, 0, false, err
 	}
 	defer rows.Close()
 
@@ -245,36 +456,50 @@ func readMeta(raw *sql.DB) (Meta, bool, error) {
 	for rows.Next() {
 		var k, v string
 		if err := rows.Scan(&k, &v); err != nil {
-			return Meta{}, false, err
+			return Meta{}, 0, false, err
 		}
 		values[k] = v
 	}
 	if err := rows.Err(); err != nil {
-		return Meta{}, false, err
+		return Meta{}, 0, false, err
 	}
 
 	if len(values) == 0 {
-		return Meta{}, false, nil
+		return Meta{}, 0, false, nil
 	}
 
 	kind, hasKind := values[metaKeyEmbedderKind]
 	dimStr, hasDim := values[metaKeyEmbeddingDim]
 	version, hasVersion := values[metaKeyModelVersion]
 	if !hasKind || !hasDim || !hasVersion {
-		return Meta{}, false, fmt.Errorf("meta table has unexpected keys %v; expected %s, %s, %s",
+		return Meta{}, 0, false, fmt.Errorf("meta table has unexpected keys %v; expected %s, %s, %s",
 			keysOf(values), metaKeyEmbedderKind, metaKeyEmbeddingDim, metaKeyModelVersion)
 	}
 
 	dim, err := strconv.Atoi(dimStr)
 	if err != nil {
-		return Meta{}, false, fmt.Errorf("parse %s=%q: %w", metaKeyEmbeddingDim, dimStr, err)
+		return Meta{}, 0, false, fmt.Errorf("parse %s=%q: %w", metaKeyEmbeddingDim, dimStr, err)
+	}
+
+	// schema_version is intentionally optional at the read layer:
+	// pre-libs databases never wrote this key, and we want them to
+	// surface as ErrSchemaMismatch in Open rather than as a corrupt-
+	// meta error here. Missing key → 0, which never matches any future
+	// CurrentSchemaVersion.
+	schemaVersion := 0
+	if s, ok := values[metaKeySchemaVersion]; ok {
+		parsed, err := strconv.Atoi(s)
+		if err != nil {
+			return Meta{}, 0, false, fmt.Errorf("parse %s=%q: %w", metaKeySchemaVersion, s, err)
+		}
+		schemaVersion = parsed
 	}
 
 	return Meta{
 		EmbedderKind: kind,
 		EmbeddingDim: dim,
 		ModelVersion: version,
-	}, true, nil
+	}, schemaVersion, true, nil
 }
 
 func writeMeta(raw *sql.DB, m Meta) error {
@@ -284,6 +509,7 @@ func writeMeta(raw *sql.DB, m Meta) error {
 		{metaKeyEmbedderKind, m.EmbedderKind},
 		{metaKeyEmbeddingDim, strconv.Itoa(m.EmbeddingDim)},
 		{metaKeyModelVersion, m.ModelVersion},
+		{metaKeySchemaVersion, strconv.Itoa(CurrentSchemaVersion)},
 	}
 	for _, r := range rows {
 		if _, err := raw.Exec(`INSERT INTO meta(key, value) VALUES (?, ?)`, r.key, r.value); err != nil {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/laradji/deadzone/internal/db"
 	"github.com/laradji/deadzone/internal/embed"
+	_ "turso.tech/database/tursogo"
 )
 
 // testEmbedder is the package-level Hugot shared by every test in this
@@ -302,5 +304,238 @@ func TestDB_RoundtripsMeta(t *testing.T) {
 	defer reopened.Close()
 	if reopened.Meta != want {
 		t.Errorf("reopened Meta = %+v, want %+v", reopened.Meta, want)
+	}
+}
+
+// countingEmbedder wraps an embed.Embedder and counts how many times
+// Embed has been called. Used by TestUpsertLibIfNew_Idempotent to prove
+// that the second upsert for the same lib_id is a literal no-op at the
+// embedder level (the issue's "at most one Embed call per lib in the
+// lifetime of the database" guarantee).
+type countingEmbedder struct {
+	inner embed.Embedder
+	calls int
+}
+
+func (c *countingEmbedder) Embed(text string) ([]float32, error) {
+	c.calls++
+	return c.inner.Embed(text)
+}
+
+// TestUpsertLibIfNew_Idempotent is the load-bearing assertion behind the
+// design's "embedding never changes once computed" claim: re-running
+// the scraper for an existing lib must NOT call Embed a second time. We
+// verify it by wrapping testEmbedder in a counter and inspecting the
+// counter after two consecutive UpsertLibIfNew calls.
+func TestUpsertLibIfNew_Idempotent(t *testing.T) {
+	d := openTestDB(t)
+	c := &countingEmbedder{inner: testEmbedder}
+
+	if err := db.UpsertLibIfNew(d, "/facebook/react", c); err != nil {
+		t.Fatalf("first UpsertLibIfNew: %v", err)
+	}
+	if c.calls != 1 {
+		t.Fatalf("after first upsert: Embed called %d time(s), want 1", c.calls)
+	}
+
+	if err := db.UpsertLibIfNew(d, "/facebook/react", c); err != nil {
+		t.Fatalf("second UpsertLibIfNew: %v", err)
+	}
+	if c.calls != 1 {
+		t.Errorf("after second upsert: Embed called %d time(s), want 1 (re-upsert must not re-embed)", c.calls)
+	}
+
+	// And a sanity check: a *different* lib_id does trigger a fresh Embed
+	// call. This catches the failure mode where UpsertLibIfNew gets
+	// over-eager and short-circuits on any non-empty libs table.
+	if err := db.UpsertLibIfNew(d, "/vercel/next.js", c); err != nil {
+		t.Fatalf("upsert second lib: %v", err)
+	}
+	if c.calls != 2 {
+		t.Errorf("after upserting a second lib: Embed called %d time(s), want 2", c.calls)
+	}
+}
+
+// TestUpdateLibCount_UpdatesRightRow verifies that UpdateLibCount only
+// touches the row keyed by libID. The "untouched lib stays at 0" half
+// of the assertion catches an obvious WHERE-clause bug; the "matching
+// lib gets the new value" half catches an obvious set-vs-add bug.
+func TestUpdateLibCount_UpdatesRightRow(t *testing.T) {
+	d := openTestDB(t)
+
+	for _, libID := range []string{"/a/one", "/b/two"} {
+		if err := db.UpsertLibIfNew(d, libID, testEmbedder); err != nil {
+			t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
+		}
+	}
+
+	if err := db.UpdateLibCount(d, "/a/one", 42); err != nil {
+		t.Fatalf("UpdateLibCount: %v", err)
+	}
+
+	got := readLibCount(t, d, "/a/one")
+	if got != 42 {
+		t.Errorf("/a/one doc_count = %d, want 42", got)
+	}
+	other := readLibCount(t, d, "/b/two")
+	if other != 0 {
+		t.Errorf("/b/two doc_count = %d, want 0 (UpdateLibCount touched the wrong row)", other)
+	}
+}
+
+func readLibCount(t *testing.T, d *db.DB, libID string) int {
+	t.Helper()
+	var n int
+	if err := d.QueryRow(`SELECT doc_count FROM libs WHERE lib_id = ?`, libID).Scan(&n); err != nil {
+		t.Fatalf("read doc_count for %q: %v", libID, err)
+	}
+	return n
+}
+
+// TestSearchLibsByEmbedding_RanksRelevantFirst is the headline test for
+// the search_libraries handler's hot path: a free-text query must rank
+// the semantically-closest lib first via lib_id-text-only embeddings.
+// "terraform aws" should resolve to /hashicorp/terraform-provider-aws
+// over the React and Express decoys; this is the exact "useful at
+// Context7 scale" property the issue is asking for.
+func TestSearchLibsByEmbedding_RanksRelevantFirst(t *testing.T) {
+	d := openTestDB(t)
+
+	libs := []string{
+		"/hashicorp/terraform-provider-aws",
+		"/facebook/react",
+		"/expressjs/express",
+	}
+	for _, libID := range libs {
+		if err := db.UpsertLibIfNew(d, libID, testEmbedder); err != nil {
+			t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
+		}
+	}
+
+	qv, err := testEmbedder.Embed("terraform aws")
+	if err != nil {
+		t.Fatalf("Embed query: %v", err)
+	}
+	results, err := db.SearchLibsByEmbedding(d, qv, 10)
+	if err != nil {
+		t.Fatalf("SearchLibsByEmbedding: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one result, got none")
+	}
+	if results[0].LibID != "/hashicorp/terraform-provider-aws" {
+		t.Errorf("expected '/hashicorp/terraform-provider-aws' first, got %q", results[0].LibID)
+		for i, r := range results {
+			t.Logf("  #%d: %s (dist=%v)", i+1, r.LibID, r.Distance)
+		}
+	}
+}
+
+// TestSearchLibsByEmbedding_HonoursLimit pins down the cap-on-result-set
+// guarantee from the tool's spec: even with three matching libs, asking
+// for two must return exactly two. The order assertion is incidental;
+// the count assertion is the load-bearing one.
+func TestSearchLibsByEmbedding_HonoursLimit(t *testing.T) {
+	d := openTestDB(t)
+
+	for _, libID := range []string{"/a/one", "/b/two", "/c/three"} {
+		if err := db.UpsertLibIfNew(d, libID, testEmbedder); err != nil {
+			t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
+		}
+	}
+
+	qv, err := testEmbedder.Embed("anything")
+	if err != nil {
+		t.Fatalf("Embed query: %v", err)
+	}
+	results, err := db.SearchLibsByEmbedding(d, qv, 2)
+	if err != nil {
+		t.Fatalf("SearchLibsByEmbedding: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("limit=2 returned %d results, want 2", len(results))
+	}
+}
+
+// TestTopLibsByDocCount_OrdersDescending pins the empty-name path of
+// the search_libraries handler. doc_count desc is what gives the LLM a
+// useful corpus-summary answer when it doesn't know what to ask for
+// yet, and it has to be deterministic so the tool's behavior is
+// reproducible across runs.
+func TestTopLibsByDocCount_OrdersDescending(t *testing.T) {
+	d := openTestDB(t)
+
+	libs := []struct {
+		id    string
+		count int
+	}{
+		{"/small/lib", 3},
+		{"/big/lib", 100},
+		{"/medium/lib", 25},
+	}
+	for _, l := range libs {
+		if err := db.UpsertLibIfNew(d, l.id, testEmbedder); err != nil {
+			t.Fatalf("UpsertLibIfNew %q: %v", l.id, err)
+		}
+		if err := db.UpdateLibCount(d, l.id, l.count); err != nil {
+			t.Fatalf("UpdateLibCount %q: %v", l.id, err)
+		}
+	}
+
+	results, err := db.TopLibsByDocCount(d, 10)
+	if err != nil {
+		t.Fatalf("TopLibsByDocCount: %v", err)
+	}
+	want := []string{"/big/lib", "/medium/lib", "/small/lib"}
+	if len(results) != len(want) {
+		t.Fatalf("got %d results, want %d", len(results), len(want))
+	}
+	for i, w := range want {
+		if results[i].LibID != w {
+			t.Errorf("position %d: got %q, want %q", i, results[i].LibID, w)
+		}
+	}
+}
+
+// TestDB_RejectsPreLibsSchema simulates an old (pre-libs) database file
+// by hand-crafting a meta table without a schema_version key. Opening
+// such a file with the current build must fail with ErrSchemaMismatch
+// — the migration story for issue #44 is "drop & re-scrape", and this
+// test guarantees the old DB can't silently slip through and produce
+// nonsense search_libraries responses (empty libs table, no rows).
+func TestDB_RejectsPreLibsSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.db")
+
+	// Open the file directly through the driver and write the v1 meta
+	// layout: just the three embedder keys, no schema_version. This is
+	// what every database created before issue #44 looks like on disk.
+	raw, err := sql.Open("turso", path)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	raw.SetMaxOpenConns(1)
+	if _, err := raw.Exec(`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatalf("create meta: %v", err)
+	}
+	for _, kv := range [][2]string{
+		{"embedder_kind", testEmbedder.Kind()},
+		{"embedding_dim", fmt.Sprintf("%d", testEmbedder.Dim())},
+		{"model_version", testEmbedder.ModelVersion()},
+	} {
+		if _, err := raw.Exec(`INSERT INTO meta(key, value) VALUES (?, ?)`, kv[0], kv[1]); err != nil {
+			t.Fatalf("insert meta %s: %v", kv[0], err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+
+	reopened, err := db.Open(path, metaFor(testEmbedder))
+	if err == nil {
+		reopened.Close()
+		t.Fatal("expected ErrSchemaMismatch on pre-libs DB, got nil")
+	}
+	if !errors.Is(err, db.ErrSchemaMismatch) {
+		t.Errorf("expected ErrSchemaMismatch, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `search_libraries(name, limit?)` MCP tool that resolves free-text queries (e.g. `"terraform aws"`) into ranked `lib_id` candidates via cosine similarity on lib_id-text embeddings
- Empty `name` returns top libraries by `doc_count` without an embedder call (cheap "what's in here" path)
- New `libs` table in the database stores per-library embeddings and corpus size
- Scraper now upserts lib catalog rows at start and updates `doc_count` at end of each run
- Introduce schema versioning (`CurrentSchemaVersion = 2`) with `ErrSchemaMismatch` to catch stale DBs

## Details

- `LibraryHit` returns `lib_id`, `doc_count`, and `match_score` (1 - cosine distance) so LLM clients can pick a single canonical result or surface multiple candidates
- `UpsertLibIfNew` is idempotent — embeds lib_id text only once per database lifetime
- `normalizeLibIDText` converts path-like lib_ids (`/hashicorp/terraform-provider-aws`) into natural language for MiniLM
- Limit clamped to [1, 50], default 10

## Test plan

- `TestHandleSearchLibraries` — end-to-end handler tests: semantic ranking, empty-name doc_count path, whitespace handling, limit enforcement
- `TestHandleSearchLibraries_NoMatches` — empty catalog returns `[]` not `null`
- `TestUpsertLibIfNew_Idempotent` — counting embedder proves no re-embed on re-upsert
- `TestUpdateLibCount_UpdatesRightRow` — only target row is modified
- `TestSearchLibsByEmbedding_RanksRelevantFirst` — "terraform aws" resolves to the right lib
- `TestSearchLibsByEmbedding_HonoursLimit` — result cap is enforced
- `TestTopLibsByDocCount_Ordering` — doc_count descending sort
- `TestSchemaMismatch_RejectsOldDB` — pre-libs databases surface as `ErrSchemaMismatch`

<!-- emdash-issue-footer:start -->
Fixes #44
<!-- emdash-issue-footer:end -->