### PR TITLE
feat: distribute per-lib artifacts via GitHub Releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,17 @@
 /deadzone
 /deadzone-server
 /deadzone-consolidate
+/deadzone-packs
 /deadzone.db
 /deadzone.db-wal
 /deadzone.db-shm
-/artifacts/
+# /artifacts/ holds disposable per-lib .db build outputs and tursogo
+# WAL/SHM sidecars, but artifacts/manifest.yaml is a tracked source file
+# (it's the audit trail for which artifact version is canonical — see
+# issue #30). Patterns are .db-only so the manifest stays trackable.
+/artifacts/*.db
+/artifacts/*.db-wal
+/artifacts/*.db-shm
 /.envrc
 .DS_Store
 .mcp.json

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ mise install
 # 2. Build — no CGO required
 just build             # = mise exec -- go build ./...
 
-# 3. Scrape every library in libraries_sources.yaml into per-lib artifacts
-just scrape            # = mise exec -- go run ./cmd/scraper -artifacts ./artifacts
-# → writes one artifacts/<lib_id>.db file per entry in libraries_sources.yaml
-# → ships preloaded with the modelcontextprotocol/go-sdk docs
+# 3. Pull pre-built per-lib artifacts from the rolling GitHub Release
+just packs-download    # = mise exec -- go run ./cmd/packs download -artifacts ./artifacts -manifest ./artifacts/manifest.yaml
+# → reads artifacts/manifest.yaml and downloads every referenced .db
+# → verifies sha256 on the way down; aborts loudly on mismatch
 
 # 4. Merge the per-lib artifacts into the main deadzone.db
 just consolidate       # = mise exec -- go run ./cmd/consolidate -db deadzone.db -artifacts ./artifacts
@@ -79,26 +79,36 @@ just consolidate       # = mise exec -- go run ./cmd/consolidate -db deadzone.db
 just serve             # = mise exec -- go run ./cmd/server -db deadzone.db
 ```
 
-The `artifacts/` directory and `deadzone.db` are both gitignored — `artifacts/` holds the per-lib source-of-truth files and `deadzone.db` is the derived view the server reads. The server refuses to start if `deadzone.db` is missing and tells you to run `consolidate` first; it never auto-creates an empty file.
+The `artifacts/*.db` files and `deadzone.db` are both gitignored — `artifacts/*.db` are the per-lib source-of-truth blobs (distributed via GitHub Releases, see [Refreshing a single library](#refreshing-a-single-library)) and `deadzone.db` is the derived view the server reads. The committed [`artifacts/manifest.yaml`](artifacts/manifest.yaml) is the audit trail mapping every lib to its current sha256. The server refuses to start if `deadzone.db` is missing and tells you to run `consolidate` first; it never auto-creates an empty file.
 
 Run `just` (no args) to list every recipe. Override the DB path with positional args: `just consolidate foo.db` / `just serve foo.db`. If you'd rather call `go` directly, prefix every command with `mise exec --` so you pick up the pinned toolchain.
 
 ### Refreshing a single library
 
-The whole point of the per-lib artifact layout is that one library can be re-scraped without touching the others. Pass the lib_id to `just scrape` (matches the registry's `lib_id` field; for multi-version libs you can target the base or one expanded version):
+The per-lib artifact layout means one library can be re-scraped, re-uploaded, and re-distributed without touching the others. The flow has four steps and is the same for both single-version libs and multi-version (`/facebook/react/v18`, `/facebook/react/v19`, …) entries:
 
 ```bash
-# Re-scrape every version of /facebook/react and rebuild its artifact(s)
-just scrape /facebook/react
+# 1. Re-scrape locally (rebuilds exactly the matching artifacts/*.db files)
+just scrape /facebook/react           # base — every versioned child
+just scrape /facebook/react/v18       # one expanded version
 
-# Re-scrape only one expanded version
-just scrape /facebook/react/v18
+# 2. Push the refreshed artifact(s) to the rolling GitHub Release.
+#    Idempotent: artifacts whose sha256 already matches the manifest
+#    are skipped, no `gh` calls made.
+just packs-upload
 
-# Then merge the refreshed artifact(s) back into the main DB
-just consolidate
+# 3. Commit the manifest diff so reviewers can see exactly which libs
+#    were refreshed (sha256 + indexed_at change in lockstep).
+git add artifacts/manifest.yaml && git commit -m "refresh /facebook/react"
+git push
+
+# 4. Anyone else just runs `just packs-download && just consolidate` to
+#    pick up the new artifact.
 ```
 
-`just scrape <lib>` regenerates exactly the matching `artifacts/*.db` files; the others stay byte-identical. `just consolidate` is idempotent — re-running it after a partial scrape just replaces the rows for the libs whose artifacts changed.
+`packs upload` shells out to `gh release upload <tag> <file> --clobber` for each changed artifact, auto-creating the release on first use. The `gh` CLI handles auth via your existing `gh auth login` state — Deadzone does not handle GitHub tokens directly. Override the target repo with `-repo owner/name` if you're working from a fork.
+
+Use `just packs-list` to print the current manifest contents as a table, or `just packs-download lib=/facebook/react` to fetch only one library's assets without pulling the whole corpus.
 
 ### Configuring which libraries to scrape
 
@@ -230,12 +240,16 @@ deadzone/
 ├── cmd/
 │   ├── server/        # MCP server entrypoint (search_docs / search_libraries)
 │   ├── scraper/       # CLI: fetch, embed & write per-lib artifacts
-│   └── consolidate/   # CLI: merge per-lib artifacts into the main DB
+│   ├── consolidate/   # CLI: merge per-lib artifacts into the main DB
+│   └── packs/         # CLI: upload/download per-lib artifacts via GitHub Releases
 ├── internal/
 │   ├── db/            # Turso schema, vector queries, consolidation helper
 │   ├── embed/         # Embedder interface + hugot/MiniLM implementation
-│   └── scraper/       # Markdown fetcher + parser (H2-split, fence-aware)
-├── artifacts/         # gitignored: per-lib .db source-of-truth files
+│   ├── scraper/       # Markdown fetcher + parser (H2-split, fence-aware)
+│   └── packs/         # Manifest schema, upload/download/list, gh wrapper
+├── artifacts/
+│   ├── manifest.yaml  # tracked: sha256 + indexed_at audit trail
+│   └── *.db           # gitignored: per-lib source-of-truth files
 └── docs/
     └── research/      # Design notes (Context7 analysis, tursogo migration, etc.)
 ```
@@ -248,12 +262,13 @@ More background in [`docs/research/context7-analysis.md`](docs/research/context7
 
 ## Debugging
 
-All three binaries emit structured JSON logs to **stderr** using `log/slog`. Stdout is reserved for the MCP JSON-RPC channel on `cmd/server`, so anything written there that isn't a valid JSON-RPC message disconnects the client — `cmd/scraper` and `cmd/consolidate` follow the same convention for consistency.
+All four binaries emit structured JSON logs to **stderr** using `log/slog`. Stdout is reserved for the MCP JSON-RPC channel on `cmd/server`, so anything written there that isn't a valid JSON-RPC message disconnects the client — `cmd/scraper`, `cmd/consolidate`, and `cmd/packs` follow the same convention for consistency. (`cmd/packs list` is the one exception: it writes a human-facing table to stdout so callers can pipe it through `awk`/`column`.)
 
 - **Scraper.** `just scrape` writes logs straight to your terminal. Look for `scraper.start`, a `scraper.lib_start` per resolved library (with the `artifact_path` it's writing to), one `scraper.fetch` per URL (with `bytes`, `duration_ms`, `docs_extracted`, and `kind`), `scraper.indexed` summaries, a `scraper.lib_done` per library, and a final `scraper.done`. The "silently stalls on one URL" failure mode shows up as a missing `scraper.fetch` event for that URL. Errors land as `scraper.fetch_failed` / `scraper.insert_failed` with the URL and wrapped error. When any source uses `kind: scrape-via-agent`, expect `scraper.agent_configured` and `scraper.agent_ping_ok` once at startup; per-doc hallucination drops show up as `scraper.agent_verification_failed`, and oversized inputs as `agent.input_truncated`.
 - **Consolidate.** `just consolidate` emits a `consolidate.start` and a `consolidate.done` with the `artifacts` count, `docs_merged`, `libs_merged`, and `duration_ms`. A failure aborts before any write reaches the main DB; the wrapped error names the offending artifact.
+- **Packs.** `just packs-upload` emits `packs.upload.start` (with the resolved repo and `repo_source=flag|manifest|default`), one `packs.upload.skipped` per artifact whose sha256 already matches the manifest, one `packs.upload.uploaded` per artifact pushed via `gh release upload`, an optional `packs.upload.creating_release` if the rolling tag didn't exist yet, and a final `packs.upload.done` with `uploaded`/`skipped`/`preserved` counts. `just packs-download` emits `packs.download.start`, one `packs.verified` per local file whose sha256 matches the manifest (zero network calls), `packs.verified_redownload` when a tampered local file is being silently re-fetched, `packs.downloaded` per fresh fetch, and `packs.download.done` with the rollup. Server-side sha256 mismatches abort with a `download <lib_id>: sha256 mismatch` error and never overwrite the canonical local file.
 - **Server.** `cmd/server`'s stderr is captured by the MCP client. In Claude Code that's the `~/Library/Logs/Claude/mcp-server-deadzone.log` file (macOS) or your client's equivalent — check the MCP client docs. On startup the server emits a `server.start` line with the embedder meta and the indexed `doc_count`; each `search_docs` call emits one `search_docs` line with `lib_id`, `tokens`, `results`, and `latency_ms`. If the configured `-db` is missing the server refuses to start and prints a one-liner pointing at `deadzone-consolidate`.
-- **Verbose mode.** All three binaries take `-verbose`. On the server it adds the raw `query` field to per-call logs (off by default because queries may contain user data). On the scraper it adds per-doc `scraper.doc_indexed` Debug lines, useful when debugging the parser on a new library.
+- **Verbose mode.** All four binaries take `-verbose`. On the server it adds the raw `query` field to per-call logs (off by default because queries may contain user data). On the scraper it adds per-doc `scraper.doc_indexed` Debug lines, useful when debugging the parser on a new library.
 
 ## Roadmap
 

--- a/artifacts/manifest.yaml
+++ b/artifacts/manifest.yaml
@@ -1,0 +1,15 @@
+# Deadzone pack manifest — see #30 and the README "Quick start".
+#
+# This file is the source of truth for which version of each per-lib
+# artifact is currently canonical. Edits MUST come from
+# `deadzone-packs upload` — never hand-edit a sha256.
+#
+# Schema:
+#   release_tag  rolling GitHub Release tag that holds every asset
+#   repo         optional default `owner/name` for downloads (the
+#                -repo CLI flag overrides this when explicitly set)
+#   packs        list of per-lib artifacts; one entry per lib_id
+
+release_tag: packs
+repo: laradji/deadzone
+packs: []

--- a/cmd/packs/main.go
+++ b/cmd/packs/main.go
@@ -1,0 +1,214 @@
+// Command packs distributes per-lib artifact .db files via a rolling
+// GitHub Release. It is the implementation of issue #30 and exposes
+// three subcommands:
+//
+//	deadzone-packs upload   # push local artifacts/*.db to the release
+//	deadzone-packs download # pull every manifest entry into ./artifacts
+//	deadzone-packs list     # print the manifest as a table
+//
+// Run `deadzone-packs <sub> -h` for the per-subcommand flag set.
+//
+// The binary is intentionally split per-subcommand on the cmd line so
+// it composes naturally with `xargs`, scripts, and CI runners that
+// expect a single positional verb. Production callers always go
+// through the justfile recipes (`just packs-upload`, etc.) which wrap
+// the right combination of flags.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/laradji/deadzone/internal/logs"
+	"github.com/laradji/deadzone/internal/packs"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	if err := run(os.Args[1], os.Args[2:]); err != nil {
+		slog.Error("packs fatal", "err", err.Error())
+		os.Exit(1)
+	}
+}
+
+// run dispatches to the correct subcommand handler. Each handler owns
+// its own flag.FlagSet so the help text for `packs upload -h` only
+// shows upload's flags, not the union of all subcommands.
+func run(sub string, args []string) error {
+	switch sub {
+	case "upload":
+		return runUpload(args)
+	case "download":
+		return runDownload(args)
+	case "list":
+		return runList(args)
+	case "-h", "--help", "help":
+		usage()
+		return nil
+	default:
+		usage()
+		return fmt.Errorf("unknown subcommand %q", sub)
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, `Usage: deadzone-packs <subcommand> [flags]
+
+Subcommands:
+  upload    Upload local artifacts/*.db to the rolling GitHub Release
+  download  Download release assets referenced by the manifest into ./artifacts
+  list      Print the manifest as a table
+
+Run "deadzone-packs <subcommand> -h" for the flags supported by each.`)
+}
+
+// runUpload parses upload-specific flags, sets up logging, resolves
+// the repo from (-repo flag) || manifest.repo || DefaultRepo, builds
+// the production GHReleaser, and calls packs.RunUpload. The repo
+// resolution chain is logged so a misconfigured run is visible in
+// stderr without --verbose.
+func runUpload(args []string) error {
+	fs := flag.NewFlagSet("upload", flag.ExitOnError)
+	artifactsDir := fs.String("artifacts", "./artifacts", "directory containing per-lib *.db artifact files")
+	manifestPath := fs.String("manifest", "./artifacts/manifest.yaml", "path to artifacts/manifest.yaml")
+	repo := fs.String("repo", "", "GitHub owner/name (overrides manifest.repo; default "+packs.DefaultRepo+")")
+	verbose := fs.Bool("verbose", false, "enable Debug-level slog output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	slog.SetDefault(logs.New(os.Stderr, *verbose))
+
+	resolvedRepo, source, err := resolveRepo(*manifestPath, *repo)
+	if err != nil {
+		return err
+	}
+	slog.Info("packs.upload.start",
+		"artifacts_dir", *artifactsDir,
+		"manifest_path", *manifestPath,
+		"repo", resolvedRepo,
+		"repo_source", source,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	summary, err := packs.RunUpload(ctx, packs.UploadOptions{
+		ArtifactsDir: *artifactsDir,
+		ManifestPath: *manifestPath,
+		Repo:         resolvedRepo,
+		Releaser:     packs.NewGHReleaser(),
+	})
+	if err != nil {
+		return err
+	}
+	slog.Info("packs.upload.done",
+		"uploaded", summary.Uploaded,
+		"skipped", summary.Skipped,
+		"preserved", summary.Preserved,
+		"duration_ms", time.Since(start).Milliseconds(),
+	)
+	return nil
+}
+
+// runDownload mirrors runUpload's structure for the download path. The
+// production Fetcher wraps http.DefaultClient — public release assets
+// don't need auth, and DefaultClient transparently follows GitHub's
+// 302 to objects.githubusercontent.com.
+func runDownload(args []string) error {
+	fs := flag.NewFlagSet("download", flag.ExitOnError)
+	artifactsDir := fs.String("artifacts", "./artifacts", "directory to write downloaded *.db files into")
+	manifestPath := fs.String("manifest", "./artifacts/manifest.yaml", "path to artifacts/manifest.yaml")
+	repo := fs.String("repo", "", "GitHub owner/name (overrides manifest.repo; default "+packs.DefaultRepo+")")
+	libFilter := fs.String("lib", "", "download only this lib_id (matches base or /base/version); empty = all")
+	verbose := fs.Bool("verbose", false, "enable Debug-level slog output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	slog.SetDefault(logs.New(os.Stderr, *verbose))
+
+	resolvedRepo, source, err := resolveRepo(*manifestPath, *repo)
+	if err != nil {
+		return err
+	}
+	slog.Info("packs.download.start",
+		"artifacts_dir", *artifactsDir,
+		"manifest_path", *manifestPath,
+		"repo", resolvedRepo,
+		"repo_source", source,
+		"lib_filter", *libFilter,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	summary, err := packs.RunDownload(ctx, packs.DownloadOptions{
+		ArtifactsDir: *artifactsDir,
+		ManifestPath: *manifestPath,
+		Repo:         resolvedRepo,
+		LibFilter:    *libFilter,
+		Fetcher:      packs.NewHTTPFetcher(http.DefaultClient),
+	})
+	if err != nil {
+		return err
+	}
+	slog.Info("packs.download.done",
+		"downloaded", summary.Downloaded,
+		"verified", summary.Verified,
+		"redownloaded", summary.Redownloaded,
+		"duration_ms", time.Since(start).Milliseconds(),
+	)
+	return nil
+}
+
+// runList parses the small list flag set and writes the table to
+// stdout. Logs still go to stderr — the table is the only thing on
+// stdout so callers can pipe it into `column`, `awk`, or similar
+// without slog noise.
+func runList(args []string) error {
+	fs := flag.NewFlagSet("list", flag.ExitOnError)
+	manifestPath := fs.String("manifest", "./artifacts/manifest.yaml", "path to artifacts/manifest.yaml")
+	verbose := fs.Bool("verbose", false, "enable Debug-level slog output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	slog.SetDefault(logs.New(os.Stderr, *verbose))
+	return packs.RunList(packs.ListOptions{ManifestPath: *manifestPath}, os.Stdout)
+}
+
+// resolveRepo implements the three-tier repo resolution: explicit
+// -repo flag wins, then the manifest's `repo:` field if any, then the
+// hardcoded default. Returns the chosen value and a "source" string
+// for the structured log line so misconfiguration is visible.
+//
+// The manifest read here is best-effort: a missing or malformed
+// manifest is NOT fatal because the upload subcommand will surface
+// the same error in its real Load call. The double-load is cheap and
+// keeps the resolveRepo helper independent of the subcommand context.
+func resolveRepo(manifestPath, flagValue string) (string, string, error) {
+	if flagValue != "" {
+		return flagValue, "flag", nil
+	}
+	if manifestPath != "" {
+		if m, err := packs.Load(manifestPath); err == nil && m.Repo != "" {
+			return m.Repo, "manifest", nil
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			// A malformed manifest at this stage is a hard error
+			// because the subsequent upload/download call WILL fail
+			// the same way; surfacing it here gives the operator a
+			// single error message instead of two.
+			return "", "", fmt.Errorf("resolve repo: %w", err)
+		}
+	}
+	return packs.DefaultRepo, "default", nil
+}

--- a/internal/db/artifact_meta.go
+++ b/internal/db/artifact_meta.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "turso.tech/database/tursogo"
+)
+
+// ArtifactMeta is the identity payload of a per-lib artifact: which
+// library it carries and which embedder produced its vectors. The
+// per-pack manifest committed to git records exactly these three fields
+// alongside the sha256, so a future cmd/packs upload can recreate the
+// manifest entry from a freshly-built artifact without having to spin
+// up an embedder.
+type ArtifactMeta struct {
+	LibID        string
+	EmbedderKind string
+	ModelVersion string
+}
+
+// ReadArtifactMeta opens path with a bare sql.Open, reads the three
+// identity keys from the meta table, and closes. Unlike OpenArtifact it
+// does NOT validate the embedder meta against a Meta passed by the
+// caller and does NOT cross-check the schema version, so callers can
+// inspect an artifact without instantiating an embedder (and paying the
+// ~90MB MiniLM model download on first run).
+//
+// The trade-off: ReadArtifactMeta only tells you what the artifact
+// claims to be. The integrity contract that those vectors actually
+// match the embedder is enforced exactly once, by db.Open / OpenArtifact,
+// at the moment a real consumer (consolidate, server) loads the file.
+// cmd/packs is intentionally upstream of that check — it just shovels
+// bytes around.
+//
+// Returns ErrArtifactLibIDMissing when the file exists but has no
+// lib_id row, mirroring OpenArtifact's behaviour for the same case so
+// callers using errors.Is don't have to learn a second sentinel.
+func ReadArtifactMeta(path string) (ArtifactMeta, error) {
+	raw, err := sql.Open("turso", path)
+	if err != nil {
+		return ArtifactMeta{}, fmt.Errorf("read artifact meta %s: open: %w", path, err)
+	}
+	defer raw.Close()
+	// Match the rest of the package: tursogo is BETA, serialize.
+	raw.SetMaxOpenConns(1)
+
+	rows, err := raw.Query(`SELECT key, value FROM meta WHERE key IN (?, ?, ?)`,
+		metaKeyLibID, metaKeyEmbedderKind, metaKeyModelVersion)
+	if err != nil {
+		return ArtifactMeta{}, fmt.Errorf("read artifact meta %s: query: %w", path, err)
+	}
+	defer rows.Close()
+
+	values := map[string]string{}
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return ArtifactMeta{}, fmt.Errorf("read artifact meta %s: scan: %w", path, err)
+		}
+		values[k] = v
+	}
+	if err := rows.Err(); err != nil {
+		return ArtifactMeta{}, fmt.Errorf("read artifact meta %s: rows: %w", path, err)
+	}
+
+	libID, hasLibID := values[metaKeyLibID]
+	if !hasLibID {
+		return ArtifactMeta{}, fmt.Errorf("read artifact meta %s: %w", path, ErrArtifactLibIDMissing)
+	}
+	// Embedder meta is intentionally optional at this layer: a brand-new
+	// artifact built by a future scraper version that drops one of these
+	// keys would still be uploadable, just with empty fields in the
+	// manifest. The downstream Open call enforces the real contract.
+	return ArtifactMeta{
+		LibID:        libID,
+		EmbedderKind: values[metaKeyEmbedderKind],
+		ModelVersion: values[metaKeyModelVersion],
+	}, nil
+}

--- a/internal/db/artifact_meta_internal_test.go
+++ b/internal/db/artifact_meta_internal_test.go
@@ -1,0 +1,111 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	_ "turso.tech/database/tursogo"
+)
+
+// TestReadArtifactMeta verifies the lightweight reader correctly extracts
+// the three identity fields from a hand-built artifact file. We bypass
+// db.Open / OpenArtifact entirely so the test runs without an embedder
+// (proving the helper's main value proposition: cmd/packs can read an
+// artifact without paying the ~90MB MiniLM model download cost).
+func TestReadArtifactMeta(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "artifact.db")
+	writeFakeMeta(t, path, map[string]string{
+		metaKeyLibID:        "/modelcontextprotocol/go-sdk",
+		metaKeyEmbedderKind: "hugot",
+		metaKeyModelVersion: "sentence-transformers/all-MiniLM-L6-v2",
+		// schema_version + embedding_dim are intentionally NOT written;
+		// ReadArtifactMeta must not require them.
+	})
+
+	got, err := ReadArtifactMeta(path)
+	if err != nil {
+		t.Fatalf("ReadArtifactMeta: %v", err)
+	}
+	want := ArtifactMeta{
+		LibID:        "/modelcontextprotocol/go-sdk",
+		EmbedderKind: "hugot",
+		ModelVersion: "sentence-transformers/all-MiniLM-L6-v2",
+	}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+// TestReadArtifactMeta_PartialMetaIsTolerated covers the case where the
+// artifact's meta table has lib_id but is missing the embedder identity
+// keys. The reader should still succeed (with empty fields), so a future
+// scraper version that drops one of those keys doesn't break uploads.
+// The downstream Open call enforces the real embedder contract; this
+// helper is intentionally permissive.
+func TestReadArtifactMeta_PartialMetaIsTolerated(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "artifact.db")
+	writeFakeMeta(t, path, map[string]string{
+		metaKeyLibID: "/x/y",
+	})
+
+	got, err := ReadArtifactMeta(path)
+	if err != nil {
+		t.Fatalf("ReadArtifactMeta: %v", err)
+	}
+	if got.LibID != "/x/y" {
+		t.Errorf("LibID = %q, want %q", got.LibID, "/x/y")
+	}
+	if got.EmbedderKind != "" {
+		t.Errorf("EmbedderKind = %q, want empty", got.EmbedderKind)
+	}
+	if got.ModelVersion != "" {
+		t.Errorf("ModelVersion = %q, want empty", got.ModelVersion)
+	}
+}
+
+// TestReadArtifactMeta_MissingLibIDFails covers the structural-corruption
+// path: an artifact whose meta table exists but has no lib_id row is
+// malformed by construction (every artifact gets its lib_id stamped at
+// creation time, see OpenArtifact). The reader returns the same sentinel
+// the rest of the package uses so callers can handle both code paths
+// with one errors.Is check.
+func TestReadArtifactMeta_MissingLibIDFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "artifact.db")
+	writeFakeMeta(t, path, map[string]string{
+		metaKeyEmbedderKind: "hugot",
+		metaKeyModelVersion: "v1",
+	})
+
+	_, err := ReadArtifactMeta(path)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrArtifactLibIDMissing) {
+		t.Errorf("err = %v, want ErrArtifactLibIDMissing", err)
+	}
+}
+
+// writeFakeMeta builds a minimal artifact file by hand: a fresh turso
+// database containing only a meta table with the supplied rows. No
+// docs, no libs, no embedder. The file is created at path; t.TempDir
+// guarantees cleanup.
+func writeFakeMeta(t *testing.T, path string, rows map[string]string) {
+	t.Helper()
+	raw, err := sql.Open("turso", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer raw.Close()
+	raw.SetMaxOpenConns(1)
+
+	if _, err := raw.Exec(`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatalf("create meta: %v", err)
+	}
+	for k, v := range rows {
+		if _, err := raw.Exec(`INSERT INTO meta(key, value) VALUES (?, ?)`, k, v); err != nil {
+			t.Fatalf("insert %s: %v", k, err)
+		}
+	}
+}

--- a/internal/packs/download.go
+++ b/internal/packs/download.go
@@ -1,0 +1,278 @@
+package packs
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// Fetcher is the surface download.Run uses to pull asset bytes from a
+// release URL. The production implementation is httpFetcher; tests
+// substitute their own to avoid hitting the real internet.
+type Fetcher interface {
+	// Get returns a reader for the body at url. The reader's Close
+	// must be called by the caller. A non-2xx status returns an error
+	// — implementations are responsible for translating "404" into a
+	// useful message containing the URL.
+	Get(ctx context.Context, url string) (io.ReadCloser, error)
+}
+
+// FetcherFunc is the http.HandlerFunc-style adapter for Fetcher: it
+// lets a plain function be used wherever a Fetcher is required, which
+// is convenient in tests that need to redirect URLs through an
+// httptest.Server. Production callers use NewHTTPFetcher and never
+// need this adapter.
+type FetcherFunc func(ctx context.Context, url string) (io.ReadCloser, error)
+
+// Get satisfies the Fetcher interface by calling the underlying
+// function.
+func (f FetcherFunc) Get(ctx context.Context, url string) (io.ReadCloser, error) {
+	return f(ctx, url)
+}
+
+// DownloadOptions are the inputs to the download subcommand.
+type DownloadOptions struct {
+	// ArtifactsDir is where downloaded *.db files are placed. Created
+	// on demand if missing.
+	ArtifactsDir string
+	// ManifestPath is the source of truth for which assets to pull.
+	ManifestPath string
+	// Repo is the owner/name of the GitHub repository the release
+	// lives in. Resolved upstream by cmd/packs (flag overrides
+	// manifest `repo:` field which overrides DefaultRepo).
+	Repo string
+	// LibFilter, if non-empty, restricts the run to packs whose
+	// lib_id matches the two-level filter (exact match or /-bounded
+	// prefix). Empty = download every entry in the manifest.
+	LibFilter string
+	// Fetcher is injected by cmd/packs (production NewHTTPFetcher) or
+	// by tests. Required.
+	Fetcher Fetcher
+}
+
+// DownloadSummary is the operator-facing rollup the cmd logs at the
+// end of a download run. Counts are by manifest entry.
+type DownloadSummary struct {
+	// Downloaded is the number of fresh asset downloads (no local
+	// file existed).
+	Downloaded int
+	// Verified is the number of entries whose local file already
+	// existed and matched the manifest sha256 — zero network calls.
+	Verified int
+	// Redownloaded is the number of entries whose local file existed
+	// but had a sha256 mismatch (treated as disposable build output
+	// and silently re-fetched).
+	Redownloaded int
+}
+
+// RunDownload pulls every release asset referenced by the manifest into
+// ArtifactsDir, verifying sha256 on the way down. Tampering semantics
+// are asymmetric:
+//
+//   - Local file mismatch (artifacts/*.db modified by something else):
+//     log a `packs.verified_redownload` event and re-fetch silently.
+//     /artifacts/ is gitignored disposable build output, so silent
+//     repair is the right behaviour.
+//
+//   - Server-side mismatch (downloaded bytes don't match manifest):
+//     hard abort with a got/want error. This means either the release
+//     asset is corrupted or the manifest is stale, and silently
+//     overwriting a good local file with a bad one is the wrong fix.
+//
+// The function never moves a sha256-mismatched file into the canonical
+// path: streaming writes go to a sibling .tmp first, the hash is
+// verified before os.Rename, and a Ctrl-C mid-stream leaves only the
+// .tmp file (which the next run will clean up).
+func RunDownload(ctx context.Context, opts DownloadOptions) (DownloadSummary, error) {
+	if opts.Fetcher == nil {
+		return DownloadSummary{}, errors.New("download: Fetcher is required")
+	}
+	if opts.Repo == "" {
+		return DownloadSummary{}, errors.New("download: Repo is required")
+	}
+
+	manifest, err := Load(opts.ManifestPath)
+	if err != nil {
+		return DownloadSummary{}, fmt.Errorf("download: %w", err)
+	}
+
+	if err := os.MkdirAll(opts.ArtifactsDir, 0o755); err != nil {
+		return DownloadSummary{}, fmt.Errorf("download: create artifacts dir %s: %w", opts.ArtifactsDir, err)
+	}
+
+	target := manifest.FilterByLibID(opts.LibFilter)
+	if opts.LibFilter != "" && len(target) == 0 {
+		return DownloadSummary{}, fmt.Errorf("download: no manifest entries match -lib %q", opts.LibFilter)
+	}
+
+	var summary DownloadSummary
+	for _, p := range target {
+		assetPath := filepath.Join(opts.ArtifactsDir, p.Asset)
+		needsDownload := true
+		needsRedownloadLog := false
+
+		if _, err := os.Stat(assetPath); err == nil {
+			localHash, err := FileSHA256(assetPath)
+			if err != nil {
+				return summary, fmt.Errorf("download: hash existing %s: %w", assetPath, err)
+			}
+			if localHash == p.SHA256 {
+				slog.Info("packs.verified",
+					"lib_id", p.LibID,
+					"asset", p.Asset,
+					"sha256", p.SHA256,
+				)
+				summary.Verified++
+				needsDownload = false
+			} else {
+				slog.Info("packs.verified_redownload",
+					"lib_id", p.LibID,
+					"asset", p.Asset,
+					"want_sha256", p.SHA256,
+					"got_sha256", localHash,
+					"reason", "local_sha256_mismatch",
+				)
+				if err := os.Remove(assetPath); err != nil {
+					return summary, fmt.Errorf("download: remove tampered local %s: %w", assetPath, err)
+				}
+				needsRedownloadLog = true
+			}
+		} else if !os.IsNotExist(err) {
+			return summary, fmt.Errorf("download: stat %s: %w", assetPath, err)
+		}
+
+		if !needsDownload {
+			continue
+		}
+
+		url := assetURL(opts.Repo, manifest.ReleaseTag, p.Asset)
+		if err := streamToFileVerified(ctx, opts.Fetcher, url, assetPath, p.SHA256); err != nil {
+			return summary, fmt.Errorf("download %s: %w", p.LibID, err)
+		}
+
+		slog.Info("packs.downloaded",
+			"lib_id", p.LibID,
+			"asset", p.Asset,
+			"sha256", p.SHA256,
+			"size", p.Size,
+			"url", url,
+		)
+		if needsRedownloadLog {
+			summary.Redownloaded++
+		} else {
+			summary.Downloaded++
+		}
+	}
+
+	return summary, nil
+}
+
+// streamToFileVerified fetches url and streams the body into <dest>.tmp,
+// computing the sha256 in flight via io.MultiWriter, and ONLY renames
+// the temp file into the canonical dest after the hash matches
+// wantHash. The "verify before rename" ordering is the load-bearing
+// invariant: a hash mismatch leaves the canonical path untouched, so
+// a tampered release asset can never replace a known-good local file
+// even transiently. A Ctrl-C mid-stream leaves only a .tmp file (the
+// next run cleans it up by overwriting on its os.Create).
+//
+// Returns a wrapped error containing both the URL and the got/want
+// pair on a hash mismatch, since "the file you tried to download is
+// corrupt" is one of the few cases where the operator needs to take
+// action (typically: re-run scrape + upload to refresh the manifest).
+func streamToFileVerified(ctx context.Context, fetcher Fetcher, url, dest, wantHash string) error {
+	body, err := fetcher.Get(ctx, url)
+	if err != nil {
+		return fmt.Errorf("fetch %s: %w", url, err)
+	}
+	defer body.Close()
+
+	tmp := dest + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create tmp %s: %w", tmp, err)
+	}
+	// Best-effort cleanup if anything below this point fails (including
+	// the hash mismatch path). Ignore the error from a no-op Remove
+	// after a successful Rename — Rename will have removed the file.
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmp)
+		}
+	}()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(f, hasher), body); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("stream %s: %w", url, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close tmp %s: %w", tmp, err)
+	}
+
+	gotHash := hex.EncodeToString(hasher.Sum(nil))
+	if gotHash != wantHash {
+		// cleanup defer takes care of removing the .tmp; we never
+		// wrote anything to dest, so there is no canonical file to
+		// roll back. Error wording matches the operator-action
+		// guidance in the docstring above.
+		return fmt.Errorf("sha256 mismatch on %s: got %s, want %s", url, gotHash, wantHash)
+	}
+
+	if err := os.Rename(tmp, dest); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmp, dest, err)
+	}
+	cleanup = false
+	return nil
+}
+
+// assetURL builds the canonical public download URL for a release
+// asset. GitHub redirects this to objects.githubusercontent.com via
+// 302; net/http's default client follows the redirect transparently.
+// Kept as a helper so tests can swap in their own server with a
+// matching path layout.
+func assetURL(repo, tag, asset string) string {
+	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, tag, asset)
+}
+
+// httpFetcher is the production Fetcher implementation. It's a thin
+// wrapper around an http.Client so cmd/packs can pass a context-aware
+// client with sane defaults; tests build their own against
+// httptest.NewServer.
+type httpFetcher struct {
+	client *http.Client
+}
+
+// NewHTTPFetcher returns a production Fetcher backed by the supplied
+// client. Pass http.DefaultClient unless you specifically need a
+// non-default timeout or transport.
+func NewHTTPFetcher(client *http.Client) Fetcher {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &httpFetcher{client: client}
+}
+
+func (h *httpFetcher) Get(ctx context.Context, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("new request %s: %w", url, err)
+	}
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get %s: %w", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("get %s: status %d", url, resp.StatusCode)
+	}
+	return resp.Body, nil
+}

--- a/internal/packs/download_test.go
+++ b/internal/packs/download_test.go
@@ -1,0 +1,364 @@
+package packs_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/laradji/deadzone/internal/packs"
+)
+
+// fileServer spins up an httptest.Server that serves a fixed map of
+// {asset_name → bytes} via the same URL layout the GitHub release uses
+// (`/<owner>/<repo>/releases/download/<tag>/<asset>`). The handler also
+// records every request path so tests can assert "no extra HTTP calls
+// happened on the idempotent run".
+type fileServer struct {
+	t        *testing.T
+	server   *httptest.Server
+	files    map[string][]byte
+	requests []string
+}
+
+func newFileServer(t *testing.T, files map[string][]byte) *fileServer {
+	t.Helper()
+	fs := &fileServer{t: t, files: files}
+	fs.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fs.requests = append(fs.requests, r.URL.Path)
+		// /<owner>/<repo>/releases/download/<tag>/<asset>
+		parts := strings.Split(r.URL.Path, "/")
+		asset := parts[len(parts)-1]
+		body, ok := fs.files[asset]
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(fs.server.Close)
+	return fs
+}
+
+// fetcherFor returns a packs.Fetcher that rewrites the canonical
+// github.com URL to point at the in-test httptest.Server. This is the
+// minimal seam needed to test the download path without monkey-patching
+// the URL builder; the production assetURL stays canonical and tests
+// inject their own Fetcher.
+func (fs *fileServer) fetcherFor(t *testing.T) packs.Fetcher {
+	t.Helper()
+	return packs.FetcherFunc(func(ctx context.Context, url string) (io.ReadCloser, error) {
+		// Replace the github.com prefix with our test server prefix.
+		const prefix = "https://github.com"
+		if !strings.HasPrefix(url, prefix) {
+			return nil, fmt.Errorf("unexpected URL %q", url)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fs.server.URL+strings.TrimPrefix(url, prefix), nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := fs.server.Client().Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("status %d for %s", resp.StatusCode, url)
+		}
+		return resp.Body, nil
+	})
+}
+
+func sha256Hex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// writeManifestWithPacks writes a manifest with one entry per supplied
+// asset (using its sha256 + length) into a fresh dir alongside an
+// empty artifacts subdirectory. Returns (artifactsDir, manifestPath).
+func writeManifestWithPacks(t *testing.T, files map[string][]byte) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	artifactsDir := filepath.Join(dir, "artifacts")
+	if err := os.MkdirAll(artifactsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	body := "release_tag: packs\nrepo: laradji/deadzone-test\npacks:\n"
+	for name, contents := range files {
+		// derive lib_id from filename: foo_bar.db → /foo/bar
+		stem := strings.TrimSuffix(name, ".db")
+		libID := "/" + strings.ReplaceAll(stem, "_", "/")
+		body += fmt.Sprintf(
+			"  - lib_id: %s\n    asset: %s\n    sha256: %s\n    size: %d\n    indexed_at: 2026-04-10T16:23:00Z\n",
+			libID, name, sha256Hex(contents), len(contents),
+		)
+	}
+	manifestPath := filepath.Join(artifactsDir, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return artifactsDir, manifestPath
+}
+
+func TestDownload_FreshClone(t *testing.T) {
+	files := map[string][]byte{
+		"x_y.db": []byte("body-of-x-y"),
+		"a_b.db": []byte("body-of-a-b"),
+	}
+	fs := newFileServer(t, files)
+	artifactsDir, manifestPath := writeManifestWithPacks(t, files)
+
+	summary, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: artifactsDir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		Fetcher:      fs.fetcherFor(t),
+	})
+	if err != nil {
+		t.Fatalf("RunDownload: %v", err)
+	}
+	if summary.Downloaded != 2 || summary.Verified != 0 || summary.Redownloaded != 0 {
+		t.Errorf("summary = %+v, want Downloaded:2", summary)
+	}
+	for name, want := range files {
+		got, err := os.ReadFile(filepath.Join(artifactsDir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("%s contents = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestDownload_AlreadyPresentSkipsHTTP(t *testing.T) {
+	files := map[string][]byte{
+		"x_y.db": []byte("body-of-x-y"),
+	}
+	fs := newFileServer(t, files)
+	artifactsDir, manifestPath := writeManifestWithPacks(t, files)
+
+	// Pre-populate the canonical file with the right contents.
+	if err := os.WriteFile(filepath.Join(artifactsDir, "x_y.db"), files["x_y.db"], 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	summary, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: artifactsDir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		Fetcher:      fs.fetcherFor(t),
+	})
+	if err != nil {
+		t.Fatalf("RunDownload: %v", err)
+	}
+	if summary.Verified != 1 || summary.Downloaded != 0 {
+		t.Errorf("summary = %+v, want Verified:1", summary)
+	}
+	if len(fs.requests) != 0 {
+		t.Errorf("HTTP requests issued on verified-only run: %v", fs.requests)
+	}
+}
+
+func TestDownload_TamperedLocalIsRedownloaded(t *testing.T) {
+	files := map[string][]byte{
+		"x_y.db": []byte("body-of-x-y"),
+	}
+	fs := newFileServer(t, files)
+	artifactsDir, manifestPath := writeManifestWithPacks(t, files)
+
+	// Plant a tampered version on disk.
+	tamperedPath := filepath.Join(artifactsDir, "x_y.db")
+	if err := os.WriteFile(tamperedPath, []byte("THIS IS THE WRONG CONTENT"), 0o600); err != nil {
+		t.Fatalf("seed tampered: %v", err)
+	}
+
+	summary, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: artifactsDir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		Fetcher:      fs.fetcherFor(t),
+	})
+	if err != nil {
+		t.Fatalf("RunDownload: %v", err)
+	}
+	if summary.Redownloaded != 1 {
+		t.Errorf("summary = %+v, want Redownloaded:1", summary)
+	}
+	got, err := os.ReadFile(tamperedPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "body-of-x-y" {
+		t.Errorf("post-redownload contents = %q, want body-of-x-y", got)
+	}
+}
+
+func TestDownload_TamperedServerHardAborts(t *testing.T) {
+	manifestFiles := map[string][]byte{
+		"x_y.db": []byte("body-of-x-y"),
+	}
+	// Server has DIFFERENT bytes for the same asset name → mismatch.
+	serverFiles := map[string][]byte{
+		"x_y.db": []byte("server-side-corruption"),
+	}
+	fs := newFileServer(t, serverFiles)
+	artifactsDir, manifestPath := writeManifestWithPacks(t, manifestFiles)
+
+	_, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: artifactsDir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		Fetcher:      fs.fetcherFor(t),
+	})
+	if err == nil {
+		t.Fatal("expected hard-abort error, got nil")
+	}
+	if !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Errorf("err = %v, want sha256 mismatch", err)
+	}
+
+	// Canonical file should NOT exist (verify-before-rename invariant).
+	if _, statErr := os.Stat(filepath.Join(artifactsDir, "x_y.db")); !os.IsNotExist(statErr) {
+		t.Error("canonical x_y.db exists after server-side mismatch — verify-before-rename invariant violated")
+	}
+	// And no .tmp leftover.
+	if _, statErr := os.Stat(filepath.Join(artifactsDir, "x_y.db.tmp")); !os.IsNotExist(statErr) {
+		t.Error(".tmp file leaked after server-side mismatch")
+	}
+}
+
+func TestDownload_TamperedServerDoesNotOverwriteGoodLocal(t *testing.T) {
+	// This is the asymmetric-tampering safety net: the local file is
+	// good, but for some reason the verifier needed to re-check the
+	// server, and the server returns garbage. The good local file
+	// must survive untouched. We construct this by tampering the
+	// local file (so the verifier triggers a redownload) AND also
+	// tampering the server (so the redownload mismatches). The hard
+	// abort runs, and... the local file is still bad (we removed it).
+	//
+	// This is fine: the contract is "good local file is preserved
+	// when there's no reason to touch it" and "tampered local file
+	// gets blown away on the off-chance the redownload succeeds".
+	// The test below covers the verify-before-rename half. Skipped
+	// — left as a comment so future readers don't add it back.
+	t.Skip("see comment — covered by TestDownload_TamperedServerHardAborts")
+}
+
+func TestDownload_LibFilterMatchesVersionedChildren(t *testing.T) {
+	files := map[string][]byte{
+		"facebook_react_v18.db": []byte("react-18"),
+		"facebook_react_v19.db": []byte("react-19"),
+		"unrelated_lib.db":      []byte("unrelated"),
+	}
+	fs := newFileServer(t, files)
+	artifactsDir, manifestPath := writeManifestWithPacks(t, files)
+
+	summary, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: artifactsDir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		LibFilter:    "/facebook/react",
+		Fetcher:      fs.fetcherFor(t),
+	})
+	if err != nil {
+		t.Fatalf("RunDownload: %v", err)
+	}
+	if summary.Downloaded != 2 {
+		t.Errorf("Downloaded = %d, want 2 (both versioned children)", summary.Downloaded)
+	}
+	if _, err := os.Stat(filepath.Join(artifactsDir, "unrelated_lib.db")); !os.IsNotExist(err) {
+		t.Error("unrelated_lib.db was downloaded despite the filter")
+	}
+}
+
+func TestDownload_LibFilterExactMatch(t *testing.T) {
+	files := map[string][]byte{
+		"facebook_react_v18.db": []byte("react-18"),
+		"facebook_react_v19.db": []byte("react-19"),
+	}
+	fs := newFileServer(t, files)
+	artifactsDir, manifestPath := writeManifestWithPacks(t, files)
+
+	summary, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: artifactsDir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		LibFilter:    "/facebook/react/v18",
+		Fetcher:      fs.fetcherFor(t),
+	})
+	if err != nil {
+		t.Fatalf("RunDownload: %v", err)
+	}
+	if summary.Downloaded != 1 {
+		t.Errorf("Downloaded = %d, want 1", summary.Downloaded)
+	}
+}
+
+func TestDownload_LibFilterNoMatchErrors(t *testing.T) {
+	files := map[string][]byte{
+		"x_y.db": []byte("payload"),
+	}
+	fs := newFileServer(t, files)
+	artifactsDir, manifestPath := writeManifestWithPacks(t, files)
+
+	_, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: artifactsDir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		LibFilter:    "/totally/missing",
+		Fetcher:      fs.fetcherFor(t),
+	})
+	if err == nil || !strings.Contains(err.Error(), "no manifest entries match") {
+		t.Errorf("err = %v, want no-match error", err)
+	}
+}
+
+func TestDownload_MissingAssetOnServerErrors(t *testing.T) {
+	manifestFiles := map[string][]byte{
+		"x_y.db": []byte("body"),
+	}
+	// Server is empty.
+	fs := newFileServer(t, map[string][]byte{})
+	artifactsDir, manifestPath := writeManifestWithPacks(t, manifestFiles)
+
+	_, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: artifactsDir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		Fetcher:      fs.fetcherFor(t),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing asset, got nil")
+	}
+}
+
+func TestDownload_RequiresFetcher(t *testing.T) {
+	_, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: "any", ManifestPath: "any", Repo: "x/y",
+	})
+	if err == nil || !errors.Is(err, errors.New("download: Fetcher is required")) && !strings.Contains(err.Error(), "Fetcher is required") {
+		t.Errorf("err = %v, want Fetcher required", err)
+	}
+}
+
+func TestDownload_RequiresRepo(t *testing.T) {
+	_, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: "any", ManifestPath: "any", Fetcher: packs.FetcherFunc(func(context.Context, string) (io.ReadCloser, error) {
+			return nil, nil
+		}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "Repo is required") {
+		t.Errorf("err = %v, want Repo required", err)
+	}
+}

--- a/internal/packs/filter.go
+++ b/internal/packs/filter.go
@@ -1,0 +1,26 @@
+package packs
+
+import "strings"
+
+// matchLibID is the two-level filter shared by `packs download -lib X`
+// and `packs list -lib X`. It mirrors the scraper's behaviour from
+// internal/scraper/config.go: an exact match returns true, and a base
+// lib_id matches every versioned child by treating the filter as a
+// /-suffixed prefix.
+//
+//	matchLibID("/x/y",     "/x/y")    → true
+//	matchLibID("/x/y/v1",  "/x/y")    → true   (versioned child)
+//	matchLibID("/x/y/v18", "/x/y")    → true
+//	matchLibID("/x/yother","/x/y")    → false  (NOT a /-bounded prefix)
+//	matchLibID("/x/y",     "")        → caller's job; this fn assumes
+//	                                    the empty filter is handled
+//	                                    upstream by FilterByLibID
+//
+// Lives in its own file so cmd/packs and any future tooling can call
+// it without depending on the Manifest type.
+func matchLibID(libID, filter string) bool {
+	if libID == filter {
+		return true
+	}
+	return strings.HasPrefix(libID, filter+"/")
+}

--- a/internal/packs/filter_test.go
+++ b/internal/packs/filter_test.go
@@ -1,0 +1,31 @@
+package packs
+
+import "testing"
+
+// matchLibID is unexported, so this test sits in the same package
+// (no _test suffix) to exercise it directly. The same scenarios are
+// covered indirectly by TestFilterByLibID in manifest_test.go, but
+// having a unit-level test makes regression triage faster.
+func TestMatchLibID(t *testing.T) {
+	cases := []struct {
+		libID  string
+		filter string
+		want   bool
+		why    string
+	}{
+		{"/x/y", "/x/y", true, "exact match"},
+		{"/x/y/v1", "/x/y", true, "versioned child of base"},
+		{"/x/y/v18", "/x/y", true, "second versioned child"},
+		{"/x/y", "/x/y/v1", false, "base does not match versioned filter"},
+		{"/x/yother", "/x/y", false, "prefix that is NOT /-bounded"},
+		{"/x/y/sub/deeper", "/x/y", true, "/-bounded prefix at any depth"},
+		{"/totally/different", "/x/y", false, "unrelated"},
+		{"/x/y", "/x/y/", false, "trailing slash filter is not normalized"},
+	}
+	for _, c := range cases {
+		got := matchLibID(c.libID, c.filter)
+		if got != c.want {
+			t.Errorf("matchLibID(%q, %q) = %v, want %v (%s)", c.libID, c.filter, got, c.want, c.why)
+		}
+	}
+}

--- a/internal/packs/list.go
+++ b/internal/packs/list.go
@@ -1,0 +1,52 @@
+package packs
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+)
+
+// ListOptions is the input to the list subcommand.
+type ListOptions struct {
+	// ManifestPath is the manifest to print. The other ListOptions
+	// fields are reserved for future filtering — kept as a struct so
+	// adding `-lib` later doesn't break the call signature.
+	ManifestPath string
+}
+
+// RunList prints the manifest as a tabwriter table to w. The output is
+// optimized for human eyeballing on a terminal: columns are LIB_ID,
+// ASSET, SIZE, SHA256 (12-char prefix), INDEXED_AT (RFC3339).
+//
+// Stdout vs. stderr separation: cmd/packs sends list output to stdout
+// while logs go to stderr (same convention as the rest of the binaries
+// — stderr is structured, stdout is human-facing).
+func RunList(opts ListOptions, w io.Writer) error {
+	manifest, err := Load(opts.ManifestPath)
+	if err != nil {
+		return fmt.Errorf("list: %w", err)
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "LIB_ID\tASSET\tSIZE\tSHA256\tINDEXED_AT")
+	for _, p := range manifest.Packs {
+		short := p.SHA256
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n",
+			p.LibID,
+			p.Asset,
+			p.Size,
+			short,
+			p.IndexedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		)
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("list: flush: %w", err)
+	}
+	if len(manifest.Packs) == 0 {
+		fmt.Fprintln(w, "(no packs in manifest)")
+	}
+	return nil
+}

--- a/internal/packs/list_test.go
+++ b/internal/packs/list_test.go
@@ -1,0 +1,43 @@
+package packs_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/laradji/deadzone/internal/packs"
+)
+
+func TestList_PrintsHeaderAndRows(t *testing.T) {
+	manifestPath := writeManifest(t, validPackYAML)
+
+	var buf bytes.Buffer
+	if err := packs.RunList(packs.ListOptions{ManifestPath: manifestPath}, &buf); err != nil {
+		t.Fatalf("RunList: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "LIB_ID") || !strings.Contains(out, "ASSET") || !strings.Contains(out, "SHA256") {
+		t.Errorf("missing header columns:\n%s", out)
+	}
+	if !strings.Contains(out, "/modelcontextprotocol/go-sdk") {
+		t.Errorf("missing data row:\n%s", out)
+	}
+	// SHA256 prefix should be the first 12 chars (9f2e8c4b1a0d), not the full 64.
+	if !strings.Contains(out, "9f2e8c4b1a0d") {
+		t.Errorf("missing 12-char sha256 prefix:\n%s", out)
+	}
+	if strings.Contains(out, "9f2e8c4b1a0d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f") {
+		t.Errorf("full sha256 leaked into output instead of prefix:\n%s", out)
+	}
+}
+
+func TestList_EmptyManifest(t *testing.T) {
+	manifestPath := writeManifest(t, "release_tag: packs\nrepo: laradji/deadzone\npacks: []\n")
+	var buf bytes.Buffer
+	if err := packs.RunList(packs.ListOptions{ManifestPath: manifestPath}, &buf); err != nil {
+		t.Fatalf("RunList: %v", err)
+	}
+	if !strings.Contains(buf.String(), "(no packs in manifest)") {
+		t.Errorf("expected empty marker, got:\n%s", buf.String())
+	}
+}

--- a/internal/packs/manifest.go
+++ b/internal/packs/manifest.go
@@ -1,0 +1,261 @@
+// Package packs implements the distribution layer for per-lib artifact
+// .db files: it uploads them to a rolling GitHub Release and downloads
+// them back on a fresh clone, with sha256 verification on both sides.
+//
+// The package is the implementation of issue #30. It exposes three
+// top-level entry points (one per cmd/packs subcommand):
+//
+//   - upload.Run: shell out to `gh release upload <tag> <file> --clobber`
+//     for every locally-changed artifact and rewrite the manifest file.
+//   - download.Run: HTTP GET each release asset referenced by the
+//     manifest, verify its sha256, drop it into ./artifacts.
+//   - list.Run: pretty-print the manifest as a tabwriter table.
+//
+// The Manifest YAML schema lives in this file because it is the data
+// contract shared by all three subcommands and is the one piece of the
+// system that is committed to git.
+package packs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultRepo is the upstream repository the manifest defaults to when
+// neither the manifest's `repo:` field nor the -repo CLI flag is set.
+// Forks override either of those two; the constant exists so the
+// "no manifest, no flag" first-time-use path still produces a usable
+// download URL.
+const DefaultRepo = "laradji/deadzone"
+
+// DefaultReleaseTag is the rolling tag the upload command uses on a
+// brand-new manifest. Mirrors the "rolling vs. versioned" decision in
+// issue #30 — there is one release, named `packs`, that gets clobbered
+// in place.
+const DefaultReleaseTag = "packs"
+
+// sha256HexRE matches a 64-character hex string. Validation rejects
+// anything else in the manifest's sha256 field, catching the "someone
+// hand-edited it" failure mode at load time instead of at download
+// time.
+var sha256HexRE = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// Pack is a single entry in the manifest. Field order is preserved on
+// round-trip via the yaml.v3 struct tag declaration order; the package
+// always serializes lib_id first so the YAML diffs in PRs are easy to
+// read.
+type Pack struct {
+	LibID               string    `yaml:"lib_id"`
+	Asset               string    `yaml:"asset"`
+	SHA256              string    `yaml:"sha256"`
+	Size                int64     `yaml:"size"`
+	IndexedAt           time.Time `yaml:"indexed_at"`
+	ScrapedWithEmbedder string    `yaml:"scraped_with_embedder,omitempty"`
+	ScrapedWithModel    string    `yaml:"scraped_with_model,omitempty"`
+}
+
+// Manifest is the parsed artifacts/manifest.yaml. ReleaseTag is the
+// rolling tag attached to the GitHub Release that holds the assets;
+// Repo is the optional `owner/name` default for downloads (the -repo
+// CLI flag overrides it at runtime); Packs is the list of currently-
+// canonical per-lib artifacts.
+type Manifest struct {
+	ReleaseTag string `yaml:"release_tag"`
+	Repo       string `yaml:"repo,omitempty"`
+	Packs      []Pack `yaml:"packs"`
+}
+
+// Load reads, parses, and validates a manifest file at path. Validation
+// runs at load time so a malformed manifest fails the run upfront with
+// a single error rather than mid-loop with a partial result.
+//
+// A manifest file with no entries (`packs: []`) is valid and useful —
+// it's the placeholder shape committed before the first real upload.
+// A manifest with no `release_tag` is rejected because every download
+// URL needs one; the upload path defaults to DefaultReleaseTag when
+// constructing a brand-new manifest, so the file on disk always has it.
+func Load(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("load manifest %s: %w", path, err)
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse manifest %s: %w", path, err)
+	}
+	if err := m.validate(); err != nil {
+		return nil, fmt.Errorf("manifest %s: %w", path, err)
+	}
+	return &m, nil
+}
+
+// validate enforces the schema rules:
+//
+//   - release_tag is non-empty
+//   - every Pack has a non-empty lib_id starting with "/"
+//   - every Pack has a non-empty asset filename
+//   - every Pack has a 64-char hex sha256
+//   - every Pack has a positive size
+//   - every Pack has a non-zero indexed_at timestamp
+//   - lib_id is unique across all Packs
+//   - asset is unique across all Packs
+//
+// Embedder identity fields (scraped_with_embedder, scraped_with_model)
+// are intentionally optional — they're informational, not load-bearing,
+// and a manifest produced before #30 added them should still parse.
+func (m *Manifest) validate() error {
+	if strings.TrimSpace(m.ReleaseTag) == "" {
+		return errors.New("release_tag is required")
+	}
+	seenLibID := map[string]int{}
+	seenAsset := map[string]int{}
+	for i, p := range m.Packs {
+		if p.LibID == "" {
+			return fmt.Errorf("packs[%d]: lib_id is required", i)
+		}
+		if !strings.HasPrefix(p.LibID, "/") {
+			return fmt.Errorf("packs[%d] (%q): lib_id must start with %q", i, p.LibID, "/")
+		}
+		if p.Asset == "" {
+			return fmt.Errorf("packs[%d] (%q): asset is required", i, p.LibID)
+		}
+		if !sha256HexRE.MatchString(p.SHA256) {
+			return fmt.Errorf("packs[%d] (%q): sha256 %q is not a 64-char hex string", i, p.LibID, p.SHA256)
+		}
+		if p.Size <= 0 {
+			return fmt.Errorf("packs[%d] (%q): size must be > 0, got %d", i, p.LibID, p.Size)
+		}
+		if p.IndexedAt.IsZero() {
+			return fmt.Errorf("packs[%d] (%q): indexed_at is required", i, p.LibID)
+		}
+		if prev, dup := seenLibID[p.LibID]; dup {
+			return fmt.Errorf("packs[%d]: duplicate lib_id %q (also at packs[%d])", i, p.LibID, prev)
+		}
+		if prev, dup := seenAsset[p.Asset]; dup {
+			return fmt.Errorf("packs[%d] (%q): duplicate asset %q (also at packs[%d])", i, p.LibID, p.Asset, prev)
+		}
+		seenLibID[p.LibID] = i
+		seenAsset[p.Asset] = i
+	}
+	return nil
+}
+
+// Save writes the manifest to path atomically via a temp-file-and-rename
+// dance. The temp file lives in the same directory as the destination so
+// os.Rename is a true atomic-on-success move (cross-filesystem renames
+// are not, on most Unix variants). On any failure between Write and
+// Rename, the destination file remains untouched.
+//
+// The serialized output is normalized: packs are sorted by lib_id so
+// the manifest's git diff is stable across runs regardless of the
+// scraper's filesystem walk order. yaml.v3's Encoder uses 2-space
+// indentation, which matches the rest of the project's YAML conventions.
+func (m *Manifest) Save(path string) error {
+	if err := m.validate(); err != nil {
+		return fmt.Errorf("save manifest %s: %w", path, err)
+	}
+
+	// Local copy with sorted packs so the on-disk byte stream is
+	// deterministic; the in-memory Manifest stays untouched in case the
+	// caller still has references to specific Pack indices.
+	out := *m
+	out.Packs = append([]Pack(nil), m.Packs...)
+	sortPacksByLibID(out.Packs)
+
+	data, err := yaml.Marshal(out)
+	if err != nil {
+		return fmt.Errorf("marshal manifest %s: %w", path, err)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".manifest-*.yaml.tmp")
+	if err != nil {
+		return fmt.Errorf("create tmp manifest in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup of the temp file on any failure path that
+	// doesn't reach the successful Rename. Ignore the error from a
+	// double-Remove because Rename consumed the original.
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write tmp manifest %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close tmp manifest %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, path, err)
+	}
+	return nil
+}
+
+// Find returns the Pack with the given lib_id, its index, and a found
+// flag. The pointer aliases the slice element so callers can mutate
+// in-place; this is intentional for the upload path which preserves
+// the existing IndexedAt verbatim on a sha256 match.
+func (m *Manifest) Find(libID string) (*Pack, int, bool) {
+	for i := range m.Packs {
+		if m.Packs[i].LibID == libID {
+			return &m.Packs[i], i, true
+		}
+	}
+	return nil, -1, false
+}
+
+// Replace inserts or updates a Pack by lib_id. New entries are appended;
+// existing entries are overwritten in place. Order of existing entries
+// is preserved so the on-disk diff stays minimal (Save sorts on output).
+func (m *Manifest) Replace(p Pack) {
+	for i := range m.Packs {
+		if m.Packs[i].LibID == p.LibID {
+			m.Packs[i] = p
+			return
+		}
+	}
+	m.Packs = append(m.Packs, p)
+}
+
+// FilterByLibID returns the packs whose lib_id matches the filter. An
+// empty filter matches everything; otherwise the matcher follows the
+// scraper's two-level rule (LibID == filter || LibID has filter as a
+// /-suffixed prefix), so passing a base lib_id matches every versioned
+// child.
+func (m *Manifest) FilterByLibID(filter string) []Pack {
+	if filter == "" {
+		return append([]Pack(nil), m.Packs...)
+	}
+	var out []Pack
+	for _, p := range m.Packs {
+		if matchLibID(p.LibID, filter) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// sortPacksByLibID sorts in lexicographic order on lib_id. Used by Save
+// to produce a stable on-disk byte stream so manifest diffs in PRs only
+// reflect actual content changes, never the scraper's walk order. Kept
+// as a helper rather than inlined so tests can independently exercise
+// it.
+func sortPacksByLibID(p []Pack) {
+	// Manual insertion sort — avoids importing sort just for this and
+	// is fastest for the small (~100 entries) sizes the manifest will
+	// see in practice.
+	for i := 1; i < len(p); i++ {
+		j := i
+		for j > 0 && p[j-1].LibID > p[j].LibID {
+			p[j-1], p[j] = p[j], p[j-1]
+			j--
+		}
+	}
+}

--- a/internal/packs/manifest_test.go
+++ b/internal/packs/manifest_test.go
@@ -1,0 +1,323 @@
+package packs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/laradji/deadzone/internal/packs"
+)
+
+// validPackYAML is a fixture body for a single well-formed pack entry.
+// Reused by every "happy path" test below.
+const validPackYAML = `release_tag: packs
+repo: laradji/deadzone
+packs:
+  - lib_id: /modelcontextprotocol/go-sdk
+    asset: modelcontextprotocol_go-sdk.db
+    sha256: 9f2e8c4b1a0d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f
+    size: 152834
+    indexed_at: 2026-04-10T16:23:00Z
+    scraped_with_embedder: hugot
+    scraped_with_model: sentence-transformers/all-MiniLM-L6-v2
+`
+
+func writeManifest(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return path
+}
+
+func TestLoad_ValidSinglePack(t *testing.T) {
+	m, err := packs.Load(writeManifest(t, validPackYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.ReleaseTag != "packs" {
+		t.Errorf("ReleaseTag = %q, want %q", m.ReleaseTag, "packs")
+	}
+	if m.Repo != "laradji/deadzone" {
+		t.Errorf("Repo = %q, want %q", m.Repo, "laradji/deadzone")
+	}
+	if len(m.Packs) != 1 {
+		t.Fatalf("len(Packs) = %d, want 1", len(m.Packs))
+	}
+	got := m.Packs[0]
+	if got.LibID != "/modelcontextprotocol/go-sdk" {
+		t.Errorf("LibID = %q", got.LibID)
+	}
+	if got.Asset != "modelcontextprotocol_go-sdk.db" {
+		t.Errorf("Asset = %q", got.Asset)
+	}
+	if got.Size != 152834 {
+		t.Errorf("Size = %d", got.Size)
+	}
+	wantTime := time.Date(2026, 4, 10, 16, 23, 0, 0, time.UTC)
+	if !got.IndexedAt.Equal(wantTime) {
+		t.Errorf("IndexedAt = %v, want %v", got.IndexedAt, wantTime)
+	}
+}
+
+func TestLoad_EmptyPacksIsValid(t *testing.T) {
+	m, err := packs.Load(writeManifest(t, "release_tag: packs\nrepo: laradji/deadzone\npacks: []\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(m.Packs) != 0 {
+		t.Errorf("len(Packs) = %d, want 0", len(m.Packs))
+	}
+}
+
+func TestLoad_RejectsMissingReleaseTag(t *testing.T) {
+	_, err := packs.Load(writeManifest(t, "packs: []\n"))
+	if err == nil || !strings.Contains(err.Error(), "release_tag") {
+		t.Fatalf("got %v, want error mentioning release_tag", err)
+	}
+}
+
+func TestLoad_RejectsBadSHA256(t *testing.T) {
+	bad := strings.Replace(validPackYAML, "9f2e8c4b1a0d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f", "deadbeef", 1)
+	_, err := packs.Load(writeManifest(t, bad))
+	if err == nil || !strings.Contains(err.Error(), "sha256") {
+		t.Fatalf("got %v, want sha256 validation error", err)
+	}
+}
+
+func TestLoad_RejectsZeroSize(t *testing.T) {
+	bad := strings.Replace(validPackYAML, "size: 152834", "size: 0", 1)
+	_, err := packs.Load(writeManifest(t, bad))
+	if err == nil || !strings.Contains(err.Error(), "size") {
+		t.Fatalf("got %v, want size validation error", err)
+	}
+}
+
+func TestLoad_RejectsLibIDWithoutSlash(t *testing.T) {
+	bad := strings.Replace(validPackYAML, "/modelcontextprotocol/go-sdk", "modelcontextprotocol/go-sdk", 1)
+	_, err := packs.Load(writeManifest(t, bad))
+	if err == nil || !strings.Contains(err.Error(), `must start with "/"`) {
+		t.Fatalf("got %v, want lib_id slash error", err)
+	}
+}
+
+func TestLoad_RejectsDuplicateLibID(t *testing.T) {
+	dup := `release_tag: packs
+packs:
+  - lib_id: /x/y
+    asset: x_y.db
+    sha256: 0000000000000000000000000000000000000000000000000000000000000001
+    size: 1
+    indexed_at: 2026-04-10T16:23:00Z
+  - lib_id: /x/y
+    asset: x_y_v2.db
+    sha256: 0000000000000000000000000000000000000000000000000000000000000002
+    size: 2
+    indexed_at: 2026-04-10T16:23:00Z
+`
+	_, err := packs.Load(writeManifest(t, dup))
+	if err == nil || !strings.Contains(err.Error(), "duplicate lib_id") {
+		t.Fatalf("got %v, want duplicate lib_id error", err)
+	}
+}
+
+func TestLoad_RejectsDuplicateAsset(t *testing.T) {
+	dup := `release_tag: packs
+packs:
+  - lib_id: /a/one
+    asset: same.db
+    sha256: 0000000000000000000000000000000000000000000000000000000000000001
+    size: 1
+    indexed_at: 2026-04-10T16:23:00Z
+  - lib_id: /a/two
+    asset: same.db
+    sha256: 0000000000000000000000000000000000000000000000000000000000000002
+    size: 2
+    indexed_at: 2026-04-10T16:23:00Z
+`
+	_, err := packs.Load(writeManifest(t, dup))
+	if err == nil || !strings.Contains(err.Error(), "duplicate asset") {
+		t.Fatalf("got %v, want duplicate asset error", err)
+	}
+}
+
+func TestSaveLoad_RoundTripSortsPacks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.yaml")
+
+	m := &packs.Manifest{
+		ReleaseTag: "packs",
+		Repo:       "laradji/deadzone",
+		Packs: []packs.Pack{
+			// Intentionally out of order so we can verify Save sorts.
+			{
+				LibID:     "/zzz/last",
+				Asset:     "zzz_last.db",
+				SHA256:    "0000000000000000000000000000000000000000000000000000000000000003",
+				Size:      3,
+				IndexedAt: time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC),
+			},
+			{
+				LibID:     "/aaa/first",
+				Asset:     "aaa_first.db",
+				SHA256:    "0000000000000000000000000000000000000000000000000000000000000001",
+				Size:      1,
+				IndexedAt: time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	if err := m.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := packs.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Packs) != 2 {
+		t.Fatalf("len(Packs) = %d, want 2", len(loaded.Packs))
+	}
+	// First entry on disk should be the lex-smallest lib_id.
+	if loaded.Packs[0].LibID != "/aaa/first" {
+		t.Errorf("Packs[0].LibID = %q, want /aaa/first", loaded.Packs[0].LibID)
+	}
+	if loaded.Packs[1].LibID != "/zzz/last" {
+		t.Errorf("Packs[1].LibID = %q, want /zzz/last", loaded.Packs[1].LibID)
+	}
+
+	// And that no temp file leaked.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("temp file leaked: %s", e.Name())
+		}
+	}
+}
+
+func TestSave_RefusesInvalidManifest(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.yaml")
+	m := &packs.Manifest{ReleaseTag: ""} // missing release_tag
+	if err := m.Save(path); err == nil {
+		t.Fatal("Save accepted manifest with empty release_tag")
+	}
+}
+
+func TestFind(t *testing.T) {
+	m, err := packs.Load(writeManifest(t, validPackYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got, idx, ok := m.Find("/modelcontextprotocol/go-sdk")
+	if !ok {
+		t.Fatal("Find returned ok=false")
+	}
+	if idx != 0 {
+		t.Errorf("idx = %d, want 0", idx)
+	}
+	if got.LibID != "/modelcontextprotocol/go-sdk" {
+		t.Errorf("LibID = %q", got.LibID)
+	}
+
+	if _, _, ok := m.Find("/missing/lib"); ok {
+		t.Error("Find of missing lib returned ok=true")
+	}
+}
+
+func TestReplace_Updates(t *testing.T) {
+	m, err := packs.Load(writeManifest(t, validPackYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	updated := m.Packs[0]
+	updated.SHA256 = "1111111111111111111111111111111111111111111111111111111111111111"
+	updated.Size = 999
+	m.Replace(updated)
+	if len(m.Packs) != 1 {
+		t.Errorf("len(Packs) = %d, want 1 (Replace should update in place)", len(m.Packs))
+	}
+	if m.Packs[0].Size != 999 {
+		t.Errorf("Size = %d, want 999", m.Packs[0].Size)
+	}
+}
+
+func TestReplace_Appends(t *testing.T) {
+	m, err := packs.Load(writeManifest(t, validPackYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	m.Replace(packs.Pack{
+		LibID:     "/new/lib",
+		Asset:     "new_lib.db",
+		SHA256:    "2222222222222222222222222222222222222222222222222222222222222222",
+		Size:      42,
+		IndexedAt: time.Now().UTC(),
+	})
+	if len(m.Packs) != 2 {
+		t.Errorf("len(Packs) = %d, want 2", len(m.Packs))
+	}
+}
+
+func TestFilterByLibID(t *testing.T) {
+	multi := `release_tag: packs
+packs:
+  - lib_id: /facebook/react/v18
+    asset: facebook_react_v18.db
+    sha256: 0000000000000000000000000000000000000000000000000000000000000001
+    size: 1
+    indexed_at: 2026-04-10T16:23:00Z
+  - lib_id: /facebook/react/v19
+    asset: facebook_react_v19.db
+    sha256: 0000000000000000000000000000000000000000000000000000000000000002
+    size: 2
+    indexed_at: 2026-04-10T16:23:00Z
+  - lib_id: /facebook/reactother
+    asset: facebook_reactother.db
+    sha256: 0000000000000000000000000000000000000000000000000000000000000003
+    size: 3
+    indexed_at: 2026-04-10T16:23:00Z
+  - lib_id: /unrelated/lib
+    asset: unrelated_lib.db
+    sha256: 0000000000000000000000000000000000000000000000000000000000000004
+    size: 4
+    indexed_at: 2026-04-10T16:23:00Z
+`
+	m, err := packs.Load(writeManifest(t, multi))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Empty filter → all packs.
+	if got := m.FilterByLibID(""); len(got) != 4 {
+		t.Errorf("FilterByLibID(\"\") returned %d packs, want 4", len(got))
+	}
+
+	// Base lib_id matches both versioned children but NOT /facebook/reactother.
+	got := m.FilterByLibID("/facebook/react")
+	if len(got) != 2 {
+		t.Errorf("FilterByLibID(/facebook/react) returned %d packs, want 2", len(got))
+	}
+	for _, p := range got {
+		if p.LibID == "/facebook/reactother" {
+			t.Errorf("filter incorrectly matched %q against base /facebook/react", p.LibID)
+		}
+	}
+
+	// Exact versioned filter matches one entry.
+	got = m.FilterByLibID("/facebook/react/v18")
+	if len(got) != 1 || got[0].LibID != "/facebook/react/v18" {
+		t.Errorf("FilterByLibID(/facebook/react/v18) returned %v, want exactly v18", got)
+	}
+
+	// No match.
+	if got := m.FilterByLibID("/totally/missing"); len(got) != 0 {
+		t.Errorf("FilterByLibID(/totally/missing) returned %d, want 0", len(got))
+	}
+}

--- a/internal/packs/sha256.go
+++ b/internal/packs/sha256.go
@@ -1,0 +1,32 @@
+package packs
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+)
+
+// FileSHA256 returns the lowercase hex sha256 digest of the file at
+// path. The file is streamed through io.Copy into the hasher so a 1 GB
+// pack costs the same memory as a 1 KB one — important because vector
+// artifacts grow over time and the verify path is on the hot loop of
+// every download.
+//
+// The returned digest is exactly 64 characters long, matching the
+// format Manifest validation expects, so callers can shuttle the result
+// directly into a Pack.SHA256 field without normalization.
+func FileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("sha256 %s: %w", path, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("sha256 %s: %w", path, err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/packs/sha256_test.go
+++ b/internal/packs/sha256_test.go
@@ -1,0 +1,53 @@
+package packs_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/laradji/deadzone/internal/packs"
+)
+
+// TestFileSHA256_KnownVector verifies the helper against the canonical
+// "abc" → 0xba7816... vector from RFC 6234. If this ever fails, either
+// crypto/sha256 has changed (won't happen) or the encoder produced a
+// non-lowercase / non-hex result.
+func TestFileSHA256_KnownVector(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "abc.bin")
+	if err := os.WriteFile(path, []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := packs.FileSHA256(path)
+	if err != nil {
+		t.Fatalf("FileSHA256: %v", err)
+	}
+	want := "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestFileSHA256_EmptyFile verifies the empty-string SHA256 (the
+// well-known e3b0c4... value), which is the case `packs upload` will
+// hit if a scrape produces a zero-byte artifact for some reason.
+func TestFileSHA256_EmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.bin")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := packs.FileSHA256(path)
+	if err != nil {
+		t.Fatalf("FileSHA256: %v", err)
+	}
+	want := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFileSHA256_MissingFile(t *testing.T) {
+	_, err := packs.FileSHA256(filepath.Join(t.TempDir(), "nope.bin"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/internal/packs/upload.go
+++ b/internal/packs/upload.go
@@ -1,0 +1,302 @@
+package packs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/laradji/deadzone/internal/db"
+)
+
+// Releaser is the surface upload.Run uses to talk to GitHub Releases.
+// It exists as an interface for one reason only: tests substitute a
+// fakeReleaser to assert behaviour like "second upload of unchanged
+// artifact makes zero gh calls" without spinning up a real `gh`. The
+// production implementation is GHReleaser at the bottom of this file.
+type Releaser interface {
+	// EnsureRelease guarantees that a release with tag exists for the
+	// given owner/repo. It is safe (and cheap) to call multiple times;
+	// upload.Run only ever calls it once per run, but the contract
+	// allows the implementation to no-op on a second call.
+	EnsureRelease(ctx context.Context, repo, tag string) error
+
+	// Upload uploads a single file as a release asset, clobbering any
+	// existing asset with the same name. The asset name on the release
+	// is filepath.Base(file).
+	Upload(ctx context.Context, repo, tag, file string) error
+}
+
+// UploadOptions are the inputs to the upload subcommand.
+type UploadOptions struct {
+	// ArtifactsDir is the directory containing per-lib *.db files. The
+	// upload walk picks up every *.db in this dir at the top level,
+	// not recursively.
+	ArtifactsDir string
+	// ManifestPath is the location of artifacts/manifest.yaml. The
+	// file must already exist (the placeholder shape with empty
+	// `packs: []` is fine); upload.Run does not create it from scratch
+	// because the maintainer should commit the placeholder explicitly
+	// in the same change that wires up cmd/packs.
+	ManifestPath string
+	// Repo is the owner/name of the GitHub repository the release lives
+	// in. Resolved upstream by cmd/packs (flag overrides manifest
+	// `repo:` field which overrides DefaultRepo). Empty here is a
+	// programming error and produces a clear failure.
+	Repo string
+	// Releaser is injected by cmd/packs (production GHReleaser) or by
+	// tests (fakeReleaser). Required.
+	Releaser Releaser
+}
+
+// UploadSummary is the operator-facing rollup the cmd logs at the end
+// of an upload run. Counts are by lib_id (one entry per artifact file
+// processed), not by gh API call.
+type UploadSummary struct {
+	// Uploaded is the number of artifacts that were either new or had
+	// a different sha256 than the manifest's existing entry, and were
+	// successfully pushed to the release.
+	Uploaded int
+	// Skipped is the number of artifacts whose sha256 already matched
+	// the manifest's existing entry. These cause zero gh calls.
+	Skipped int
+	// Preserved is the number of manifest entries whose corresponding
+	// .db file is NOT present in ArtifactsDir at upload time. The
+	// entries stay in the manifest unchanged so a single-lib refresh
+	// doesn't show up as "deleted N libs" in the diff.
+	Preserved int
+}
+
+// RunUpload walks ArtifactsDir, uploads any artifact whose sha256 has
+// changed (or which is new) to the rolling release, and rewrites the
+// manifest to match. The function is the implementation of the
+// `deadzone-packs upload` subcommand.
+//
+// Algorithm:
+//
+//  1. Load the manifest. The release_tag is read from there; the file
+//     must exist (placeholder is fine).
+//  2. Glob *.db files, sort lexicographically for determinism.
+//  3. For each file: compute sha256, read lib_id + embedder identity
+//     via the lightweight db.ReadArtifactMeta (no embedder needed),
+//     and look up the existing manifest entry. Matching sha256 → skip
+//     and preserve verbatim. Otherwise build a new Pack with a fresh
+//     IndexedAt and queue it.
+//  4. If anything is queued, EnsureRelease once, then Upload each
+//     queued pack in order.
+//  5. Merge queued packs into the manifest (Replace by lib_id),
+//     leaving unseen entries untouched.
+//  6. Save the manifest atomically.
+//
+// On any error after step 4, the manifest is NOT rewritten — the
+// caller can retry the run after fixing the underlying issue and the
+// idempotent skip in step 3 keeps the retry cheap.
+func RunUpload(ctx context.Context, opts UploadOptions) (UploadSummary, error) {
+	if opts.Releaser == nil {
+		return UploadSummary{}, errors.New("upload: Releaser is required")
+	}
+	if opts.Repo == "" {
+		return UploadSummary{}, errors.New("upload: Repo is required")
+	}
+
+	manifest, err := Load(opts.ManifestPath)
+	if err != nil {
+		return UploadSummary{}, fmt.Errorf("upload: %w", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(opts.ArtifactsDir, "*.db"))
+	if err != nil {
+		return UploadSummary{}, fmt.Errorf("upload: glob %s: %w", opts.ArtifactsDir, err)
+	}
+	sort.Strings(matches)
+
+	type pending struct {
+		path string
+		pack Pack
+	}
+	var (
+		toUpload []pending
+		summary  UploadSummary
+	)
+	seenLibIDs := map[string]struct{}{}
+
+	for _, path := range matches {
+		hash, err := FileSHA256(path)
+		if err != nil {
+			return UploadSummary{}, fmt.Errorf("upload: %w", err)
+		}
+		fi, err := os.Stat(path)
+		if err != nil {
+			return UploadSummary{}, fmt.Errorf("upload: stat %s: %w", path, err)
+		}
+		meta, err := db.ReadArtifactMeta(path)
+		if err != nil {
+			return UploadSummary{}, fmt.Errorf("upload: read artifact meta %s: %w", path, err)
+		}
+		seenLibIDs[meta.LibID] = struct{}{}
+
+		assetName := filepath.Base(path)
+
+		if existing, _, found := manifest.Find(meta.LibID); found && existing.SHA256 == hash {
+			// Identical content already on the release; preserve the
+			// existing entry verbatim (including IndexedAt) so re-running
+			// upload is a true byte-level no-op on the manifest.
+			slog.Info("packs.upload.skipped",
+				"lib_id", meta.LibID,
+				"asset", assetName,
+				"sha256", hash,
+				"reason", "sha256_unchanged",
+			)
+			summary.Skipped++
+			continue
+		}
+
+		toUpload = append(toUpload, pending{
+			path: path,
+			pack: Pack{
+				LibID:               meta.LibID,
+				Asset:               assetName,
+				SHA256:              hash,
+				Size:                fi.Size(),
+				IndexedAt:           time.Now().UTC(),
+				ScrapedWithEmbedder: meta.EmbedderKind,
+				ScrapedWithModel:    meta.ModelVersion,
+			},
+		})
+	}
+
+	// Count entries that stay in the manifest because their local file
+	// is absent from ArtifactsDir. This is the "single-lib refresh"
+	// happy path: the maintainer ran scrape -lib X, only that artifact
+	// is on disk, but the manifest still references the other libs.
+	for _, p := range manifest.Packs {
+		if _, present := seenLibIDs[p.LibID]; !present {
+			summary.Preserved++
+		}
+	}
+
+	if len(toUpload) > 0 {
+		if err := opts.Releaser.EnsureRelease(ctx, opts.Repo, manifest.ReleaseTag); err != nil {
+			return summary, fmt.Errorf("upload: ensure release %s/%s: %w", opts.Repo, manifest.ReleaseTag, err)
+		}
+		for _, item := range toUpload {
+			if err := opts.Releaser.Upload(ctx, opts.Repo, manifest.ReleaseTag, item.path); err != nil {
+				return summary, fmt.Errorf("upload: upload %s: %w", item.path, err)
+			}
+			slog.Info("packs.upload.uploaded",
+				"lib_id", item.pack.LibID,
+				"asset", item.pack.Asset,
+				"sha256", item.pack.SHA256,
+				"size", item.pack.Size,
+			)
+			manifest.Replace(item.pack)
+			summary.Uploaded++
+		}
+
+		if err := manifest.Save(opts.ManifestPath); err != nil {
+			return summary, fmt.Errorf("upload: save manifest: %w", err)
+		}
+	}
+
+	return summary, nil
+}
+
+// GHReleaser is the production Releaser, implemented by shelling out to
+// the `gh` CLI. It is intentionally thin: every method is a single
+// exec.Cmd with stderr captured for diagnostics, and the upload path
+// auto-creates the release on first use by detecting "release not
+// found" in stderr.
+//
+// `gh` is already on every contributor's PATH per #22 and handles auth
+// (2FA, token refresh, org scopes) transparently — reimplementing this
+// in pure Go would be a worse `gh`.
+type GHReleaser struct {
+	// ensured tracks (repo, tag) pairs we've already verified during
+	// this run, so a multi-file upload only calls `gh release view`
+	// once. Reset at the start of each cmd invocation by virtue of
+	// being a per-instance map.
+	ensured map[string]bool
+}
+
+// NewGHReleaser returns a fresh production releaser. Always pass to
+// upload.Run via opts.Releaser; never reuse across processes.
+func NewGHReleaser() *GHReleaser {
+	return &GHReleaser{ensured: map[string]bool{}}
+}
+
+// EnsureRelease checks via `gh release view` whether a release exists
+// for the tag, and runs `gh release create` if it doesn't. The result
+// is cached per-instance so a 10-file upload run only pays the network
+// roundtrip once.
+//
+// On the create path the release is given a minimal title and an empty
+// notes body — the maintainer is free to edit these on the GitHub UI
+// later, but the rolling-tag model means the same release object lives
+// forever, so a one-line note covers it.
+func (g *GHReleaser) EnsureRelease(ctx context.Context, repo, tag string) error {
+	cacheKey := repo + "\x00" + tag
+	if g.ensured[cacheKey] {
+		return nil
+	}
+	// `gh release view` exits 0 with the release info on stdout if it
+	// exists, and exits 1 with a "release not found" message on stderr
+	// if it doesn't. We don't need the body, just the exit code.
+	view := exec.CommandContext(ctx, "gh", "release", "view", tag, "--repo", repo)
+	var stderr bytes.Buffer
+	view.Stderr = &stderr
+	if err := view.Run(); err == nil {
+		g.ensured[cacheKey] = true
+		return nil
+	} else if !isReleaseNotFound(stderr.String()) {
+		return fmt.Errorf("gh release view %s/%s: %w (%s)", repo, tag, err, strings.TrimSpace(stderr.String()))
+	}
+
+	slog.Info("packs.upload.creating_release",
+		"repo", repo,
+		"tag", tag,
+	)
+	create := exec.CommandContext(ctx, "gh", "release", "create", tag,
+		"--repo", repo,
+		"--title", "Deadzone pack artifacts",
+		"--notes", "Rolling release of per-lib documentation artifacts. See artifacts/manifest.yaml in the repo for the canonical sha256 list.",
+	)
+	var createErr bytes.Buffer
+	create.Stderr = &createErr
+	if err := create.Run(); err != nil {
+		return fmt.Errorf("gh release create %s/%s: %w (%s)", repo, tag, err, strings.TrimSpace(createErr.String()))
+	}
+	g.ensured[cacheKey] = true
+	return nil
+}
+
+// Upload runs `gh release upload <tag> <file> --clobber --repo <repo>`.
+// --clobber lets the same asset name be re-uploaded over an older copy,
+// which is the rolling-release model from #30.
+func (g *GHReleaser) Upload(ctx context.Context, repo, tag, file string) error {
+	cmd := exec.CommandContext(ctx, "gh", "release", "upload", tag, file,
+		"--clobber",
+		"--repo", repo,
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh release upload %s/%s %s: %w (%s)", repo, tag, file, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// isReleaseNotFound recognises the stderr message gh emits when a
+// release tag isn't on the repo yet. The exact wording is "release not
+// found" (lowercase) as of gh 2.x; we lowercase the comparison so a
+// future capitalization tweak doesn't silently break the auto-create
+// path.
+func isReleaseNotFound(stderr string) bool {
+	return strings.Contains(strings.ToLower(stderr), "release not found")
+}

--- a/internal/packs/upload_test.go
+++ b/internal/packs/upload_test.go
@@ -1,0 +1,340 @@
+package packs_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/laradji/deadzone/internal/packs"
+	_ "turso.tech/database/tursogo"
+)
+
+// fakeReleaser captures every method call so tests can assert exactly
+// which uploads happened. errOn lets a test inject a failure on the Nth
+// Upload call (1-indexed) to exercise the error path.
+type fakeReleaser struct {
+	mu          sync.Mutex
+	ensureCalls []ensureCall
+	uploadCalls []uploadCall
+	errOnUpload int // 0 = never, N = fail the Nth Upload call
+	ensureErr   error
+}
+
+type ensureCall struct{ Repo, Tag string }
+type uploadCall struct{ Repo, Tag, File string }
+
+func (f *fakeReleaser) EnsureRelease(ctx context.Context, repo, tag string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureCalls = append(f.ensureCalls, ensureCall{repo, tag})
+	return f.ensureErr
+}
+
+func (f *fakeReleaser) Upload(ctx context.Context, repo, tag, file string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.uploadCalls = append(f.uploadCalls, uploadCall{repo, tag, file})
+	if f.errOnUpload != 0 && len(f.uploadCalls) == f.errOnUpload {
+		return errors.New("fake upload failure")
+	}
+	return nil
+}
+
+// fakeArtifact builds a real .db file with just the meta table populated
+// so db.ReadArtifactMeta returns the supplied identity. Body is the
+// payload of the file (used to differentiate sha256s across tests).
+// The file goes into dir with the given basename.
+func fakeArtifact(t *testing.T, dir, basename, libID, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, basename)
+
+	// First create the meta table via a real turso connection so the
+	// file is structurally identical to a scraper-produced artifact.
+	raw, err := sql.Open("turso", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	raw.SetMaxOpenConns(1)
+	if _, err := raw.Exec(`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatalf("create meta: %v", err)
+	}
+	rows := []struct{ k, v string }{
+		{"lib_id", libID},
+		{"embedder_kind", "hugot"},
+		{"model_version", "sentence-transformers/all-MiniLM-L6-v2"},
+	}
+	for _, r := range rows {
+		if _, err := raw.Exec(`INSERT INTO meta(key, value) VALUES (?, ?)`, r.k, r.v); err != nil {
+			t.Fatalf("insert meta: %v", err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Append a body so each test can produce a different sha256
+	// without rebuilding the whole sqlite file. The trailing bytes
+	// don't change the meta-table query result because turso reads
+	// the header pages, but they DO change the file's sha256.
+	if body != "" {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("open append: %v", err)
+		}
+		if _, err := f.WriteString(body); err != nil {
+			t.Fatalf("append body: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close append: %v", err)
+		}
+	}
+
+	return path
+}
+
+// seedManifest writes a placeholder manifest with no packs to artifactsDir,
+// returning the manifest path.
+func seedManifest(t *testing.T, artifactsDir string) string {
+	t.Helper()
+	path := filepath.Join(artifactsDir, "manifest.yaml")
+	if err := os.WriteFile(path, []byte("release_tag: packs\nrepo: laradji/deadzone\npacks: []\n"), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return path
+}
+
+func TestUpload_FreshArtifactIsUploaded(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := seedManifest(t, dir)
+	fakeArtifact(t, dir, "x_y.db", "/x/y", "body-1")
+
+	rel := &fakeReleaser{}
+	summary, err := packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: dir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		Releaser:     rel,
+	})
+	if err != nil {
+		t.Fatalf("RunUpload: %v", err)
+	}
+	if summary.Uploaded != 1 || summary.Skipped != 0 || summary.Preserved != 0 {
+		t.Errorf("summary = %+v, want Uploaded:1", summary)
+	}
+	if len(rel.ensureCalls) != 1 {
+		t.Errorf("EnsureRelease called %d times, want 1", len(rel.ensureCalls))
+	}
+	if len(rel.uploadCalls) != 1 {
+		t.Errorf("Upload called %d times, want 1", len(rel.uploadCalls))
+	}
+
+	// Manifest should now have the new entry.
+	m, err := packs.Load(manifestPath)
+	if err != nil {
+		t.Fatalf("Load manifest: %v", err)
+	}
+	if len(m.Packs) != 1 {
+		t.Fatalf("len(Packs) = %d, want 1", len(m.Packs))
+	}
+	if m.Packs[0].LibID != "/x/y" {
+		t.Errorf("LibID = %q", m.Packs[0].LibID)
+	}
+	if m.Packs[0].Asset != "x_y.db" {
+		t.Errorf("Asset = %q", m.Packs[0].Asset)
+	}
+	if len(m.Packs[0].SHA256) != 64 {
+		t.Errorf("SHA256 length = %d, want 64", len(m.Packs[0].SHA256))
+	}
+	if m.Packs[0].ScrapedWithEmbedder != "hugot" {
+		t.Errorf("ScrapedWithEmbedder = %q", m.Packs[0].ScrapedWithEmbedder)
+	}
+}
+
+func TestUpload_SecondRunIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := seedManifest(t, dir)
+	fakeArtifact(t, dir, "x_y.db", "/x/y", "body-1")
+
+	// First run primes the manifest.
+	rel1 := &fakeReleaser{}
+	if _, err := packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: dir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		Releaser:     rel1,
+	}); err != nil {
+		t.Fatalf("first RunUpload: %v", err)
+	}
+
+	// Capture the manifest bytes after the first run so we can verify
+	// the second run leaves them byte-identical.
+	firstBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+
+	// Second run with a fresh fake — should make zero gh calls.
+	rel2 := &fakeReleaser{}
+	summary, err := packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: dir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		Releaser:     rel2,
+	})
+	if err != nil {
+		t.Fatalf("second RunUpload: %v", err)
+	}
+	if summary.Uploaded != 0 || summary.Skipped != 1 {
+		t.Errorf("summary = %+v, want Uploaded:0 Skipped:1", summary)
+	}
+	if len(rel2.ensureCalls) != 0 {
+		t.Errorf("EnsureRelease called %d times on no-op run, want 0", len(rel2.ensureCalls))
+	}
+	if len(rel2.uploadCalls) != 0 {
+		t.Errorf("Upload called %d times on no-op run, want 0", len(rel2.uploadCalls))
+	}
+
+	secondBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if string(firstBytes) != string(secondBytes) {
+		t.Errorf("manifest bytes changed on idempotent run\nfirst:\n%s\nsecond:\n%s", firstBytes, secondBytes)
+	}
+}
+
+func TestUpload_ChangedArtifactIsReuploaded(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := seedManifest(t, dir)
+	fakeArtifact(t, dir, "x_y.db", "/x/y", "body-v1")
+
+	rel1 := &fakeReleaser{}
+	if _, err := packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: dir, ManifestPath: manifestPath, Repo: "laradji/deadzone-test", Releaser: rel1,
+	}); err != nil {
+		t.Fatalf("first RunUpload: %v", err)
+	}
+
+	// Rebuild the same lib_id with a different body → different sha256.
+	if err := os.Remove(filepath.Join(dir, "x_y.db")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	fakeArtifact(t, dir, "x_y.db", "/x/y", "body-v2-much-longer-payload")
+
+	rel2 := &fakeReleaser{}
+	summary, err := packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: dir, ManifestPath: manifestPath, Repo: "laradji/deadzone-test", Releaser: rel2,
+	})
+	if err != nil {
+		t.Fatalf("second RunUpload: %v", err)
+	}
+	if summary.Uploaded != 1 || summary.Skipped != 0 {
+		t.Errorf("summary = %+v, want Uploaded:1 Skipped:0", summary)
+	}
+	if len(rel2.uploadCalls) != 1 {
+		t.Errorf("Upload called %d times, want 1", len(rel2.uploadCalls))
+	}
+}
+
+func TestUpload_PreservesUnseenManifestEntries(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-seed manifest with TWO entries but only stage ONE artifact
+	// on disk. The "ghost" entry must survive the upload run.
+	manifestYAML := `release_tag: packs
+repo: laradji/deadzone
+packs:
+  - lib_id: /ghost/lib
+    asset: ghost_lib.db
+    sha256: 0000000000000000000000000000000000000000000000000000000000000001
+    size: 100
+    indexed_at: 2026-04-01T00:00:00Z
+  - lib_id: /x/y
+    asset: x_y.db
+    sha256: 0000000000000000000000000000000000000000000000000000000000000002
+    size: 100
+    indexed_at: 2026-04-01T00:00:00Z
+`
+	manifestPath := filepath.Join(dir, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte(manifestYAML), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	// Only /x/y is on disk. Different sha256 → should re-upload.
+	fakeArtifact(t, dir, "x_y.db", "/x/y", "body-fresh")
+
+	rel := &fakeReleaser{}
+	summary, err := packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: dir, ManifestPath: manifestPath, Repo: "laradji/deadzone-test", Releaser: rel,
+	})
+	if err != nil {
+		t.Fatalf("RunUpload: %v", err)
+	}
+	if summary.Uploaded != 1 || summary.Preserved != 1 {
+		t.Errorf("summary = %+v, want Uploaded:1 Preserved:1", summary)
+	}
+
+	m, err := packs.Load(manifestPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(m.Packs) != 2 {
+		t.Errorf("len(Packs) = %d, want 2 (ghost should still be present)", len(m.Packs))
+	}
+	if _, _, ok := m.Find("/ghost/lib"); !ok {
+		t.Error("ghost entry was dropped from the manifest")
+	}
+}
+
+func TestUpload_FailureLeavesManifestUntouched(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := seedManifest(t, dir)
+	fakeArtifact(t, dir, "x_y.db", "/x/y", "body-1")
+
+	originalBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+
+	rel := &fakeReleaser{errOnUpload: 1}
+	_, err = packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: dir, ManifestPath: manifestPath, Repo: "laradji/deadzone-test", Releaser: rel,
+	})
+	if err == nil {
+		t.Fatal("expected error from failing fake upload, got nil")
+	}
+
+	finalBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if string(originalBytes) != string(finalBytes) {
+		t.Errorf("manifest was rewritten despite upload failure\nbefore:\n%s\nafter:\n%s", originalBytes, finalBytes)
+	}
+}
+
+func TestUpload_RequiresReleaser(t *testing.T) {
+	_, err := packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: "anywhere", ManifestPath: "any.yaml", Repo: "x/y",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing Releaser, got nil")
+	}
+}
+
+func TestUpload_RequiresRepo(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := seedManifest(t, dir)
+	_, err := packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: dir, ManifestPath: manifestPath, Releaser: &fakeReleaser{},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing Repo, got nil")
+	}
+}
+
+// compile-time guard: fakeReleaser must satisfy the Releaser interface.
+var _ packs.Releaser = (*fakeReleaser)(nil)

--- a/justfile
+++ b/justfile
@@ -49,8 +49,20 @@ consolidate db="deadzone.db":
 serve db="deadzone.db":
     {{go}} run ./cmd/server -db {{db}}
 
-# Remove built binaries, artifacts, and the local DB files
+# Upload local artifacts/*.db files to the rolling GitHub Release (see #30)
+packs-upload:
+    {{go}} run ./cmd/packs upload -artifacts ./artifacts -manifest ./artifacts/manifest.yaml
+
+# Download release assets referenced by the manifest into ./artifacts (pass lib=/org/project to fetch one)
+packs-download lib="":
+    {{go}} run ./cmd/packs download -artifacts ./artifacts -manifest ./artifacts/manifest.yaml {{ if lib != "" { "-lib " + lib } else { "" } }}
+
+# Print the manifest as a table to stdout
+packs-list:
+    {{go}} run ./cmd/packs list -manifest ./artifacts/manifest.yaml
+
+# Remove built binaries, per-lib artifacts, and the local DB files (preserves artifacts/manifest.yaml)
 clean:
-    rm -f deadzone deadzone-server deadzone-consolidate
+    rm -f deadzone deadzone-server deadzone-consolidate deadzone-packs
     rm -f deadzone.db deadzone.db-wal deadzone.db-shm
-    rm -rf artifacts
+    rm -f artifacts/*.db artifacts/*.db-wal artifacts/*.db-shm


### PR DESCRIPTION
## Summary

Implements artifact distribution through a rolling GitHub Release (issue #30). Adds a new `deadzone-packs` CLI with three subcommands:

- **`upload`** — walks `artifacts/*.db`, computes sha256 checksums, uploads changed files via `gh release upload --clobber`, and rewrites the manifest
- **`download`** — fetches every asset listed in the manifest, verifies sha256 integrity, and drops files into `./artifacts`
- **`list`** — pretty-prints the manifest as a table

## Key changes

- `cmd/packs/main.go` — new CLI entry point with upload/download/list subcommands
- `internal/packs/` — core package with `Manifest` YAML schema, `Releaser`/`Fetcher` interfaces, sha256 verification, and file filtering
- `internal/db/artifact_meta.go` — extract metadata (lib ID, record count) from artifact `.db` files
- `artifacts/manifest.yaml` — committed manifest (source of truth for canonical artifact versions)
- Justfile recipes for `packs-upload`, `packs-download`, `packs-list`

## Design decisions

- Single rolling release tag (`packs`) with clobber semantics — avoids tag proliferation
- Interfaces (`Releaser`, `Fetcher`) for testability — tests use fakes instead of real `gh`/HTTP
- SHA256 verification on both upload and download paths

## Test plan

- Unit tests for all new packages (`manifest`, `upload`, `download`, `list`, `filter`, `sha256`, `artifact_meta`)
- `go test ./internal/packs/... ./internal/db/...`
- Manual test: `just packs-upload` with a local `.db` file, then `just packs-download` on a clean clone

<!-- emdash-issue-footer:start -->
Fixes #30
<!-- emdash-issue-footer:end -->