### PR TITLE
feat: add scrape-via-agent source kind for LLM-backed doc extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ libraries:
 | Field | Required | Purpose |
 |---|---|---|
 | `lib_id` | yes | canonical `/org/project` identifier (matches `db.docs.lib_id`) |
-| `kind` | yes | source kind discriminator — only `github-md` is valid today |
+| `kind` | yes | source kind discriminator — `github-md` for raw markdown, `scrape-via-agent` for HTML/text via an LLM (see [Scraping non-trivial doc sources](#scraping-non-trivial-doc-sources-scrape-via-agent)) |
 | `urls` | yes | list of doc URLs (with optional `{version}` placeholder) |
 | `versions` | no | list of version tags; expands `{version}` in `urls` and produces one effective `lib_id` per version |
 
@@ -151,6 +151,51 @@ mise exec -- go run ./cmd/scraper -artifacts ./artifacts -lib /facebook/react/v1
 ```
 
 `-lib` matches at two levels: a base `lib_id` selects every expanded version of that base; a fully versioned `lib_id` selects exactly one expanded entry. Omitting `-lib` scrapes everything in the registry. Each entry produces (or replaces) one `artifacts/<lib_id>.db` file — the leading `/` is stripped and the remaining `/` characters become `_`, so `/facebook/react/v18` lands at `artifacts/facebook_react_v18.db`.
+
+### Scraping non-trivial doc sources (`scrape-via-agent`)
+
+The `github-md` kind only works on libraries that publish raw markdown on GitHub. For everything else — Terraform providers (HTML), React (`react.dev`), mkdocs/docusaurus/vitepress sites, GitBook, ReadTheDocs — Deadzone supports a second source kind, `scrape-via-agent`, that delegates **content → clean markdown** extraction to any OpenAI-compatible chat completions endpoint.
+
+Deadzone does **not** host an LLM. You bring your own runtime — [Ollama](https://ollama.ai), [llama.cpp server](https://github.com/ggerganov/llama.cpp/tree/master/examples/server), [vLLM](https://github.com/vllm-project/vllm), [LocalAI](https://localai.io), [LM Studio](https://lmstudio.ai), [Groq](https://groq.com), OpenAI itself, anything that speaks `POST /v1/chat/completions` — and point Deadzone at the endpoint via three environment variables:
+
+```bash
+# Required
+export DEADZONE_AGENT_ENDPOINT=http://localhost:11434/v1
+export DEADZONE_AGENT_ENDPOINT_MODEL=qwen2.5:7b
+
+# Optional — only set if your endpoint requires auth
+export DEADZONE_AGENT_ENDPOINT_API_KEY=sk-...
+```
+
+Then add an entry with `kind: scrape-via-agent` to `libraries_sources.yaml`:
+
+```yaml
+libraries:
+  - lib_id: /hashicorp/terraform-provider-aws
+    kind: scrape-via-agent
+    urls:
+      - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
+      - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role
+      - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function
+```
+
+The downstream pipeline (`ParseMarkdown` → chunk → embed → store) is **identical** for both kinds. The only thing that changes is where the markdown comes from: `github-md` reads it directly from a `raw.githubusercontent.com` URL, `scrape-via-agent` fetches the page, hands it to the LLM, and indexes whatever clean markdown comes back.
+
+**Startup contract.** If `libraries_sources.yaml` contains any `scrape-via-agent` source, the scraper resolves the agent config from env, pings the endpoint with a trivial completion, and aborts the run with a clear error if anything is missing or unreachable. There is no silent fallback — a misconfigured endpoint fails the run before any URL is processed.
+
+**Hallucination protection.** Every fenced code block in the LLM's output is verified to appear verbatim in the source content. If the model invents a code example, the doc is dropped (`scraper.agent_verification_failed` in the log) and the rest of the URLs in that source still get processed. Prose hallucination is still possible — this catches the most dangerous failure mode but is not a complete defense.
+
+**Input budget.** Inputs longer than ~48 KiB are truncated with a single `agent.input_truncated` warning. Smart chunking is a planned follow-up.
+
+**Supported content types in v1.**
+
+| Content type | Status |
+|---|---|
+| `text/html`, `application/xhtml+xml` | supported |
+| `text/markdown`, `text/x-markdown` | supported |
+| `text/plain` | supported |
+| `application/pdf` | reserved — clear error, planned follow-up |
+| anything else | clear `unsupported content type` error |
 
 > **First-run model download.** The first `just scrape` or `just serve` invocation downloads the MiniLM-L6-v2 ONNX weights (~90 MB) into the platform user-cache directory under `deadzone/models/`:
 >
@@ -205,7 +250,7 @@ More background in [`docs/research/context7-analysis.md`](docs/research/context7
 
 All three binaries emit structured JSON logs to **stderr** using `log/slog`. Stdout is reserved for the MCP JSON-RPC channel on `cmd/server`, so anything written there that isn't a valid JSON-RPC message disconnects the client — `cmd/scraper` and `cmd/consolidate` follow the same convention for consistency.
 
-- **Scraper.** `just scrape` writes logs straight to your terminal. Look for `scraper.start`, a `scraper.lib_start` per resolved library (with the `artifact_path` it's writing to), one `scraper.fetch` per URL (with `bytes`, `duration_ms`, `docs_extracted`), `scraper.indexed` summaries, a `scraper.lib_done` per library, and a final `scraper.done`. The "silently stalls on one URL" failure mode shows up as a missing `scraper.fetch` event for that URL. Errors land as `scraper.fetch_failed` / `scraper.insert_failed` with the URL and wrapped error.
+- **Scraper.** `just scrape` writes logs straight to your terminal. Look for `scraper.start`, a `scraper.lib_start` per resolved library (with the `artifact_path` it's writing to), one `scraper.fetch` per URL (with `bytes`, `duration_ms`, `docs_extracted`, and `kind`), `scraper.indexed` summaries, a `scraper.lib_done` per library, and a final `scraper.done`. The "silently stalls on one URL" failure mode shows up as a missing `scraper.fetch` event for that URL. Errors land as `scraper.fetch_failed` / `scraper.insert_failed` with the URL and wrapped error. When any source uses `kind: scrape-via-agent`, expect `scraper.agent_configured` and `scraper.agent_ping_ok` once at startup; per-doc hallucination drops show up as `scraper.agent_verification_failed`, and oversized inputs as `agent.input_truncated`.
 - **Consolidate.** `just consolidate` emits a `consolidate.start` and a `consolidate.done` with the `artifacts` count, `docs_merged`, `libs_merged`, and `duration_ms`. A failure aborts before any write reaches the main DB; the wrapped error names the offending artifact.
 - **Server.** `cmd/server`'s stderr is captured by the MCP client. In Claude Code that's the `~/Library/Logs/Claude/mcp-server-deadzone.log` file (macOS) or your client's equivalent — check the MCP client docs. On startup the server emits a `server.start` line with the embedder meta and the indexed `doc_count`; each `search_docs` call emits one `search_docs` line with `lib_id`, `tokens`, `results`, and `latency_ms`. If the configured `-db` is missing the server refuses to start and prints a one-liner pointing at `deadzone-consolidate`.
 - **Verbose mode.** All three binaries take `-verbose`. On the server it adds the raw `query` field to per-call logs (off by default because queries may contain user data). On the scraper it adds per-doc `scraper.doc_indexed` Debug lines, useful when debugging the parser on a new library.

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -52,18 +52,6 @@ func run() error {
 		return fmt.Errorf("no libraries to scrape in %s", *configPath)
 	}
 
-	// scrape-via-agent sources need an OpenAI-compatible endpoint
-	// resolved from env. We construct + ping the agent before any URL
-	// is processed so a misconfigured endpoint surfaces as a single
-	// startup error rather than a per-URL cascade midway through.
-	// Sources without any agent-kind entry skip this entirely so the
-	// scraper still works on a clean checkout with no env vars set.
-	ctx := context.Background()
-	agent, err := setupAgent(ctx, sources)
-	if err != nil {
-		return err
-	}
-
 	// One artifacts/ dir per scraper run; created on demand so the
 	// first invocation on a fresh checkout doesn't require an extra
 	// `mkdir -p` step in the README.
@@ -80,6 +68,22 @@ func run() error {
 			slog.Warn("embedder close", "err", err.Error())
 		}
 	}()
+
+	// scrape-via-agent sources need an OpenAI-compatible endpoint
+	// resolved from env. We construct + ping the agent before any URL
+	// is processed so a misconfigured endpoint surfaces as a single
+	// startup error rather than a per-URL cascade midway through.
+	//
+	// Ordered AFTER embed.New so a missing model file or other
+	// embedder failure short-circuits before we pay the agent ping
+	// latency. Sources without any agent-kind entry skip this entirely
+	// so the scraper still works on a clean checkout with no env vars
+	// set.
+	ctx := context.Background()
+	agent, err := setupAgent(ctx, sources)
+	if err != nil {
+		return err
+	}
 
 	meta := db.Meta{
 		EmbedderKind: e.Kind(),

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -51,6 +52,18 @@ func run() error {
 		return fmt.Errorf("no libraries to scrape in %s", *configPath)
 	}
 
+	// scrape-via-agent sources need an OpenAI-compatible endpoint
+	// resolved from env. We construct + ping the agent before any URL
+	// is processed so a misconfigured endpoint surfaces as a single
+	// startup error rather than a per-URL cascade midway through.
+	// Sources without any agent-kind entry skip this entirely so the
+	// scraper still works on a clean checkout with no env vars set.
+	ctx := context.Background()
+	agent, err := setupAgent(ctx, sources)
+	if err != nil {
+		return err
+	}
+
 	// One artifacts/ dir per scraper run; created on demand so the
 	// first invocation on a fresh checkout doesn't require an extra
 	// `mkdir -p` step in the README.
@@ -84,12 +97,11 @@ func run() error {
 		"model_version", e.ModelVersion(),
 	)
 
-	ctx := context.Background()
 	runStart := time.Now()
 	var docsTotal int
 
 	for _, src := range sources {
-		libDocs, err := scrapeLibToArtifact(ctx, http.DefaultClient, e, meta, *artifactsDir, src)
+		libDocs, err := scrapeLibToArtifact(ctx, http.DefaultClient, agent, e, meta, *artifactsDir, src)
 		if err != nil {
 			return err
 		}
@@ -122,6 +134,7 @@ func run() error {
 func scrapeLibToArtifact(
 	ctx context.Context,
 	client *http.Client,
+	agent *scraper.Agent,
 	e embed.Embedder,
 	meta db.Meta,
 	artifactsDir string,
@@ -173,14 +186,42 @@ func scrapeLibToArtifact(
 	for _, u := range src.URLs {
 		// Per-URL fetch — split out from the embed/insert loop so the
 		// "silently stalls on one URL" failure mode shows up as a
-		// missing scraper.fetch event for that URL.
+		// missing scraper.fetch event for that URL. The kind dispatch
+		// is intentionally trivial: github-md is the fast HTTP→parse
+		// path, scrape-via-agent runs the LLM extractor.
 		fetchStart := time.Now()
-		res, err := scraper.FetchOne(ctx, client, src.LibID, u)
+		var (
+			res     scraper.FetchOneResult
+			err     error
+			fetcher = src.Kind
+		)
+		switch src.Kind {
+		case scraper.KindGithubMD:
+			res, err = scraper.FetchOne(ctx, client, src.LibID, u)
+		case scraper.KindScrapeViaAgent:
+			res, err = scraper.FetchOneViaAgent(ctx, client, agent, src.LibID, u)
+		default:
+			return docsTotal, fmt.Errorf("unsupported kind %q for lib %q", src.Kind, src.LibID)
+		}
 		fetchDur := time.Since(fetchStart)
 		if err != nil {
+			// Verification failure is a per-URL hallucination drop:
+			// log loudly, skip the URL, keep processing the rest of
+			// the source. Every other fetch error is fatal for the
+			// lib (the alternative is half-indexed artifacts).
+			if errors.Is(err, scraper.ErrAgentVerificationFailed) {
+				slog.Error("scraper.agent_verification_failed",
+					"lib_id", src.LibID,
+					"url", u,
+					"duration_ms", fetchDur.Milliseconds(),
+					"err", err.Error(),
+				)
+				continue
+			}
 			slog.Error("scraper.fetch_failed",
 				"lib_id", src.LibID,
 				"url", u,
+				"kind", fetcher,
 				"duration_ms", fetchDur.Milliseconds(),
 				"err", err.Error(),
 			)
@@ -189,6 +230,7 @@ func scrapeLibToArtifact(
 		slog.Info("scraper.fetch",
 			"lib_id", src.LibID,
 			"url", u,
+			"kind", fetcher,
 			"bytes", res.Bytes,
 			"duration_ms", fetchDur.Milliseconds(),
 			"docs_extracted", len(res.Docs),
@@ -288,4 +330,48 @@ func scrapeLibToArtifact(
 func artifactFilename(libID string) string {
 	trimmed := strings.TrimPrefix(libID, "/")
 	return strings.ReplaceAll(trimmed, "/", "_") + ".db"
+}
+
+// setupAgent decides whether the scrape-via-agent path is needed for
+// this run and, if so, builds + health-checks the Agent before any URL
+// is processed.
+//
+// The contract from #27 is "fail fast at startup, no silent fallback":
+//   - if no source uses scrape-via-agent, return (nil, nil) so a clean
+//     checkout with no env vars set still works
+//   - if any source does, env must be configured AND Ping must succeed
+//     before the function returns
+//
+// The agent value is shared across every scrape-via-agent source for
+// the run; the http.Client inside it carries its own per-call timeout.
+func setupAgent(ctx context.Context, sources []scraper.ResolvedSource) (*scraper.Agent, error) {
+	needs := false
+	for _, s := range sources {
+		if s.Kind == scraper.KindScrapeViaAgent {
+			needs = true
+			break
+		}
+	}
+	if !needs {
+		return nil, nil
+	}
+
+	agent, err := scraper.NewAgentFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("scrape-via-agent source present but agent not configured: %w", err)
+	}
+
+	slog.Info("scraper.agent_configured",
+		"endpoint", agent.Endpoint(),
+		"model", agent.Model(),
+	)
+
+	if err := agent.Ping(ctx); err != nil {
+		return nil, fmt.Errorf("agent health check failed for endpoint %s: %w", agent.Endpoint(), err)
+	}
+	slog.Info("scraper.agent_ping_ok",
+		"endpoint", agent.Endpoint(),
+		"model", agent.Model(),
+	)
+	return agent, nil
 }

--- a/internal/scraper/agent.go
+++ b/internal/scraper/agent.go
@@ -1,0 +1,404 @@
+package scraper
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// Environment variables consumed by NewAgentFromEnv. Documented in the
+// README "Scraping non-trivial doc sources" section. The agent endpoint
+// is per-user infrastructure (Ollama on localhost, a shared corporate
+// vLLM, OpenAI proper, ...), not project metadata, which is why these
+// live in env rather than libraries_sources.yaml.
+const (
+	EnvAgentEndpoint = "DEADZONE_AGENT_ENDPOINT"
+	EnvAgentModel    = "DEADZONE_AGENT_ENDPOINT_MODEL"
+	EnvAgentAPIKey   = "DEADZONE_AGENT_ENDPOINT_API_KEY"
+)
+
+// agentInputMaxChars is the conservative cap applied to LLM input on
+// the scrape-via-agent path. Inputs longer than this are truncated to
+// this exact length and a warning is logged once per affected URL.
+//
+// 48 KiB ≈ 12k tokens for typical English-with-markup, which fits an
+// 8k–16k context window with comfortable headroom for the system
+// prompt and the model's own response. Modern local models (qwen2.5,
+// llama3.1) easily exceed this in their default config; the cap exists
+// for the small-context models that are common on consumer hardware.
+//
+// v1 deliberately ships a single constant rather than a tunable. The
+// follow-up listed in #27 is "smart chunking" — section-aware splitting
+// and multi-call extraction — which is the right place to revisit this.
+const agentInputMaxChars = 48 * 1024
+
+// agentDefaultTimeout caps a single LLM call. Local 7B models typically
+// finish HTML extraction in well under a minute; the timeout is sized
+// generously so the scraper doesn't abort a slow but progressing call,
+// and small enough that a stuck endpoint surfaces in the operator log
+// rather than hanging the run.
+const agentDefaultTimeout = 5 * time.Minute
+
+// systemPrompt is the extraction instruction shared by Ping and Extract.
+// Locked at temperature 0, single-shot, no streaming. The prompt itself
+// is content-type agnostic — Extract prepends a one-line hint so
+// smaller models know whether they're looking at HTML, markdown, or
+// plain text without changing the rules.
+const systemPrompt = `You are a documentation extractor.
+Given a technical documentation page, return clean Markdown.
+
+Rules:
+- Preserve every code block VERBATIM — do not paraphrase, rewrite, or
+  format any code. Keep original indentation and whitespace.
+- Preserve headings, lists, tables, and their hierarchy.
+- Remove navigation, sidebars, footers, ads, breadcrumbs, table-of-contents
+  widgets, and any site chrome that is not documentation content.
+- Do NOT invent content. Do NOT add explanations. Do NOT summarize.
+- If a section has no meaningful documentation content, omit it.
+- Output ONLY the extracted Markdown. No preamble, no commentary.`
+
+// ErrAgentNotConfigured is returned by NewAgentFromEnv when the
+// required env vars are missing. Wrap with errors.Is to detect — the
+// scraper main loop uses it to print a single actionable startup error
+// instead of a generic env-var dump.
+var ErrAgentNotConfigured = errors.New("agent endpoint not configured (set " + EnvAgentEndpoint + " and " + EnvAgentModel + ")")
+
+// ErrAgentVerificationFailed is returned by FetchOneViaAgent when the
+// LLM's output contains a fenced code block that does not appear in
+// the source content (likely a hallucination). The doc is dropped and
+// the failure is logged at scraper.agent_verification_failed.
+var ErrAgentVerificationFailed = errors.New("agent output failed code-block verification")
+
+// Agent drives LLM-backed content extraction via an OpenAI-compatible
+// /v1/chat/completions endpoint. Deadzone does not host an LLM — the
+// user brings their own runtime (Ollama, vLLM, LocalAI, OpenAI, ...).
+// All Agent does is build the request, ship it, and parse the
+// response.
+//
+// Concurrency: Agent is safe for concurrent use as long as the
+// embedded http.Client is. The default constructor wires a fresh
+// http.Client per Agent, so you get that for free.
+type Agent struct {
+	// endpoint is the base URL of the OpenAI-compatible API, e.g.
+	// "http://localhost:11434/v1". Trailing slashes are stripped at
+	// construction time so requestURL can append "/chat/completions"
+	// unconditionally.
+	endpoint string
+
+	// model is the model name to pass in the request body, e.g.
+	// "qwen2.5:7b" for Ollama or "gpt-4o-mini" for OpenAI proper.
+	model string
+
+	// apiKey is the optional bearer token. Empty means no
+	// Authorization header is sent — required for unauthenticated
+	// localhost runtimes like Ollama.
+	apiKey string
+
+	client *http.Client
+}
+
+// NewAgentFromEnv constructs an Agent from the three DEADZONE_AGENT_*
+// env vars. Endpoint and model are required; the API key is optional
+// (Ollama and most local runtimes don't need one). Returns
+// ErrAgentNotConfigured if either required var is unset, so callers
+// can distinguish "user forgot to set env" from "endpoint is bad".
+func NewAgentFromEnv() (*Agent, error) {
+	endpoint := strings.TrimSpace(os.Getenv(EnvAgentEndpoint))
+	model := strings.TrimSpace(os.Getenv(EnvAgentModel))
+	if endpoint == "" || model == "" {
+		return nil, ErrAgentNotConfigured
+	}
+	apiKey := strings.TrimSpace(os.Getenv(EnvAgentAPIKey))
+	return NewAgent(endpoint, model, apiKey, nil), nil
+}
+
+// NewAgent is the explicit constructor used by tests (which inject an
+// httptest.Server URL) and by NewAgentFromEnv. Passing client == nil
+// gives you a fresh http.Client with agentDefaultTimeout.
+func NewAgent(endpoint, model, apiKey string, client *http.Client) *Agent {
+	if client == nil {
+		client = &http.Client{Timeout: agentDefaultTimeout}
+	}
+	return &Agent{
+		endpoint: strings.TrimRight(endpoint, "/"),
+		model:    model,
+		apiKey:   apiKey,
+		client:   client,
+	}
+}
+
+// Endpoint returns the base URL the agent talks to. Exposed for the
+// startup log line so an operator can see which runtime they wired up.
+func (a *Agent) Endpoint() string { return a.endpoint }
+
+// Model returns the configured model name (for the startup log line).
+func (a *Agent) Model() string { return a.model }
+
+// chatRequest is the OpenAI-compatible /v1/chat/completions request body.
+// Deadzone speaks the smallest possible subset: model, messages, and the
+// determinism / single-shot knobs. No tool calling, no JSON mode, no
+// response_format — the system prompt already says "output only Markdown".
+type chatRequest struct {
+	Model       string        `json:"model"`
+	Messages    []chatMessage `json:"messages"`
+	Temperature float64       `json:"temperature"`
+	Stream      bool          `json:"stream"`
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// chatResponse is the subset of the OpenAI-compatible response we read.
+// We tolerate extra fields (Ollama and vLLM both add their own) by
+// letting json.Unmarshal silently drop them.
+type chatResponse struct {
+	Choices []struct {
+		Message chatMessage `json:"message"`
+	} `json:"choices"`
+}
+
+// Ping sends a trivial chat completion to the configured endpoint to
+// verify it is reachable, the model is loaded, and the API key (if
+// any) is accepted. Called once at scraper startup when at least one
+// source has kind=scrape-via-agent, so the operator finds out about a
+// misconfigured endpoint before any URLs are processed.
+//
+// Ping uses the same code path as Extract — same URL, same auth, same
+// response shape — so a successful Ping implies the actual extraction
+// calls have a working transport.
+func (a *Agent) Ping(ctx context.Context) error {
+	req := chatRequest{
+		Model: a.model,
+		Messages: []chatMessage{
+			{Role: "system", Content: "You are a health check responder."},
+			{Role: "user", Content: "Reply with the single word: ok"},
+		},
+		Temperature: 0,
+		Stream:      false,
+	}
+	if _, err := a.do(ctx, req); err != nil {
+		return fmt.Errorf("agent ping: %w", err)
+	}
+	return nil
+}
+
+// Extract normalizes content into clean Markdown via the LLM.
+//
+// contentType drives a one-line hint prepended to the user message so
+// smaller models know what they're looking at. The system prompt
+// itself is identical regardless of input type — the rules
+// (preserve code verbatim, drop chrome, no commentary) don't depend
+// on whether the source was HTML or PDF text.
+//
+// Inputs longer than agentInputMaxChars are truncated to that exact
+// length and a slog.Warn is emitted via slog.Default(). v1 ships a
+// single constant cap; smart chunking is a follow-up listed in #27.
+func (a *Agent) Extract(ctx context.Context, content, contentType string) (string, error) {
+	if strings.TrimSpace(content) == "" {
+		return "", fmt.Errorf("agent extract: empty content")
+	}
+
+	if len(content) > agentInputMaxChars {
+		slog.Warn("agent.input_truncated",
+			"content_type", contentType,
+			"original_chars", len(content),
+			"truncated_to", agentInputMaxChars,
+		)
+		content = content[:agentInputMaxChars]
+	}
+
+	hint := contentTypeHint(contentType)
+	userMsg := hint + "\n\n" + content
+
+	req := chatRequest{
+		Model: a.model,
+		Messages: []chatMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: userMsg},
+		},
+		Temperature: 0,
+		Stream:      false,
+	}
+
+	resp, err := a.do(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("agent extract: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return "", fmt.Errorf("agent extract: response has no choices")
+	}
+	out := strings.TrimSpace(resp.Choices[0].Message.Content)
+	if out == "" {
+		return "", fmt.Errorf("agent extract: empty response content")
+	}
+	return out, nil
+}
+
+// contentTypeHint produces a one-line nudge prepended to the user
+// message. Locked-in strings so the prompt is fully reproducible from
+// the source.
+func contentTypeHint(contentType string) string {
+	switch normalizeContentType(contentType) {
+	case contentTypeHTML, contentTypeXHTML:
+		return "The input below is raw HTML scraped from a documentation page."
+	case contentTypeMarkdown, contentTypeXMD:
+		return "The input below is Markdown that may be templated, dense, or contain site chrome to remove."
+	case contentTypePlain:
+		return "The input below is plain text extracted from a documentation page."
+	default:
+		// Anything else should have been rejected by preprocess
+		// already, but stay on the safe side with a generic hint
+		// rather than panicking.
+		return "The input below is documentation content."
+	}
+}
+
+// do executes one chat completion request against a.endpoint and
+// returns the parsed response. Centralised so Ping and Extract share
+// the same auth, error wrapping, and response decoding.
+func (a *Agent) do(ctx context.Context, body chatRequest) (*chatResponse, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := a.endpoint + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(buf))
+	if err != nil {
+		return nil, fmt.Errorf("build request %s: %w", url, err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	if a.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+a.apiKey)
+	}
+
+	resp, err := a.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("post %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("read response %s: %w", url, readErr)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Trim noisy bodies but keep enough to debug — most OpenAI-
+		// compatible servers return a JSON error with a useful
+		// "message" field that's well under 512 bytes.
+		snippet := string(respBody)
+		if len(snippet) > 512 {
+			snippet = snippet[:512] + "…"
+		}
+		return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, url, snippet)
+	}
+
+	var parsed chatResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("decode response %s: %w", url, err)
+	}
+	return &parsed, nil
+}
+
+// verifyCodeBlocks returns true iff every fenced code block in md
+// appears as a verbatim substring of source.
+//
+// Catches the most dangerous LLM failure mode: a hallucinated code
+// example that looks plausible but doesn't exist in the source page.
+// Strict by default — whitespace and indentation must match exactly.
+// Documented as a known limitation: prose hallucination is still
+// possible and will be tightened in a follow-up.
+//
+// "Empty md" and "md with no fenced blocks" both return true. Prose-
+// only pages are legitimate output and shouldn't be rejected just for
+// not containing code.
+func verifyCodeBlocks(md, source string) bool {
+	for _, block := range extractFencedBlocks(md) {
+		if !strings.Contains(source, block) {
+			return false
+		}
+	}
+	return true
+}
+
+// extractFencedBlocks pulls the inner text of every fenced code block
+// in md. Recognises both backtick (```) and tilde (~~~) fences with an
+// optional language tag on the opening line. The closing fence must
+// match the opener (a ``` block stays open until the next ```; a ~~~
+// block stays open until the next ~~~).
+//
+// Returned strings are the raw inner content with the original line
+// breaks preserved — no trimming, no language tag — so verifyCodeBlocks
+// can do a literal substring check against the source.
+func extractFencedBlocks(md string) []string {
+	var blocks []string
+	lines := strings.Split(md, "\n")
+
+	var (
+		inFence    bool
+		fenceChar  byte // '`' or '~' so the closer matches the opener
+		current    strings.Builder
+		firstChunk bool
+	)
+
+	for _, line := range lines {
+		stripped := strings.TrimLeft(line, " \t")
+
+		if !inFence {
+			if strings.HasPrefix(stripped, "```") {
+				inFence = true
+				fenceChar = '`'
+				current.Reset()
+				firstChunk = true
+				continue
+			}
+			if strings.HasPrefix(stripped, "~~~") {
+				inFence = true
+				fenceChar = '~'
+				current.Reset()
+				firstChunk = true
+				continue
+			}
+			continue
+		}
+
+		// We're inside a fence. The closer is three of the same fence
+		// character at the start of a (possibly indented) line.
+		closer := strings.Repeat(string(fenceChar), 3)
+		if strings.HasPrefix(stripped, closer) {
+			blocks = append(blocks, current.String())
+			inFence = false
+			current.Reset()
+			continue
+		}
+
+		// Accumulate the inner content. Don't prepend a newline to
+		// the first chunk so a single-line block doesn't end up with
+		// a leading "\n".
+		if !firstChunk {
+			current.WriteByte('\n')
+		}
+		current.WriteString(line)
+		firstChunk = false
+	}
+
+	// Unterminated fence: ignore the partial block. The verifier
+	// silently accepts it — better to miss a flag than reject a whole
+	// otherwise-valid extraction over a stray triple-backtick in
+	// trailing prose. Operators see the malformed output in the
+	// indexed docs and can iterate on the prompt.
+
+	return blocks
+}

--- a/internal/scraper/agent_test.go
+++ b/internal/scraper/agent_test.go
@@ -1,6 +1,7 @@
 package scraper
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -134,8 +135,15 @@ func TestAgentExtract_RequestBodyShape(t *testing.T) {
 	if captured.parsedBody.Model != "test-model" {
 		t.Errorf("body.model = %q, want test-model", captured.parsedBody.Model)
 	}
-	if captured.parsedBody.Temperature != 0 {
-		t.Errorf("body.temperature = %v, want 0", captured.parsedBody.Temperature)
+	// Strict raw-body check: float64's zero value would make a parsed
+	// `Temperature != 0` assertion trivially true even if the field
+	// were dropped from the JSON entirely. Walk the bytes to prove the
+	// field is actually serialized as the literal "temperature":0.
+	if !bytes.Contains(captured.rawBody, []byte(`"temperature":0`)) {
+		t.Errorf("raw body missing literal `\"temperature\":0`, got: %s", captured.rawBody)
+	}
+	if !bytes.Contains(captured.rawBody, []byte(`"stream":false`)) {
+		t.Errorf("raw body missing literal `\"stream\":false`, got: %s", captured.rawBody)
 	}
 	if captured.parsedBody.Stream {
 		t.Error("body.stream = true, want false")

--- a/internal/scraper/agent_test.go
+++ b/internal/scraper/agent_test.go
@@ -1,0 +1,409 @@
+package scraper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeAgentResponse builds a minimal OpenAI-compatible chat completion
+// response wrapping a single choice. Tests use this to script the
+// httptest server's reply.
+func fakeAgentResponse(content string) string {
+	return fmt.Sprintf(`{"choices":[{"message":{"role":"assistant","content":%s}}]}`, mustQuote(content))
+}
+
+func mustQuote(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// startFakeAgent spins up an httptest server that records the parsed
+// request body and replies with replyContent (or a non-200 status when
+// statusCode != 200). Returns the *Agent pre-pointed at the server URL
+// plus a recorded-request pointer the test can inspect after the call.
+func startFakeAgent(t *testing.T, replyContent string, statusCode int) (*Agent, *capturedRequest, *httptest.Server) {
+	t.Helper()
+	captured := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.contentType = r.Header.Get("Content-Type")
+		captured.authorization = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		captured.rawBody = body
+		_ = json.Unmarshal(body, &captured.parsedBody)
+
+		if statusCode != 0 && statusCode != http.StatusOK {
+			w.WriteHeader(statusCode)
+			_, _ = w.Write([]byte(`{"error":{"message":"forced failure"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(replyContent))
+	}))
+	t.Cleanup(srv.Close)
+
+	agent := NewAgent(srv.URL+"/v1", "test-model", "", srv.Client())
+	return agent, captured, srv
+}
+
+type capturedRequest struct {
+	method        string
+	path          string
+	contentType   string
+	authorization string
+	rawBody       []byte
+	parsedBody    chatRequest
+}
+
+// --- NewAgentFromEnv ---------------------------------------------------
+
+func TestNewAgentFromEnv_MissingEnvErrors(t *testing.T) {
+	t.Setenv(EnvAgentEndpoint, "")
+	t.Setenv(EnvAgentModel, "")
+	t.Setenv(EnvAgentAPIKey, "")
+
+	_, err := NewAgentFromEnv()
+	if err == nil {
+		t.Fatal("expected error for missing env, got nil")
+	}
+	if !errors.Is(err, ErrAgentNotConfigured) {
+		t.Errorf("expected ErrAgentNotConfigured, got %v", err)
+	}
+}
+
+func TestNewAgentFromEnv_PartialEnvErrors(t *testing.T) {
+	t.Setenv(EnvAgentEndpoint, "http://localhost:11434/v1")
+	t.Setenv(EnvAgentModel, "")
+
+	_, err := NewAgentFromEnv()
+	if !errors.Is(err, ErrAgentNotConfigured) {
+		t.Errorf("expected ErrAgentNotConfigured for missing model, got %v", err)
+	}
+}
+
+func TestNewAgentFromEnv_TrimsTrailingSlash(t *testing.T) {
+	t.Setenv(EnvAgentEndpoint, "http://localhost:11434/v1/")
+	t.Setenv(EnvAgentModel, "qwen2.5:7b")
+	t.Setenv(EnvAgentAPIKey, "")
+
+	agent, err := NewAgentFromEnv()
+	if err != nil {
+		t.Fatalf("NewAgentFromEnv: %v", err)
+	}
+	if agent.Endpoint() != "http://localhost:11434/v1" {
+		t.Errorf("Endpoint = %q, want trailing slash stripped", agent.Endpoint())
+	}
+	if agent.Model() != "qwen2.5:7b" {
+		t.Errorf("Model = %q", agent.Model())
+	}
+}
+
+// --- Request body shape ------------------------------------------------
+
+func TestAgentExtract_RequestBodyShape(t *testing.T) {
+	agent, captured, _ := startFakeAgent(t, fakeAgentResponse("# Hello\n"), http.StatusOK)
+
+	_, err := agent.Extract(context.Background(), "<html><body>hi</body></html>", "text/html")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	if captured.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", captured.method)
+	}
+	if captured.path != "/v1/chat/completions" {
+		t.Errorf("path = %q, want /v1/chat/completions", captured.path)
+	}
+	if !strings.HasPrefix(captured.contentType, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", captured.contentType)
+	}
+	if captured.authorization != "" {
+		t.Errorf("Authorization header set without API key: %q", captured.authorization)
+	}
+	if captured.parsedBody.Model != "test-model" {
+		t.Errorf("body.model = %q, want test-model", captured.parsedBody.Model)
+	}
+	if captured.parsedBody.Temperature != 0 {
+		t.Errorf("body.temperature = %v, want 0", captured.parsedBody.Temperature)
+	}
+	if captured.parsedBody.Stream {
+		t.Error("body.stream = true, want false")
+	}
+	if got := len(captured.parsedBody.Messages); got != 2 {
+		t.Fatalf("body.messages len = %d, want 2", got)
+	}
+	if captured.parsedBody.Messages[0].Role != "system" {
+		t.Errorf("messages[0].role = %q, want system", captured.parsedBody.Messages[0].Role)
+	}
+	if !strings.Contains(captured.parsedBody.Messages[0].Content, "documentation extractor") {
+		t.Errorf("system prompt missing identity, got %q", captured.parsedBody.Messages[0].Content)
+	}
+	if captured.parsedBody.Messages[1].Role != "user" {
+		t.Errorf("messages[1].role = %q, want user", captured.parsedBody.Messages[1].Role)
+	}
+	if !strings.Contains(captured.parsedBody.Messages[1].Content, "raw HTML") {
+		t.Errorf("user message missing HTML hint, got %q", captured.parsedBody.Messages[1].Content)
+	}
+	if !strings.Contains(captured.parsedBody.Messages[1].Content, "<html>") {
+		t.Errorf("user message missing source content, got %q", captured.parsedBody.Messages[1].Content)
+	}
+}
+
+func TestAgentExtract_AuthHeaderWhenAPIKeySet(t *testing.T) {
+	captured := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.authorization = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(fakeAgentResponse("ok")))
+	}))
+	defer srv.Close()
+
+	agent := NewAgent(srv.URL+"/v1", "test-model", "sk-secret-token", srv.Client())
+	if _, err := agent.Extract(context.Background(), "hello", "text/plain"); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	if captured.authorization != "Bearer sk-secret-token" {
+		t.Errorf("Authorization = %q, want %q", captured.authorization, "Bearer sk-secret-token")
+	}
+}
+
+func TestAgentExtract_PropagatesNon200(t *testing.T) {
+	agent, _, _ := startFakeAgent(t, "", http.StatusUnauthorized)
+	_, err := agent.Extract(context.Background(), "hello", "text/plain")
+	if err == nil {
+		t.Fatal("expected error for HTTP 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should mention HTTP 401, got %v", err)
+	}
+}
+
+func TestAgentExtract_EmptyContentRejected(t *testing.T) {
+	agent, _, _ := startFakeAgent(t, fakeAgentResponse("ignored"), http.StatusOK)
+	_, err := agent.Extract(context.Background(), "   \n\t  ", "text/plain")
+	if err == nil {
+		t.Fatal("expected error for empty content")
+	}
+}
+
+func TestAgentExtract_TruncatesOversizedInput(t *testing.T) {
+	agent, captured, _ := startFakeAgent(t, fakeAgentResponse("# truncated"), http.StatusOK)
+
+	huge := strings.Repeat("A", agentInputMaxChars+10_000)
+	if _, err := agent.Extract(context.Background(), huge, "text/plain"); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	// The user message is "<hint>\n\n<content>". The content section
+	// must be exactly agentInputMaxChars bytes long, never more.
+	user := captured.parsedBody.Messages[1].Content
+	parts := strings.SplitN(user, "\n\n", 2)
+	if len(parts) != 2 {
+		t.Fatalf("user message missing hint separator, got %q", user)
+	}
+	if got := len(parts[1]); got != agentInputMaxChars {
+		t.Errorf("truncated content length = %d, want %d", got, agentInputMaxChars)
+	}
+}
+
+// --- Ping --------------------------------------------------------------
+
+func TestAgentPing_Succeeds(t *testing.T) {
+	agent, captured, _ := startFakeAgent(t, fakeAgentResponse("ok"), http.StatusOK)
+	if err := agent.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if captured.path != "/v1/chat/completions" {
+		t.Errorf("Ping hit %q, want /v1/chat/completions", captured.path)
+	}
+}
+
+func TestAgentPing_FailsOnUnreachable(t *testing.T) {
+	// Wire the agent at a port nothing is listening on. The error
+	// path doesn't care about the exact dial error — only that it
+	// surfaces with the "agent ping" prefix.
+	agent := NewAgent("http://127.0.0.1:1/v1", "test-model", "", &http.Client{})
+	err := agent.Ping(context.Background())
+	if err == nil {
+		t.Fatal("expected error pinging unreachable endpoint")
+	}
+	if !strings.Contains(err.Error(), "agent ping") {
+		t.Errorf("error %q missing 'agent ping' prefix", err.Error())
+	}
+}
+
+// --- verifyCodeBlocks --------------------------------------------------
+
+func TestVerifyCodeBlocks_AcceptsMatchingBlocks(t *testing.T) {
+	source := "Some text\n\n```go\nfmt.Println(\"hi\")\n```\nmore text"
+	md := "## Title\n\n```go\nfmt.Println(\"hi\")\n```\n"
+
+	if !verifyCodeBlocks(md, source) {
+		t.Errorf("expected verify to pass with matching code block")
+	}
+}
+
+func TestVerifyCodeBlocks_RejectsHallucinatedBlock(t *testing.T) {
+	source := "documentation describing how to call the API"
+	md := "## API\n\n```go\ndeleteUniverse() // does not exist in source\n```\n"
+
+	if verifyCodeBlocks(md, source) {
+		t.Errorf("expected verify to reject hallucinated code block")
+	}
+}
+
+func TestVerifyCodeBlocks_AcceptsProseOnly(t *testing.T) {
+	source := "Some prose with no code at all."
+	md := "## Title\n\nClean markdown summary, no fences here.\n"
+
+	if !verifyCodeBlocks(md, source) {
+		t.Errorf("expected verify to accept prose-only output")
+	}
+}
+
+func TestVerifyCodeBlocks_StrictWhitespace(t *testing.T) {
+	// Source has 4-space indent; md has tab indent. Strict-by-default
+	// per #27 means this is rejected, not accepted.
+	source := "Example:\n\n    indented code line\n"
+	md := "```\n\tindented code line\n```\n"
+
+	if verifyCodeBlocks(md, source) {
+		t.Errorf("expected verify to reject whitespace-divergent code")
+	}
+}
+
+func TestVerifyCodeBlocks_HandlesTildeFences(t *testing.T) {
+	source := "Example:\n\nfoo\nbar\n"
+	md := "~~~\nfoo\nbar\n~~~\n"
+
+	if !verifyCodeBlocks(md, source) {
+		t.Errorf("expected verify to accept matching tilde-fenced block")
+	}
+}
+
+func TestVerifyCodeBlocks_MultipleBlocksAllChecked(t *testing.T) {
+	source := "alpha\n```\nfirst\n```\nbeta\n```\nsecond\n```\n"
+	mdGood := "```\nfirst\n```\n\nand\n\n```\nsecond\n```\n"
+	mdBad := "```\nfirst\n```\n\nand\n\n```\nsecond_modified\n```\n"
+
+	if !verifyCodeBlocks(mdGood, source) {
+		t.Errorf("expected good multi-block to pass")
+	}
+	if verifyCodeBlocks(mdBad, source) {
+		t.Errorf("expected bad multi-block to fail (one bad block)")
+	}
+}
+
+// --- contentTypeHint ---------------------------------------------------
+
+func TestContentTypeHint_VariesByType(t *testing.T) {
+	cases := map[string]string{
+		"text/html":               "raw HTML",
+		"text/markdown":           "Markdown",
+		"text/plain":              "plain text",
+		"application/octet-stream": "documentation content", // fallback
+	}
+	for ct, fragment := range cases {
+		hint := contentTypeHint(ct)
+		if !strings.Contains(hint, fragment) {
+			t.Errorf("contentTypeHint(%q) = %q, want fragment %q", ct, hint, fragment)
+		}
+	}
+}
+
+// --- FetchOneViaAgent end-to-end ---------------------------------------
+
+func TestFetchOneViaAgent_HappyPath(t *testing.T) {
+	// Source server: serves an HTML page on GET /docs.
+	sourceHTML := `<html><body><h1>Page</h1><pre><code>foo()</code></pre></body></html>`
+	sourceSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(sourceHTML))
+	}))
+	defer sourceSrv.Close()
+
+	// Agent server: returns a markdown extraction whose code block
+	// is verbatim from the source so the verifier accepts it.
+	extracted := "# Page\n\n```\nfoo()\n```\n"
+	agent, _, _ := startFakeAgent(t, fakeAgentResponse(extracted), http.StatusOK)
+
+	res, err := FetchOneViaAgent(context.Background(), sourceSrv.Client(), agent, "/test/lib", sourceSrv.URL+"/docs")
+	if err != nil {
+		t.Fatalf("FetchOneViaAgent: %v", err)
+	}
+	if res.Bytes != len(sourceHTML) {
+		t.Errorf("Bytes = %d, want %d", res.Bytes, len(sourceHTML))
+	}
+	if len(res.Docs) == 0 {
+		t.Fatal("expected at least one parsed doc, got 0")
+	}
+	for _, d := range res.Docs {
+		if d.LibID != "/test/lib" {
+			t.Errorf("doc has LibID %q, want /test/lib", d.LibID)
+		}
+	}
+}
+
+func TestFetchOneViaAgent_HallucinatedCodeRejected(t *testing.T) {
+	sourceHTML := `<html><body>just prose, no code</body></html>`
+	sourceSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(sourceHTML))
+	}))
+	defer sourceSrv.Close()
+
+	extracted := "# Page\n\n```\ninvented_code_block()\n```\n"
+	agent, _, _ := startFakeAgent(t, fakeAgentResponse(extracted), http.StatusOK)
+
+	_, err := FetchOneViaAgent(context.Background(), sourceSrv.Client(), agent, "/test/lib", sourceSrv.URL+"/docs")
+	if err == nil {
+		t.Fatal("expected verification failure, got nil")
+	}
+	if !errors.Is(err, ErrAgentVerificationFailed) {
+		t.Errorf("expected ErrAgentVerificationFailed, got %v", err)
+	}
+}
+
+func TestFetchOneViaAgent_PDFContentTypeRejected(t *testing.T) {
+	sourceSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		_, _ = w.Write([]byte("%PDF-1.7\ndummy"))
+	}))
+	defer sourceSrv.Close()
+
+	agent, _, _ := startFakeAgent(t, fakeAgentResponse("ignored"), http.StatusOK)
+
+	_, err := FetchOneViaAgent(context.Background(), sourceSrv.Client(), agent, "/test/lib", sourceSrv.URL+"/spec.pdf")
+	if err == nil {
+		t.Fatal("expected error for PDF content type, got nil")
+	}
+	if !errors.Is(err, ErrPDFNotSupportedYet) {
+		t.Errorf("expected ErrPDFNotSupportedYet, got %v", err)
+	}
+}
+
+func TestFetchOneViaAgent_NilAgentReturnsError(t *testing.T) {
+	sourceSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hi"))
+	}))
+	defer sourceSrv.Close()
+
+	_, err := FetchOneViaAgent(context.Background(), sourceSrv.Client(), nil, "/test/lib", sourceSrv.URL)
+	if err == nil {
+		t.Fatal("expected error for nil agent")
+	}
+	if !strings.Contains(err.Error(), "agent is nil") {
+		t.Errorf("error %q should mention nil agent", err.Error())
+	}
+}

