### PR TITLE
refactor: per-lib database artifacts with consolidate pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 /deadzone
 /deadzone-server
+/deadzone-consolidate
 /deadzone.db
 /deadzone.db-wal
 /deadzone.db-shm
+/artifacts/
 /.envrc
 .DS_Store
 .mcp.json

--- a/README.md
+++ b/README.md
@@ -67,16 +67,38 @@ mise install
 # 2. Build — no CGO required
 just build             # = mise exec -- go build ./...
 
-# 3. Scrape and index a library (defaults to ./deadzone.db)
-just scrape            # = mise exec -- go run ./cmd/scraper -db deadzone.db
-# → indexes every library listed in ./libraries_sources.yaml
+# 3. Scrape every library in libraries_sources.yaml into per-lib artifacts
+just scrape            # = mise exec -- go run ./cmd/scraper -artifacts ./artifacts
+# → writes one artifacts/<lib_id>.db file per entry in libraries_sources.yaml
 # → ships preloaded with the modelcontextprotocol/go-sdk docs
 
-# 4. Run the MCP server
+# 4. Merge the per-lib artifacts into the main deadzone.db
+just consolidate       # = mise exec -- go run ./cmd/consolidate -db deadzone.db -artifacts ./artifacts
+
+# 5. Run the MCP server against the consolidated DB
 just serve             # = mise exec -- go run ./cmd/server -db deadzone.db
 ```
 
-Run `just` (no args) to list every recipe. Override the DB path with positional args: `just scrape foo.db` / `just serve foo.db`. If you'd rather call `go` directly, prefix every command with `mise exec --` so you pick up the pinned toolchain.
+The `artifacts/` directory and `deadzone.db` are both gitignored — `artifacts/` holds the per-lib source-of-truth files and `deadzone.db` is the derived view the server reads. The server refuses to start if `deadzone.db` is missing and tells you to run `consolidate` first; it never auto-creates an empty file.
+
+Run `just` (no args) to list every recipe. Override the DB path with positional args: `just consolidate foo.db` / `just serve foo.db`. If you'd rather call `go` directly, prefix every command with `mise exec --` so you pick up the pinned toolchain.
+
+### Refreshing a single library
+
+The whole point of the per-lib artifact layout is that one library can be re-scraped without touching the others. Pass the lib_id to `just scrape` (matches the registry's `lib_id` field; for multi-version libs you can target the base or one expanded version):
+
+```bash
+# Re-scrape every version of /facebook/react and rebuild its artifact(s)
+just scrape /facebook/react
+
+# Re-scrape only one expanded version
+just scrape /facebook/react/v18
+
+# Then merge the refreshed artifact(s) back into the main DB
+just consolidate
+```
+
+`just scrape <lib>` regenerates exactly the matching `artifacts/*.db` files; the others stay byte-identical. `just consolidate` is idempotent — re-running it after a partial scrape just replaces the rows for the libs whose artifacts changed.
 
 ### Configuring which libraries to scrape
 
@@ -112,20 +134,23 @@ libraries:
 
 Adding a new library means adding a YAML entry — no Go editing, no recompile.
 
-The scraper accepts two flags for working with the registry:
+The scraper accepts a few flags for working with the registry and the artifact directory:
 
 ```bash
 # Use a non-default registry path
-mise exec -- go run ./cmd/scraper -db deadzone.db -config /path/to/libraries_sources.yaml
+mise exec -- go run ./cmd/scraper -artifacts ./artifacts -config /path/to/libraries_sources.yaml
+
+# Use a non-default artifacts directory
+mise exec -- go run ./cmd/scraper -artifacts /var/cache/deadzone/artifacts
 
 # Scrape every configured version of one base lib
-mise exec -- go run ./cmd/scraper -db deadzone.db -lib /facebook/react
+mise exec -- go run ./cmd/scraper -artifacts ./artifacts -lib /facebook/react
 
 # Scrape only one specific versioned lib
-mise exec -- go run ./cmd/scraper -db deadzone.db -lib /facebook/react/v18
+mise exec -- go run ./cmd/scraper -artifacts ./artifacts -lib /facebook/react/v18
 ```
 
-`-lib` matches at two levels: a base `lib_id` selects every expanded version of that base; a fully versioned `lib_id` selects exactly one expanded entry. Omitting `-lib` scrapes everything in the registry.
+`-lib` matches at two levels: a base `lib_id` selects every expanded version of that base; a fully versioned `lib_id` selects exactly one expanded entry. Omitting `-lib` scrapes everything in the registry. Each entry produces (or replaces) one `artifacts/<lib_id>.db` file — the leading `/` is stripped and the remaining `/` characters become `_`, so `/facebook/react/v18` lands at `artifacts/facebook_react_v18.db`.
 
 > **First-run model download.** The first `just scrape` or `just serve` invocation downloads the MiniLM-L6-v2 ONNX weights (~90 MB) into the platform user-cache directory under `deadzone/models/`:
 >
@@ -158,14 +183,16 @@ Then call the `search_docs` or `search_libraries` tool from the client.
 ```
 deadzone/
 ├── cmd/
-│   ├── server/    # MCP server entrypoint (search_docs tool)
-│   └── scraper/   # CLI: fetch, embed & index a library's docs
+│   ├── server/        # MCP server entrypoint (search_docs / search_libraries)
+│   ├── scraper/       # CLI: fetch, embed & write per-lib artifacts
+│   └── consolidate/   # CLI: merge per-lib artifacts into the main DB
 ├── internal/
-│   ├── db/        # Turso schema and vector queries (F32_BLOB + vector_distance_cos)
-│   ├── embed/     # Embedder interface + hugot/MiniLM implementation
-│   └── scraper/   # Markdown fetcher + parser (H2-split, fence-aware)
+│   ├── db/            # Turso schema, vector queries, consolidation helper
+│   ├── embed/         # Embedder interface + hugot/MiniLM implementation
+│   └── scraper/       # Markdown fetcher + parser (H2-split, fence-aware)
+├── artifacts/         # gitignored: per-lib .db source-of-truth files
 └── docs/
-    └── research/  # Design notes (Context7 analysis, tursogo migration, etc.)
+    └── research/      # Design notes (Context7 analysis, tursogo migration, etc.)
 ```
 
 ## Why vector search
@@ -176,11 +203,12 @@ More background in [`docs/research/context7-analysis.md`](docs/research/context7
 
 ## Debugging
 
-Both binaries emit structured JSON logs to **stderr** using `log/slog`. Stdout is reserved for the MCP JSON-RPC channel on `cmd/server`, so anything written there that isn't a valid JSON-RPC message disconnects the client — `cmd/scraper` follows the same convention for consistency.
+All three binaries emit structured JSON logs to **stderr** using `log/slog`. Stdout is reserved for the MCP JSON-RPC channel on `cmd/server`, so anything written there that isn't a valid JSON-RPC message disconnects the client — `cmd/scraper` and `cmd/consolidate` follow the same convention for consistency.
 
-- **Scraper.** `just scrape` writes logs straight to your terminal. Look for `scraper.start`, one `scraper.fetch` per URL (with `bytes`, `duration_ms`, `docs_extracted`), `scraper.indexed` summaries, and a final `scraper.done`. The "silently stalls on one URL" failure mode shows up as a missing `scraper.fetch` event for that URL. Errors land as `scraper.fetch_failed` / `scraper.insert_failed` with the URL and wrapped error.
-- **Server.** `cmd/server`'s stderr is captured by the MCP client. In Claude Code that's the `~/Library/Logs/Claude/mcp-server-deadzone.log` file (macOS) or your client's equivalent — check the MCP client docs. On startup the server emits a `server.start` line with the embedder meta and the indexed `doc_count`; each `search_docs` call emits one `search_docs` line with `lib_id`, `tokens`, `results`, and `latency_ms`.
-- **Verbose mode.** Both binaries take `-verbose`. On the server it adds the raw `query` field to per-call logs (off by default because queries may contain user data). On the scraper it adds per-doc `scraper.doc_indexed` Debug lines, useful when debugging the parser on a new library.
+- **Scraper.** `just scrape` writes logs straight to your terminal. Look for `scraper.start`, a `scraper.lib_start` per resolved library (with the `artifact_path` it's writing to), one `scraper.fetch` per URL (with `bytes`, `duration_ms`, `docs_extracted`), `scraper.indexed` summaries, a `scraper.lib_done` per library, and a final `scraper.done`. The "silently stalls on one URL" failure mode shows up as a missing `scraper.fetch` event for that URL. Errors land as `scraper.fetch_failed` / `scraper.insert_failed` with the URL and wrapped error.
+- **Consolidate.** `just consolidate` emits a `consolidate.start` and a `consolidate.done` with the `artifacts` count, `docs_merged`, `libs_merged`, and `duration_ms`. A failure aborts before any write reaches the main DB; the wrapped error names the offending artifact.
+- **Server.** `cmd/server`'s stderr is captured by the MCP client. In Claude Code that's the `~/Library/Logs/Claude/mcp-server-deadzone.log` file (macOS) or your client's equivalent — check the MCP client docs. On startup the server emits a `server.start` line with the embedder meta and the indexed `doc_count`; each `search_docs` call emits one `search_docs` line with `lib_id`, `tokens`, `results`, and `latency_ms`. If the configured `-db` is missing the server refuses to start and prints a one-liner pointing at `deadzone-consolidate`.
+- **Verbose mode.** All three binaries take `-verbose`. On the server it adds the raw `query` field to per-call logs (off by default because queries may contain user data). On the scraper it adds per-doc `scraper.doc_indexed` Debug lines, useful when debugging the parser on a new library.
 
 ## Roadmap
 

--- a/cmd/consolidate/main.go
+++ b/cmd/consolidate/main.go
@@ -1,0 +1,94 @@
+// Command consolidate merges every per-lib artifact .db file in
+// -artifacts into the main -db, replacing any rows that share a
+// lib_id. Run after scraping (or after pulling fresh artifacts from
+// wherever #30's distribution layer ends up living) to refresh the
+// database the MCP server reads.
+//
+// The command is intentionally explicit: the server does not auto-
+// consolidate at startup, and there is no "are you sure?" prompt
+// here. Re-running consolidate is idempotent and safe — it deletes
+// per-lib slices in main and re-inserts from each artifact within a
+// single transaction, so a partial failure leaves main byte-identical
+// to its pre-call state.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/laradji/deadzone/internal/db"
+	"github.com/laradji/deadzone/internal/embed"
+	"github.com/laradji/deadzone/internal/logs"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("consolidate fatal", "err", err.Error())
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	dbPath := flag.String("db", "deadzone.db", "path to main deadzone database (created if missing)")
+	artifactsDir := flag.String("artifacts", "./artifacts", "directory containing per-lib artifact .db files")
+	embedderKind := flag.String("embedder", embed.KindHugot, "embedder to use (valid: hugot)")
+	verbose := flag.Bool("verbose", false, "verbose logging")
+	flag.Parse()
+
+	slog.SetDefault(logs.New(os.Stderr, *verbose))
+
+	// The embedder is loaded purely so we can hand its meta to
+	// db.Open and to the validation pass — consolidate doesn't itself
+	// embed any text. The model is downloaded on first use exactly
+	// like the scraper, so a fresh checkout that runs `consolidate`
+	// before `scrape` still works (it just downloads ~90MB of model
+	// weights to no immediate purpose).
+	e, err := embed.New(*embedderKind)
+	if err != nil {
+		return fmt.Errorf("embedder: %w", err)
+	}
+	defer func() {
+		if err := e.Close(); err != nil {
+			slog.Warn("embedder close", "err", err.Error())
+		}
+	}()
+
+	meta := db.Meta{
+		EmbedderKind: e.Kind(),
+		EmbeddingDim: e.Dim(),
+		ModelVersion: e.ModelVersion(),
+	}
+
+	d, err := db.Open(*dbPath, meta)
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer d.Close()
+
+	slog.Info("consolidate.start",
+		"db_path", *dbPath,
+		"artifacts_dir", *artifactsDir,
+		"embedder_kind", e.Kind(),
+		"embedding_dim", e.Dim(),
+		"model_version", e.ModelVersion(),
+	)
+
+	start := time.Now()
+	result, err := db.Consolidate(d, *artifactsDir)
+	if err != nil {
+		return fmt.Errorf("consolidate: %w", err)
+	}
+
+	slog.Info("consolidate.done",
+		"db_path", *dbPath,
+		"artifacts_dir", *artifactsDir,
+		"artifacts", result.Artifacts,
+		"docs_merged", result.DocsMerged,
+		"libs_merged", result.LibsMerged,
+		"duration_ms", time.Since(start).Milliseconds(),
+	)
+	return nil
+}

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/laradji/deadzone/internal/db"
@@ -23,7 +25,7 @@ func main() {
 }
 
 func run() error {
-	dbPath := flag.String("db", "deadzone.db", "path to turso database file")
+	artifactsDir := flag.String("artifacts", "./artifacts", "directory to write per-lib artifact .db files into")
 	embedderKind := flag.String("embedder", embed.KindHugot, "embedder to use (valid: hugot)")
 	verbose := flag.Bool("verbose", false, "emit per-doc Debug log lines in addition to per-URL summaries")
 	configPath := flag.String("config", "libraries_sources.yaml", "path to libraries_sources.yaml registry")
@@ -49,6 +51,13 @@ func run() error {
 		return fmt.Errorf("no libraries to scrape in %s", *configPath)
 	}
 
+	// One artifacts/ dir per scraper run; created on demand so the
+	// first invocation on a fresh checkout doesn't require an extra
+	// `mkdir -p` step in the README.
+	if err := os.MkdirAll(*artifactsDir, 0o755); err != nil {
+		return fmt.Errorf("create artifacts dir %s: %w", *artifactsDir, err)
+	}
+
 	e, err := embed.New(*embedderKind)
 	if err != nil {
 		return fmt.Errorf("embedder: %w", err)
@@ -59,24 +68,17 @@ func run() error {
 		}
 	}()
 
-	// db.Open enforces meta consistency: if the database already exists
-	// and was indexed with a different embedder, it returns
-	// db.ErrEmbedderMismatch and we abort without touching the data.
-	d, err := db.Open(*dbPath, db.Meta{
+	meta := db.Meta{
 		EmbedderKind: e.Kind(),
 		EmbeddingDim: e.Dim(),
 		ModelVersion: e.ModelVersion(),
-	})
-	if err != nil {
-		return fmt.Errorf("open db: %w", err)
 	}
-	defer d.Close()
 
 	slog.Info("scraper.start",
 		"config_path", *configPath,
 		"lib_filter", *libFilter,
 		"lib_count", len(sources),
-		"db_path", *dbPath,
+		"artifacts_dir", *artifactsDir,
 		"embedder_kind", e.Kind(),
 		"embedding_dim", e.Dim(),
 		"model_version", e.ModelVersion(),
@@ -87,7 +89,7 @@ func run() error {
 	var docsTotal int
 
 	for _, src := range sources {
-		libDocs, err := scrapeLib(ctx, http.DefaultClient, e, d, src)
+		libDocs, err := scrapeLibToArtifact(ctx, http.DefaultClient, e, meta, *artifactsDir, src)
 		if err != nil {
 			return err
 		}
@@ -98,29 +100,59 @@ func run() error {
 		"lib_count", len(sources),
 		"docs_total", docsTotal,
 		"duration_ms", time.Since(runStart).Milliseconds(),
-		"db_path", *dbPath,
+		"artifacts_dir", *artifactsDir,
 	)
 	return nil
 }
 
-// scrapeLib runs the per-URL fetch / embed / insert loop for one resolved
-// library and returns the number of docs successfully indexed. It is
-// extracted from run() so the multi-library loop stays readable while the
-// per-URL bookkeeping (timings, fetch_failed events, embed/insert
-// summaries) keeps its single-lib structure.
-func scrapeLib(
+// scrapeLibToArtifact handles one resolved library end-to-end: it
+// computes the artifact path from the lib_id, removes any pre-existing
+// artifact file (and tursogo's WAL/SHM sidecars) so the new run starts
+// from a clean slate, opens a fresh per-lib DB via OpenArtifact, runs
+// the per-URL fetch/embed/insert loop, updates the libs catalog row,
+// and closes the artifact. Returns the number of docs successfully
+// indexed for the operator log.
+//
+// Each artifact contains exactly one lib_id by construction; the
+// "delete then open" rebuild model is intentional — the per-lib
+// granularity is the whole point of #28, so a partial scrape that
+// leaves an artifact stale would defeat the design. If the rebuild
+// fails midway the artifact file is missing on disk, not corrupted,
+// and the operator can re-run the same -lib filter to retry.
+func scrapeLibToArtifact(
 	ctx context.Context,
 	client *http.Client,
 	e embed.Embedder,
-	d *db.DB,
+	meta db.Meta,
+	artifactsDir string,
 	src scraper.ResolvedSource,
 ) (int, error) {
+	artifactPath := filepath.Join(artifactsDir, artifactFilename(src.LibID))
+
+	// Wipe any prior artifact + tursogo sidecar files. The sidecars
+	// are journaling state; an orphaned -wal/-shm pointing at a now-
+	// deleted main file confuses the next Open. Errors from os.Remove
+	// for non-existent files are ignored — the only thing we care
+	// about is that nothing from a previous run survives this point.
+	for _, p := range []string{artifactPath, artifactPath + "-wal", artifactPath + "-shm"} {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return 0, fmt.Errorf("remove stale artifact %s: %w", p, err)
+		}
+	}
+
+	d, err := db.OpenArtifact(artifactPath, meta, src.LibID)
+	if err != nil {
+		return 0, fmt.Errorf("open artifact %s: %w", artifactPath, err)
+	}
+	defer d.Close()
+
 	slog.Info("scraper.lib_start",
 		"lib_id", src.LibID,
 		"base_lib_id", src.BaseLibID,
 		"version", src.Version,
 		"kind", src.Kind,
 		"url_count", len(src.URLs),
+		"artifact_path", artifactPath,
 	)
 
 	// Make sure the libs catalog row exists before we start indexing
@@ -220,13 +252,11 @@ func scrapeLib(
 		docsTotal += docsInserted
 	}
 
-	// Update the libs catalog with the actual indexed doc count so
-	// search_libraries can rank by "how well-indexed is this lib". The
-	// scraper currently appends to docs without dedupe (see #28 for
-	// the per-lib artifact story), so docsTotal here is the new-rows
-	// count for this run, not the absolute table row count for the
-	// lib; callers re-running the scraper on a non-fresh DB are
-	// expected to drop & re-scrape per issue #44's migration story.
+	// Update the libs catalog with the final indexed doc count so
+	// search_libraries can rank by "how well-indexed is this lib".
+	// Each artifact is rebuilt from scratch, so docsTotal is the
+	// absolute row count for the lib in this artifact — no append-
+	// vs-replace ambiguity.
 	if err := db.UpdateLibCount(d, src.LibID, docsTotal); err != nil {
 		slog.Error("scraper.update_lib_count_failed",
 			"lib_id", src.LibID,
@@ -240,6 +270,22 @@ func scrapeLib(
 		"lib_id", src.LibID,
 		"docs_total", docsTotal,
 		"duration_ms", time.Since(libStart).Milliseconds(),
+		"artifact_path", artifactPath,
 	)
 	return docsTotal, nil
+}
+
+// artifactFilename derives the on-disk basename for a lib_id's
+// artifact: the leading "/" is stripped and the remaining slashes
+// become underscores. Example:
+//
+//	/modelcontextprotocol/go-sdk → modelcontextprotocol_go-sdk.db
+//	/facebook/react/v18         → facebook_react_v18.db
+//
+// The mapping is deterministic and 1:1 with the lib_id, so an operator
+// can read the file listing of artifacts/ and recover every lib by
+// inspection. Hyphens and dots are preserved.
+func artifactFilename(libID string) string {
+	trimmed := strings.TrimPrefix(libID, "/")
+	return strings.ReplaceAll(trimmed, "/", "_") + ".db"
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -239,6 +240,17 @@ func run() error {
 	// structured JSON to stderr — never stdout, which is the MCP
 	// JSON-RPC channel.
 	slog.SetDefault(logs.New(os.Stderr, *verbose))
+
+	// The server is a read-only consumer of the consolidated DB; it
+	// must NOT auto-create a fresh empty file (that would silently
+	// hide a missed `consolidate` step and serve zero results to
+	// every query). Stat first; if missing, point the operator at
+	// the consolidate command before any other work happens.
+	if _, err := os.Stat(*dbPath); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("%s not found. Run `deadzone-consolidate -db %s -artifacts ./artifacts` first to merge per-lib artifacts into the main database", *dbPath, *dbPath)
+	} else if err != nil {
+		return fmt.Errorf("stat db %s: %w", *dbPath, err)
+	}
 
 	// db.Open validates the embedder's reported meta against whatever
 	// the database was created with; a mismatch fails fast and tells

--- a/internal/db/consolidate.go
+++ b/internal/db/consolidate.go
@@ -1,0 +1,205 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sort"
+)
+
+// ConsolidateResult is the per-run summary returned by Consolidate. The
+// counts are best-effort accounting for the operator log line; they have
+// no bearing on the on-disk state, which is governed entirely by the
+// transaction's commit/rollback.
+type ConsolidateResult struct {
+	// Artifacts is the number of artifact files merged into main.
+	Artifacts int
+	// DocsMerged is the total number of docs rows inserted into main
+	// across every merged artifact (i.e. the new row count for the
+	// libs that participated; rows displaced by the per-lib DELETE
+	// are not counted as "merged").
+	DocsMerged int
+	// LibsMerged is the number of libs rows inserted into main. Each
+	// artifact contributes either 0 (degenerate empty artifact) or 1.
+	LibsMerged int
+}
+
+// Consolidate merges every *.db file in artifactsDir into main. It is
+// the inverse of the per-lib scrape: each artifact replaces (not
+// appends to) the rows in main that share its lib_id, in both the docs
+// and libs tables, atomically.
+//
+// The operation runs in two passes:
+//
+//  1. Validation. Every artifact is opened with main's Meta so any
+//     embedder mismatch (ErrEmbedderMismatch), schema mismatch
+//     (ErrSchemaMismatch), or missing artifact lib_id
+//     (ErrArtifactLibIDMissing) surfaces *before* any write touches
+//     main. Failures here leave main byte-identical.
+//
+//  2. Merge. A single transaction is begun on main; for each validated
+//     artifact, the existing rows for its lib_id are deleted from
+//     docs and libs, and the artifact's rows are streamed in via the
+//     transaction. The transaction commits at the end of the loop. If
+//     any step in pass 2 fails, the transaction rolls back and main is
+//     restored to its pre-call state.
+//
+// Reading and writing happen on different *sql.DB connection pools
+// (one per artifact, one for main), so the merge does not contend
+// with the per-pool MaxOpenConns=1 cap that tursogo serializes on.
+//
+// Artifact files are processed in lexicographic order so that the
+// merged-on-disk doc IDs are stable across runs — useful for
+// debugging diff'ing the same corpus on two machines.
+func Consolidate(main *DB, artifactsDir string) (ConsolidateResult, error) {
+	var result ConsolidateResult
+
+	matches, err := filepath.Glob(filepath.Join(artifactsDir, "*.db"))
+	if err != nil {
+		return result, fmt.Errorf("glob artifacts dir %s: %w", artifactsDir, err)
+	}
+	sort.Strings(matches)
+
+	type entry struct {
+		path  string
+		libID string
+	}
+	entries := make([]entry, 0, len(matches))
+
+	// Pass 1 — validation. Opening each artifact with libID="" both
+	// re-runs Open's meta/schema cross-check against main.Meta and
+	// reads the artifact's recorded lib_id. We close immediately so
+	// the conn pool is free for pass 2.
+	for _, path := range matches {
+		a, err := OpenArtifact(path, main.Meta, "")
+		if err != nil {
+			return result, fmt.Errorf("validate artifact %s: %w", filepath.Base(path), err)
+		}
+		entries = append(entries, entry{path: path, libID: a.ArtifactLibID})
+		_ = a.Close()
+	}
+
+	if len(entries) == 0 {
+		return result, nil
+	}
+
+	// Pass 2 — merge. database/sql Begin yields a tx that pins the
+	// single tursogo connection; every read and write below issues
+	// against tx, and the inner Query against the artifact runs on
+	// the artifact's own (separate) pool, so we never re-enter the
+	// main connection from two stacks at once.
+	tx, err := main.Begin()
+	if err != nil {
+		return result, fmt.Errorf("begin main tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	for _, e := range entries {
+		merged, libRow, err := mergeArtifactInto(tx, e.path, e.libID, main.Meta)
+		if err != nil {
+			return result, fmt.Errorf("merge artifact %s: %w", filepath.Base(e.path), err)
+		}
+		result.Artifacts++
+		result.DocsMerged += merged
+		if libRow {
+			result.LibsMerged++
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return result, fmt.Errorf("commit main tx: %w", err)
+	}
+	committed = true
+	return result, nil
+}
+
+// mergeArtifactInto reopens one artifact, deletes any existing rows in
+// main for its lib_id (across both docs and libs), and streams the
+// artifact's rows in via the supplied transaction. Returns the number
+// of docs inserted and whether a libs row was inserted.
+//
+// The artifact is opened with libID set to the value captured during
+// pass 1; any drift between the validation pass and the merge pass
+// (e.g. an artifact file rewritten between the two) surfaces here as
+// ErrArtifactLibIDMismatch and rolls back the whole consolidation.
+func mergeArtifactInto(tx *sql.Tx, path, libID string, meta Meta) (int, bool, error) {
+	a, err := OpenArtifact(path, meta, libID)
+	if err != nil {
+		return 0, false, err
+	}
+	defer a.Close()
+
+	// docs: drop the old per-lib slice in main, then stream the
+	// artifact's rows back in. vector_extract / vector() round-trips
+	// the F32_BLOB through the same JSON-array form formatVector
+	// uses on the insert path, so we don't need to teach this
+	// function about the on-disk encoding.
+	if _, err := tx.Exec(`DELETE FROM docs WHERE lib_id = ?`, libID); err != nil {
+		return 0, false, fmt.Errorf("delete docs for %q: %w", libID, err)
+	}
+	docRows, err := a.Query(`SELECT lib_id, title, content, vector_extract(embedding) FROM docs`)
+	if err != nil {
+		return 0, false, fmt.Errorf("select artifact docs: %w", err)
+	}
+	docsInserted := 0
+	for docRows.Next() {
+		var rowLibID, title, content, vecJSON string
+		if err := docRows.Scan(&rowLibID, &title, &content, &vecJSON); err != nil {
+			docRows.Close()
+			return 0, false, fmt.Errorf("scan artifact doc: %w", err)
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO docs(lib_id, title, content, embedding) VALUES (?, ?, ?, vector(?))`,
+			rowLibID, title, content, vecJSON,
+		); err != nil {
+			docRows.Close()
+			return 0, false, fmt.Errorf("insert doc into main: %w", err)
+		}
+		docsInserted++
+	}
+	if err := docRows.Err(); err != nil {
+		docRows.Close()
+		return 0, false, fmt.Errorf("iterate artifact docs: %w", err)
+	}
+	docRows.Close()
+
+	// libs: same dance. Most artifacts hold exactly one libs row
+	// (the lib_id they advertise via meta), but the loop is generic
+	// in case a future scraper writes additional bookkeeping rows.
+	if _, err := tx.Exec(`DELETE FROM libs WHERE lib_id = ?`, libID); err != nil {
+		return 0, false, fmt.Errorf("delete libs for %q: %w", libID, err)
+	}
+	libRows, err := a.Query(`SELECT lib_id, doc_count, vector_extract(embedding) FROM libs`)
+	if err != nil {
+		return 0, false, fmt.Errorf("select artifact libs: %w", err)
+	}
+	libRowInserted := false
+	for libRows.Next() {
+		var rowLibID, vecJSON string
+		var docCount int
+		if err := libRows.Scan(&rowLibID, &docCount, &vecJSON); err != nil {
+			libRows.Close()
+			return 0, false, fmt.Errorf("scan artifact lib: %w", err)
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO libs(lib_id, doc_count, embedding) VALUES (?, ?, vector(?))`,
+			rowLibID, docCount, vecJSON,
+		); err != nil {
+			libRows.Close()
+			return 0, false, fmt.Errorf("insert lib into main: %w", err)
+		}
+		libRowInserted = true
+	}
+	if err := libRows.Err(); err != nil {
+		libRows.Close()
+		return 0, false, fmt.Errorf("iterate artifact libs: %w", err)
+	}
+	libRows.Close()
+
+	return docsInserted, libRowInserted, nil
+}

--- a/internal/db/consolidate_test.go
+++ b/internal/db/consolidate_test.go
@@ -1,0 +1,431 @@
+package db_test
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/laradji/deadzone/internal/db"
+	_ "turso.tech/database/tursogo"
+)
+
+// makeArtifact builds a fresh artifact file at <dir>/<basename>.db
+// containing one libs row and the supplied docs. The basename is taken
+// from the lib_id with "/" turned into "_" and the leading slash
+// stripped — i.e. it follows the same naming rule the scraper uses, so
+// the test fixtures double as a regression check on the filename
+// scheme. Returns the artifact's on-disk path.
+func makeArtifact(t *testing.T, dir, libID string, docs []db.Doc) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", dir, err)
+	}
+	name := artifactBasename(libID) + ".db"
+	path := filepath.Join(dir, name)
+
+	a, err := db.OpenArtifact(path, metaFor(testEmbedder), libID)
+	if err != nil {
+		t.Fatalf("OpenArtifact %q: %v", libID, err)
+	}
+	if err := db.UpsertLibIfNew(a, libID, testEmbedder); err != nil {
+		a.Close()
+		t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
+	}
+	for _, doc := range docs {
+		if err := db.Insert(a, doc, embedText(t, testEmbedder, doc)); err != nil {
+			a.Close()
+			t.Fatalf("Insert into artifact %q: %v", libID, err)
+		}
+	}
+	if err := db.UpdateLibCount(a, libID, len(docs)); err != nil {
+		a.Close()
+		t.Fatalf("UpdateLibCount %q: %v", libID, err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close artifact %q: %v", libID, err)
+	}
+	return path
+}
+
+// artifactBasename mirrors the scraper's filename derivation. Kept
+// here in the test package (rather than imported) so the test catches
+// drift if the scraper's rule changes — when both sides break together
+// it's a deliberate refactor; when only one side breaks the diff is a
+// red flag.
+func artifactBasename(libID string) string {
+	out := libID
+	if len(out) > 0 && out[0] == '/' {
+		out = out[1:]
+	}
+	b := []byte(out)
+	for i, c := range b {
+		if c == '/' {
+			b[i] = '_'
+		}
+	}
+	return string(b)
+}
+
+func TestOpenArtifact_FreshWritesLibID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fresh.db")
+	a, err := db.OpenArtifact(path, metaFor(testEmbedder), "/foo/bar")
+	if err != nil {
+		t.Fatalf("OpenArtifact: %v", err)
+	}
+	if a.ArtifactLibID != "/foo/bar" {
+		t.Errorf("ArtifactLibID = %q, want %q", a.ArtifactLibID, "/foo/bar")
+	}
+	a.Close()
+
+	// Reopen with the same lib_id should succeed.
+	reopened, err := db.OpenArtifact(path, metaFor(testEmbedder), "/foo/bar")
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if reopened.ArtifactLibID != "/foo/bar" {
+		t.Errorf("reopen ArtifactLibID = %q, want %q", reopened.ArtifactLibID, "/foo/bar")
+	}
+	reopened.Close()
+
+	// Reopen with libID="" should also succeed and surface the
+	// stored value — this is the consolidate code path.
+	discovered, err := db.OpenArtifact(path, metaFor(testEmbedder), "")
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if discovered.ArtifactLibID != "/foo/bar" {
+		t.Errorf("discovered ArtifactLibID = %q, want %q", discovered.ArtifactLibID, "/foo/bar")
+	}
+	discovered.Close()
+}
+
+func TestOpenArtifact_RejectsLibIDMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tampered.db")
+	a, err := db.OpenArtifact(path, metaFor(testEmbedder), "/real/lib")
+	if err != nil {
+		t.Fatalf("OpenArtifact: %v", err)
+	}
+	a.Close()
+
+	_, err = db.OpenArtifact(path, metaFor(testEmbedder), "/wrong/lib")
+	if err == nil {
+		t.Fatal("expected ErrArtifactLibIDMismatch, got nil")
+	}
+	if !errors.Is(err, db.ErrArtifactLibIDMismatch) {
+		t.Errorf("expected ErrArtifactLibIDMismatch, got %v", err)
+	}
+}
+
+func TestOpenArtifact_DiscoverModeRequiresExistingFile(t *testing.T) {
+	// libID="" against a non-existent file must NOT create a stub.
+	path := filepath.Join(t.TempDir(), "ghost.db")
+	_, err := db.OpenArtifact(path, metaFor(testEmbedder), "")
+	if err == nil {
+		t.Fatal("expected error opening missing artifact in discover mode, got nil")
+	}
+	if _, statErr := os.Stat(path); statErr == nil {
+		t.Errorf("OpenArtifact created a stub file at %s; should have refused", path)
+	}
+}
+
+func TestOpenArtifact_DiscoverModeOnMainDBFails(t *testing.T) {
+	// A database opened via Open() (not OpenArtifact) has no lib_id
+	// meta key. Asking OpenArtifact to discover its identity must
+	// surface ErrArtifactLibIDMissing rather than silently returning
+	// an empty lib_id that would later cause a DELETE WHERE lib_id=''
+	// to wipe untagged rows in main.
+	path := filepath.Join(t.TempDir(), "main.db")
+	d, err := db.Open(path, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	d.Close()
+
+	_, err = db.OpenArtifact(path, metaFor(testEmbedder), "")
+	if err == nil {
+		t.Fatal("expected ErrArtifactLibIDMissing, got nil")
+	}
+	if !errors.Is(err, db.ErrArtifactLibIDMissing) {
+		t.Errorf("expected ErrArtifactLibIDMissing, got %v", err)
+	}
+}
+
+func TestConsolidate_EmptyDirIsNoop(t *testing.T) {
+	mainPath := filepath.Join(t.TempDir(), "main.db")
+	main, err := db.Open(mainPath, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("Open main: %v", err)
+	}
+	defer main.Close()
+
+	emptyDir := t.TempDir()
+	result, err := db.Consolidate(main, emptyDir)
+	if err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	if result.Artifacts != 0 || result.DocsMerged != 0 || result.LibsMerged != 0 {
+		t.Errorf("got %+v, want zero result", result)
+	}
+
+	var docCount, libCount int
+	if err := main.QueryRow(`SELECT count(*) FROM docs`).Scan(&docCount); err != nil {
+		t.Fatalf("count docs: %v", err)
+	}
+	if err := main.QueryRow(`SELECT count(*) FROM libs`).Scan(&libCount); err != nil {
+		t.Fatalf("count libs: %v", err)
+	}
+	if docCount != 0 || libCount != 0 {
+		t.Errorf("empty consolidate left rows behind: docs=%d libs=%d", docCount, libCount)
+	}
+}
+
+func TestConsolidate_MergesMultipleArtifacts(t *testing.T) {
+	tmp := t.TempDir()
+	artifactsDir := filepath.Join(tmp, "artifacts")
+
+	// Two artifacts, one doc each, distinct lib_ids. Each artifact
+	// is its own .db file, isolated from the others — exactly what
+	// the per-lib refactor promises.
+	makeArtifact(t, artifactsDir, "/a/one", []db.Doc{
+		{LibID: "/a/one", Title: "alpha", Content: "doc a"},
+	})
+	makeArtifact(t, artifactsDir, "/b/two", []db.Doc{
+		{LibID: "/b/two", Title: "beta", Content: "doc b"},
+	})
+
+	mainPath := filepath.Join(tmp, "main.db")
+	main, err := db.Open(mainPath, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("Open main: %v", err)
+	}
+	defer main.Close()
+
+	result, err := db.Consolidate(main, artifactsDir)
+	if err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	if result.Artifacts != 2 || result.DocsMerged != 2 || result.LibsMerged != 2 {
+		t.Errorf("got %+v, want {2,2,2}", result)
+	}
+
+	libIDs := readLibIDs(t, main)
+	want := []string{"/a/one", "/b/two"}
+	if len(libIDs) != len(want) {
+		t.Fatalf("got libs %v, want %v", libIDs, want)
+	}
+	for i := range want {
+		if libIDs[i] != want[i] {
+			t.Errorf("position %d: got %q, want %q", i, libIDs[i], want[i])
+		}
+	}
+}
+
+func TestConsolidate_ReplacesExistingLibInMain(t *testing.T) {
+	tmp := t.TempDir()
+	artifactsDir := filepath.Join(tmp, "artifacts")
+
+	// First scrape: artifact with two docs.
+	v1Path := makeArtifact(t, artifactsDir, "/x/y", []db.Doc{
+		{LibID: "/x/y", Title: "v1 first", Content: "older content"},
+		{LibID: "/x/y", Title: "v1 second", Content: "older content"},
+	})
+
+	mainPath := filepath.Join(tmp, "main.db")
+	main, err := db.Open(mainPath, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("Open main: %v", err)
+	}
+	defer main.Close()
+
+	if _, err := db.Consolidate(main, artifactsDir); err != nil {
+		t.Fatalf("first Consolidate: %v", err)
+	}
+
+	// Second scrape: rebuild the artifact with a single fresh doc.
+	// This is exactly what `deadzone scrape -lib /x/y` does — the
+	// scraper deletes the file and writes a new one.
+	if err := os.Remove(v1Path); err != nil {
+		t.Fatalf("remove v1 artifact: %v", err)
+	}
+	makeArtifact(t, artifactsDir, "/x/y", []db.Doc{
+		{LibID: "/x/y", Title: "v2 only", Content: "newer content"},
+	})
+
+	if _, err := db.Consolidate(main, artifactsDir); err != nil {
+		t.Fatalf("second Consolidate: %v", err)
+	}
+
+	var docCount int
+	if err := main.QueryRow(`SELECT count(*) FROM docs WHERE lib_id = ?`, "/x/y").Scan(&docCount); err != nil {
+		t.Fatalf("count docs: %v", err)
+	}
+	if docCount != 1 {
+		t.Errorf("after replace: doc count = %d, want 1 (DELETE WHERE lib_id failed?)", docCount)
+	}
+
+	var title string
+	if err := main.QueryRow(`SELECT title FROM docs WHERE lib_id = ?`, "/x/y").Scan(&title); err != nil {
+		t.Fatalf("read title: %v", err)
+	}
+	if title != "v2 only" {
+		t.Errorf("title = %q, want %q", title, "v2 only")
+	}
+}
+
+func TestConsolidate_EmbedderMismatchLeavesMainUnchanged(t *testing.T) {
+	tmp := t.TempDir()
+	artifactsDir := filepath.Join(tmp, "artifacts")
+
+	// One healthy artifact + one tampered to look like it was built
+	// with a different embedder. The healthy one is alphabetically
+	// later so it would otherwise be merged second; if the merge
+	// loop were not transactional, the first iteration would commit
+	// before the second one detected the mismatch.
+	makeArtifact(t, artifactsDir, "/aaa/healthy", []db.Doc{
+		{LibID: "/aaa/healthy", Title: "ok", Content: "fine"},
+	})
+	tampered := makeArtifact(t, artifactsDir, "/zzz/bad", []db.Doc{
+		{LibID: "/zzz/bad", Title: "bad", Content: "doomed"},
+	})
+	// Sneak through the driver to corrupt only the embedder_kind
+	// row — same trick TestDB_RejectsPreLibsSchema uses to forge a
+	// pre-libs database without rebuilding hugot from scratch.
+	tamperEmbedderKind(t, tampered, "fake-embedder")
+
+	// Seed main with one row so we can prove the rollback returned
+	// it to its pre-call state instead of merging the healthy
+	// artifact and aborting halfway.
+	mainPath := filepath.Join(tmp, "main.db")
+	main, err := db.Open(mainPath, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("Open main: %v", err)
+	}
+	defer main.Close()
+	seed := db.Doc{LibID: "/seed/lib", Title: "seed", Content: "seed content"}
+	if err := db.Insert(main, seed, embedText(t, testEmbedder, seed)); err != nil {
+		t.Fatalf("Insert seed: %v", err)
+	}
+	if err := db.UpsertLibIfNew(main, "/seed/lib", testEmbedder); err != nil {
+		t.Fatalf("UpsertLibIfNew seed: %v", err)
+	}
+
+	_, err = db.Consolidate(main, artifactsDir)
+	if err == nil {
+		t.Fatal("expected ErrEmbedderMismatch, got nil")
+	}
+	if !errors.Is(err, db.ErrEmbedderMismatch) {
+		t.Errorf("expected ErrEmbedderMismatch, got %v", err)
+	}
+
+	// Main must look exactly like it did pre-Consolidate: just the
+	// seed row, neither artifact merged in.
+	var docCount, libCount int
+	if err := main.QueryRow(`SELECT count(*) FROM docs`).Scan(&docCount); err != nil {
+		t.Fatalf("count docs: %v", err)
+	}
+	if err := main.QueryRow(`SELECT count(*) FROM libs`).Scan(&libCount); err != nil {
+		t.Fatalf("count libs: %v", err)
+	}
+	if docCount != 1 {
+		t.Errorf("docs = %d, want 1 (validation pass should run before any write)", docCount)
+	}
+	if libCount != 1 {
+		t.Errorf("libs = %d, want 1", libCount)
+	}
+}
+
+func TestConsolidate_SchemaMismatchLeavesMainUnchanged(t *testing.T) {
+	tmp := t.TempDir()
+	artifactsDir := filepath.Join(tmp, "artifacts")
+
+	// Build a real artifact then drop the schema_version row to
+	// fake a pre-libs (v0) artifact. Open() reads the missing key
+	// as 0, which never matches CurrentSchemaVersion.
+	path := makeArtifact(t, artifactsDir, "/old/lib", []db.Doc{
+		{LibID: "/old/lib", Title: "x", Content: "x"},
+	})
+	dropSchemaVersion(t, path)
+
+	mainPath := filepath.Join(tmp, "main.db")
+	main, err := db.Open(mainPath, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("Open main: %v", err)
+	}
+	defer main.Close()
+
+	_, err = db.Consolidate(main, artifactsDir)
+	if err == nil {
+		t.Fatal("expected ErrSchemaMismatch, got nil")
+	}
+	if !errors.Is(err, db.ErrSchemaMismatch) {
+		t.Errorf("expected ErrSchemaMismatch, got %v", err)
+	}
+
+	var docCount int
+	if err := main.QueryRow(`SELECT count(*) FROM docs`).Scan(&docCount); err != nil {
+		t.Fatalf("count docs: %v", err)
+	}
+	if docCount != 0 {
+		t.Errorf("docs = %d, want 0 (main should be untouched)", docCount)
+	}
+}
+
+// readLibIDs lists every lib_id in main's libs table in deterministic
+// order. Used by the multi-artifact merge test to assert "every
+// artifact's lib_id is now present in main".
+func readLibIDs(t *testing.T, d *db.DB) []string {
+	t.Helper()
+	rows, err := d.Query(`SELECT lib_id FROM libs`)
+	if err != nil {
+		t.Fatalf("select lib_ids: %v", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var libID string
+		if err := rows.Scan(&libID); err != nil {
+			t.Fatalf("scan lib_id: %v", err)
+		}
+		out = append(out, libID)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate lib_ids: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// tamperEmbedderKind rewrites the embedder_kind row in the meta table
+// to simulate an artifact built with a different embedder. The artifact
+// must already exist on disk and be closed.
+func tamperEmbedderKind(t *testing.T, path, fakeKind string) {
+	t.Helper()
+	raw, err := sql.Open("turso", path)
+	if err != nil {
+		t.Fatalf("raw open %s: %v", path, err)
+	}
+	raw.SetMaxOpenConns(1)
+	defer raw.Close()
+	if _, err := raw.Exec(`UPDATE meta SET value = ? WHERE key = ?`, fakeKind, "embedder_kind"); err != nil {
+		t.Fatalf("tamper embedder_kind: %v", err)
+	}
+}
+
+// dropSchemaVersion deletes the schema_version row from an artifact's
+// meta table so it looks like a pre-libs (v0) database — Open will
+// fail to read schema version and return ErrSchemaMismatch.
+func dropSchemaVersion(t *testing.T, path string) {
+	t.Helper()
+	raw, err := sql.Open("turso", path)
+	if err != nil {
+		t.Fatalf("raw open %s: %v", path, err)
+	}
+	raw.SetMaxOpenConns(1)
+	defer raw.Close()
+	if _, err := raw.Exec(`DELETE FROM meta WHERE key = ?`, "schema_version"); err != nil {
+		t.Fatalf("delete schema_version: %v", err)
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -15,6 +15,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -35,6 +36,20 @@ var ErrEmbedderMismatch = errors.New("embedder metadata mismatch")
 // re-scrape) until an in-place migration is implemented. Wrap with
 // errors.Is to detect.
 var ErrSchemaMismatch = errors.New("database schema version mismatch")
+
+// ErrArtifactLibIDMissing is returned by OpenArtifact when the caller
+// passes libID == "" (i.e. asks the artifact to identify itself) but
+// the on-disk meta table has no lib_id key. Wrap with errors.Is to
+// detect — the consolidate path treats it as a structural problem with
+// the artifact file itself, not a transient I/O error.
+var ErrArtifactLibIDMissing = errors.New("artifact has no lib_id in meta")
+
+// ErrArtifactLibIDMismatch is returned by OpenArtifact when both the
+// stored and the requested lib_id are non-empty but disagree. Catches
+// the failure mode where an artifact gets renamed on disk so its
+// filename and recorded lib_id no longer match, which would otherwise
+// silently merge rows under the wrong key.
+var ErrArtifactLibIDMismatch = errors.New("artifact lib_id mismatch")
 
 // CurrentSchemaVersion is the on-disk schema version written by this
 // build. Bump whenever the table layout changes in a non-backwards-
@@ -60,9 +75,15 @@ type Meta struct {
 // Insert and SearchByEmbedding can validate vector lengths without
 // re-reading the meta table on every call. *sql.DB is embedded so callers
 // can still use QueryRow, Exec, Close, etc. directly on a *DB.
+//
+// ArtifactLibID is populated only when the database was opened via
+// OpenArtifact. It is the canonical lib_id this artifact carries (read
+// from the meta table at open time). The main consolidated database
+// always leaves it empty — the libs table is the source of truth there.
 type DB struct {
 	*sql.DB
-	Meta Meta
+	Meta          Meta
+	ArtifactLibID string
 }
 
 // Doc represents a documentation snippet stored in the docs table.
@@ -178,6 +199,97 @@ func Open(path string, meta Meta) (*DB, error) {
 	}
 
 	return &DB{DB: raw, Meta: meta}, nil
+}
+
+// OpenArtifact opens (or creates) a per-lib artifact database. An
+// artifact carries a single lib_id recorded in its meta table; the
+// recorded value is the source of truth for which library the
+// artifact's docs and libs rows belong to.
+//
+// libID semantics:
+//
+//   - libID != "" — the caller knows which lib this artifact represents
+//     (e.g. the scraper). On a fresh file the lib_id is written. On an
+//     existing file the stored lib_id must match libID, otherwise
+//     ErrArtifactLibIDMismatch is returned.
+//
+//   - libID == "" — the caller is reading an existing artifact and
+//     wants to discover its lib_id (e.g. consolidate). The file must
+//     already exist; if it doesn't, an os.ErrNotExist-wrapped error
+//     is returned without creating a stub. If the file exists but has
+//     no lib_id stored, ErrArtifactLibIDMissing is returned.
+//
+// Embedder meta and schema version validation are inherited from Open
+// — an artifact built with a different embedder than the caller's
+// surfaces as ErrEmbedderMismatch, exactly like the main DB.
+func OpenArtifact(path string, meta Meta, libID string) (*DB, error) {
+	// Refuse to fabricate a stub file when the caller is in
+	// "read existing artifact" mode. Lets the consolidate path
+	// distinguish "no such file" from "file exists but is malformed"
+	// without inspecting the resulting *DB.
+	if libID == "" {
+		if _, err := os.Stat(path); err != nil {
+			return nil, fmt.Errorf("open artifact %s: %w", path, err)
+		}
+	}
+
+	d, err := Open(path, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	stored, hasStored, err := readArtifactLibID(d.DB)
+	if err != nil {
+		d.Close()
+		return nil, fmt.Errorf("open artifact %s: read lib_id: %w", path, err)
+	}
+
+	switch {
+	case libID != "" && hasStored:
+		if stored != libID {
+			d.Close()
+			return nil, fmt.Errorf("%w: stored=%q requested=%q (file=%s)",
+				ErrArtifactLibIDMismatch, stored, libID, path)
+		}
+	case libID != "" && !hasStored:
+		if err := writeArtifactLibID(d.DB, libID); err != nil {
+			d.Close()
+			return nil, fmt.Errorf("open artifact %s: write lib_id: %w", path, err)
+		}
+		stored = libID
+	case libID == "" && !hasStored:
+		d.Close()
+		return nil, fmt.Errorf("%w: %s", ErrArtifactLibIDMissing, path)
+	}
+
+	d.ArtifactLibID = stored
+	return d, nil
+}
+
+// readArtifactLibID returns the lib_id meta value if present. The
+// boolean is false (with no error) when the row is simply absent — the
+// "main DB, no artifact identity" case — so callers can distinguish
+// "missing" from "I/O failure" without an errors.Is dance.
+func readArtifactLibID(raw *sql.DB) (string, bool, error) {
+	var v string
+	err := raw.QueryRow(`SELECT value FROM meta WHERE key = ?`, metaKeyLibID).Scan(&v)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return v, true, nil
+}
+
+// writeArtifactLibID inserts the lib_id meta row. Caller is responsible
+// for guaranteeing the row does not already exist (OpenArtifact only
+// calls this on the !hasStored branch); a UNIQUE-constraint failure
+// here means the readArtifactLibID call above raced with a writer,
+// which the single-connection scraper rules out by construction.
+func writeArtifactLibID(raw *sql.DB, libID string) error {
+	_, err := raw.Exec(`INSERT INTO meta(key, value) VALUES (?, ?)`, metaKeyLibID, libID)
+	return err
 }
 
 // Insert stores a Doc along with its precomputed embedding. The embedding
@@ -424,6 +536,11 @@ const (
 	metaKeyEmbeddingDim  = "embedding_dim"
 	metaKeyModelVersion  = "model_version"
 	metaKeySchemaVersion = "schema_version"
+	// metaKeyLibID is written by OpenArtifact and absent from the main
+	// consolidated database. The reader (readMeta) intentionally
+	// ignores any meta keys it does not recognize, so adding this key
+	// is backwards-compatible with the existing schema version.
+	metaKeyLibID = "lib_id"
 )
 
 func validateMeta(m Meta) error {

--- a/justfile
+++ b/justfile
@@ -37,15 +37,20 @@ vet:
 tidy:
     {{go}} mod tidy
 
-# Run the scraper, indexing into the given DB file
-scrape db="deadzone.db":
-    {{go}} run ./cmd/scraper -db {{db}}
+# Run the scraper, writing one artifact per lib to ./artifacts/ (pass lib=/org/project to refresh only that entry)
+scrape lib="":
+    {{go}} run ./cmd/scraper -artifacts ./artifacts {{ if lib != "" { "-lib " + lib } else { "" } }}
 
-# Run the MCP server against the given DB file
+# Merge per-lib artifacts in ./artifacts/ into the main deadzone DB
+consolidate db="deadzone.db":
+    {{go}} run ./cmd/consolidate -db {{db}} -artifacts ./artifacts
+
+# Run the MCP server against the given DB file (must already be consolidated)
 serve db="deadzone.db":
     {{go}} run ./cmd/server -db {{db}}
 
-# Remove built binaries and the local DB files
+# Remove built binaries, artifacts, and the local DB files
 clean:
-    rm -f deadzone deadzone-server
+    rm -f deadzone deadzone-server deadzone-consolidate
     rm -f deadzone.db deadzone.db-wal deadzone.db-shm
+    rm -rf artifacts


### PR DESCRIPTION
## Summary

- **Per-lib artifact databases**: The scraper now writes one `.db` file per library into `./artifacts/` instead of inserting directly into the main database. Each artifact carries its own `lib_id` in the meta table and is self-contained.
- **New `cmd/consolidate` command**: Merges all per-lib artifact `.db` files from `./artifacts/` into the main `deadzone.db` in a single atomic transaction. Idempotent — replaces existing rows per `lib_id` with a full delete-then-insert within one tx.
- **`OpenArtifact` in `internal/db`**: New entry point for opening per-lib databases with `lib_id` identity tracking, validation, and mismatch detection (`ErrArtifactLibIDMissing`, `ErrArtifactLibIDMismatch`).
- **Schema version bump to v2**: Adds `schema_version` to the meta table and cross-checks on open, surfacing `ErrSchemaMismatch` for incompatible databases.
- **Justfile recipes**: Added `scrape`, `consolidate`, `serve`, and `clean` recipes for the new two-stage pipeline.

## Motivation

Decouples per-lib scraping from the shared database so individual libraries can be re-scraped independently (`just scrape lib=/org/project`) without touching other libs' data. The consolidate step is explicit and atomic — partial failures leave the main DB untouched.

## Test plan

- `just test` — new `consolidate_test.go` covers validation pass (embedder mismatch, schema mismatch, missing lib_id), merge pass (single/multi artifact, idempotent re-merge), and rollback on mid-merge failure
- `just build` — all three commands compile
- `just scrape lib=/some/lib && just consolidate` — end-to-end artifact creation and merge

<!-- emdash-issue-footer:start -->
Fixes #28
<!-- emdash-issue-footer:end -->