--- a/internal/scraper/config.go
+++ b/internal/scraper/config.go
@@ -14,11 +14,27 @@ import (
 // (single-version entries, version strings themselves).
 const versionPlaceholder = "{version}"
 
-// validKinds enumerates the source kind discriminators known to v1 of the
-// loader. Adding new kinds (e.g. scrape-via-agent in #27) means appending
-// to this set, not changing the schema.
+// Kind discriminators for LibrarySource.Kind. Both branches feed the
+// same downstream pipeline (ParseMarkdown → embed → store); they only
+// differ in how the markdown is obtained.
+const (
+	// KindGithubMD is the fast path: HTTP GET on raw markdown URLs and
+	// straight into ParseMarkdown. No LLM, no preprocessing.
+	KindGithubMD = "github-md"
+
+	// KindScrapeViaAgent delegates content → clean markdown extraction
+	// to an OpenAI-compatible chat completions endpoint (Ollama, vLLM,
+	// LocalAI, OpenAI, ...). The catch-all path for HTML doc sites and
+	// any other format that isn't trivially raw markdown. See #27.
+	KindScrapeViaAgent = "scrape-via-agent"
+)
+
+// validKinds enumerates the source kind discriminators known to the
+// loader. Adding new kinds means appending to this set, not changing
+// the schema.
 var validKinds = map[string]bool{
-	"github-md": true,
+	KindGithubMD:       true,
+	KindScrapeViaAgent: true,
 }
 
 // Config is the parsed libraries_sources.yaml file.
@@ -96,7 +112,7 @@ func (l LibrarySource) validate() error {
 		return fmt.Errorf("kind is required")
 	}
 	if !validKinds[l.Kind] {
-		return fmt.Errorf("unknown kind %q (valid: github-md)", l.Kind)
+		return fmt.Errorf("unknown kind %q (valid: %s, %s)", l.Kind, KindGithubMD, KindScrapeViaAgent)
 	}
 	if len(l.URLs) == 0 {
 		return fmt.Errorf("urls must be non-empty")

--- a/internal/scraper/config_test.go
+++ b/internal/scraper/config_test.go
@@ -181,6 +181,37 @@ libraries:
 	}
 }
 
+func TestLoadConfig_AcceptsScrapeViaAgentKind(t *testing.T) {
+	path := writeConfig(t, `
+libraries:
+  - lib_id: /hashicorp/terraform-provider-aws
+    kind: scrape-via-agent
+    urls:
+      - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
+      - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role
+`)
+
+	cfg, err := scraper.LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Libraries) != 1 {
+		t.Fatalf("expected 1 library, got %d", len(cfg.Libraries))
+	}
+	if got := cfg.Libraries[0].Kind; got != scraper.KindScrapeViaAgent {
+		t.Errorf("Kind = %q, want %q", got, scraper.KindScrapeViaAgent)
+	}
+
+	// Verify the kind round-trips through Resolve as well.
+	resolved := cfg.Resolve("")
+	if len(resolved) != 1 {
+		t.Fatalf("Resolve returned %d, want 1", len(resolved))
+	}
+	if resolved[0].Kind != scraper.KindScrapeViaAgent {
+		t.Errorf("ResolvedSource.Kind = %q, want %q", resolved[0].Kind, scraper.KindScrapeViaAgent)
+	}
+}
+
 func TestLoadConfig_VersionsRules(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/scraper/preprocess.go
+++ b/internal/scraper/preprocess.go
@@ -1,0 +1,70 @@
+package scraper
+
+import (
+	"errors"
+	"fmt"
+	"mime"
+	"strings"
+)
+
+// ErrPDFNotSupportedYet is returned by preprocess for application/pdf
+// content. The slot is reserved deliberately: the architecture in #27
+// is designed so adding PDF is a single new case in this switch plus a
+// pure-Go text extractor, not a rearchitecture. Until that follow-up
+// lands the scraper refuses PDFs loudly rather than silently routing
+// raw bytes through the LLM.
+var ErrPDFNotSupportedYet = errors.New("application/pdf input is not supported yet (planned follow-up to #27)")
+
+// ContentType buckets we accept on the agent path. The string values
+// match the canonical MIME types after media-type parameter stripping.
+const (
+	contentTypeHTML     = "text/html"
+	contentTypeXHTML    = "application/xhtml+xml"
+	contentTypeMarkdown = "text/markdown"
+	contentTypeXMD      = "text/x-markdown"
+	contentTypePlain    = "text/plain"
+	contentTypePDF      = "application/pdf"
+)
+
+// preprocess turns a raw HTTP response body into LLM-ready text for
+// Agent.Extract. The contentType argument is the raw Content-Type
+// response header (parameters and casing tolerated); preprocess does
+// the parsing.
+//
+// Behaviour is intentionally minimal in v1: HTML, markdown, and plain
+// text are returned as-is — modern LLMs handle HTML natively and don't
+// need a Go-side DOM walk to do good extraction. PDF is reserved for a
+// follow-up. Anything else is rejected with a clear error so the
+// operator notices instead of feeding the model raw bytes that turn
+// into garbage downstream.
+func preprocess(body []byte, contentType string) (string, error) {
+	switch normalizeContentType(contentType) {
+	case contentTypeHTML, contentTypeXHTML:
+		return string(body), nil
+	case contentTypeMarkdown, contentTypeXMD, contentTypePlain:
+		return string(body), nil
+	case contentTypePDF:
+		return "", ErrPDFNotSupportedYet
+	default:
+		// Empty Content-Type is most often a misconfigured static
+		// server; surface it as the same "unsupported" error rather
+		// than guessing.
+		return "", fmt.Errorf("unsupported content type %q", contentType)
+	}
+}
+
+// normalizeContentType strips media-type parameters (charset=, boundary=, …)
+// and lower-cases the bare type/subtype so the switch in preprocess can
+// match exact strings. Failures fall back to the trimmed lower-cased
+// header so the resulting "unsupported" error message includes whatever
+// the server actually sent.
+func normalizeContentType(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	mt, _, err := mime.ParseMediaType(raw)
+	if err != nil {
+		return strings.ToLower(strings.TrimSpace(raw))
+	}
+	return mt
+}

--- a/internal/scraper/preprocess_test.go
+++ b/internal/scraper/preprocess_test.go
@@ -1,0 +1,98 @@
+package scraper
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// preprocess and normalizeContentType are package-private; this test
+// file lives in the same package (no _test suffix on the package
+// declaration) so the unit tests can call them directly without an
+// exported wrapper.
+func TestPreprocess_AcceptsHTML(t *testing.T) {
+	body := []byte("<html><body><h1>Hi</h1></body></html>")
+	cases := []string{
+		"text/html",
+		"text/html; charset=utf-8",
+		"TEXT/HTML",
+		"application/xhtml+xml",
+	}
+	for _, ct := range cases {
+		t.Run(ct, func(t *testing.T) {
+			text, err := preprocess(body, ct)
+			if err != nil {
+				t.Fatalf("preprocess(%q): %v", ct, err)
+			}
+			if text != string(body) {
+				t.Errorf("preprocess returned %q, want %q", text, body)
+			}
+		})
+	}
+}
+
+func TestPreprocess_AcceptsMarkdownAndPlain(t *testing.T) {
+	body := []byte("# Title\n\nbody")
+	for _, ct := range []string{"text/markdown", "text/x-markdown", "text/plain", "text/plain; charset=us-ascii"} {
+		t.Run(ct, func(t *testing.T) {
+			text, err := preprocess(body, ct)
+			if err != nil {
+				t.Fatalf("preprocess(%q): %v", ct, err)
+			}
+			if text != string(body) {
+				t.Errorf("preprocess returned %q, want %q", text, body)
+			}
+		})
+	}
+}
+
+func TestPreprocess_RejectsPDFWithSentinel(t *testing.T) {
+	_, err := preprocess([]byte("%PDF-1.7\n..."), "application/pdf")
+	if err == nil {
+		t.Fatal("expected error for application/pdf, got nil")
+	}
+	if !errors.Is(err, ErrPDFNotSupportedYet) {
+		t.Errorf("expected ErrPDFNotSupportedYet, got %v", err)
+	}
+}
+
+func TestPreprocess_RejectsUnknownTypes(t *testing.T) {
+	cases := []string{
+		"image/png",
+		"application/octet-stream",
+		"application/json",
+		"",
+		"   ",
+	}
+	for _, ct := range cases {
+		t.Run(ct, func(t *testing.T) {
+			_, err := preprocess([]byte("anything"), ct)
+			if err == nil {
+				t.Fatalf("expected error for content type %q, got nil", ct)
+			}
+			if !strings.Contains(err.Error(), "unsupported content type") {
+				t.Errorf("error %q does not mention 'unsupported content type'", err.Error())
+			}
+		})
+	}
+}
+
+func TestNormalizeContentType_StripsParameters(t *testing.T) {
+	cases := map[string]string{
+		"text/html; charset=utf-8":               "text/html",
+		"TEXT/HTML; charset=UTF-8":               "text/html",
+		"application/pdf":                        "application/pdf",
+		" text/markdown ":                        "text/markdown",
+		"":                                       "",
+		"not a real header but trimmed":          "not a real header but trimmed",
+		"application/xhtml+xml; profile=\"foo\"": "application/xhtml+xml",
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			got := normalizeContentType(input)
+			if got != want {
+				t.Errorf("normalizeContentType(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -161,6 +161,62 @@ func FetchOne(ctx context.Context, client *http.Client, libID, url string) (Fetc
 	return FetchOneResult{Docs: docs, Bytes: len(body)}, nil
 }
 
+// FetchOneViaAgent is the per-URL primitive for the scrape-via-agent
+// kind: HTTP GET, content-type-aware preprocessing, LLM extraction,
+// code-block verification, and ParseMarkdown into docs.
+//
+// Returns ErrAgentVerificationFailed if the LLM emitted a fenced code
+// block that does not appear verbatim in the source content. The
+// caller is expected to log the failure and skip the doc; the rest of
+// the URLs in the same source still get processed.
+//
+// Like FetchOne, this is the per-URL primitive used by cmd/scraper so
+// the operator log can carry per-URL fetch / verify / index events
+// instead of one summary per source.
+func FetchOneViaAgent(ctx context.Context, client *http.Client, agent *Agent, libID, url string) (FetchOneResult, error) {
+	if agent == nil {
+		return FetchOneResult{}, fmt.Errorf("fetch via agent %s: agent is nil", url)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return FetchOneResult{}, fmt.Errorf("build request %s: %w", url, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return FetchOneResult{}, fmt.Errorf("fetch %s: %w", url, err)
+	}
+
+	body, readErr := io.ReadAll(resp.Body)
+	contentType := resp.Header.Get("Content-Type")
+	resp.Body.Close()
+	if readErr != nil {
+		return FetchOneResult{}, fmt.Errorf("read body %s: %w", url, readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return FetchOneResult{}, fmt.Errorf("fetch %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	text, err := preprocess(body, contentType)
+	if err != nil {
+		return FetchOneResult{}, fmt.Errorf("preprocess %s: %w", url, err)
+	}
+
+	md, err := agent.Extract(ctx, text, contentType)
+	if err != nil {
+		return FetchOneResult{}, fmt.Errorf("extract %s: %w", url, err)
+	}
+
+	if !verifyCodeBlocks(md, text) {
+		return FetchOneResult{}, fmt.Errorf("%s: %w", url, ErrAgentVerificationFailed)
+	}
+
+	sourceName := strings.TrimSuffix(path.Base(url), path.Ext(url))
+	docs := ParseMarkdown(libID, sourceName, md)
+	return FetchOneResult{Docs: docs, Bytes: len(body)}, nil
+}
+
 // Fetch downloads each URL in src and returns the concatenated Docs.
 // Implemented as a thin loop over FetchOne so callers that just want
 // "give me everything" don't have to deal with per-URL bookkeeping.

--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -3,7 +3,13 @@
 # Each entry is one library to scrape. Required fields:
 #
 #   lib_id   canonical "/org/project" identifier (matches db.docs.lib_id)
-#   kind     source kind discriminator (only "github-md" is valid in v1)
+#   kind     source kind discriminator. Valid values:
+#              - github-md         raw markdown URLs, no LLM (fast path)
+#              - scrape-via-agent  HTML/text via an OpenAI-compatible
+#                                  chat completions endpoint (set the
+#                                  DEADZONE_AGENT_ENDPOINT[_*] env vars;
+#                                  see README "Scraping non-trivial doc
+#                                  sources" for the full contract)
 #   urls     list of doc URLs to fetch
 #
 # Optional:


### PR DESCRIPTION
## Summary

- Add `scrape-via-agent` source kind that delegates HTML/text → clean Markdown extraction to any OpenAI-compatible chat completions endpoint (Ollama, vLLM, LocalAI, OpenAI, etc.)
- Implement `Agent` with startup health-check (ping), content-type-aware extraction prompt, input truncation (~48 KiB cap), and fenced code-block verification to catch hallucinated code examples
- Add `preprocess` module for content-type normalization and gating (HTML, Markdown, plain text supported; PDF reserved with clear error)
- Wire kind dispatch into the scraper main loop with fail-fast startup contract: missing/unreachable endpoint aborts the run before any URL is processed
- Downstream pipeline (`ParseMarkdown` → chunk → embed → store) is identical for both kinds

## Configuration

Three env vars configure the agent endpoint:

bash
export DEADZONE_AGENT_ENDPOINT=http://localhost:11434/v1
export DEADZONE_AGENT_ENDPOINT_MODEL=qwen2.5:7b
export DEADZONE_AGENT_ENDPOINT_API_KEY=sk-...  # optional

Then use `kind: scrape-via-agent` in `libraries_sources.yaml`.

## Test plan

- [x] Unit tests for `Agent` (ping, extract, truncation, error paths) via `httptest` server
- [x] Unit tests for code-block verification (verbatim match, hallucination rejection, edge cases)
- [x] Unit tests for `preprocess` (content-type normalization, gating, PDF rejection)
- [x] Config validation tests for new kind
- [ ] Manual: run scraper with Ollama endpoint against a `scrape-via-agent` source and verify indexed docs

<!-- emdash-issue-footer:start -->
Fixes #27
<!-- emdash-issue-footer:end -->