### PR TITLE
feat(scraper): disable reasoning mode on LLM agent calls

### DIFF
--- a/internal/scraper/agent.go
+++ b/internal/scraper/agent.go
@@ -146,11 +146,56 @@ func (a *Agent) Model() string { return a.model }
 // Deadzone speaks the smallest possible subset: model, messages, and the
 // determinism / single-shot knobs. No tool calling, no JSON mode, no
 // response_format — the system prompt already says "output only Markdown".
+//
+// The trailing three fields — ChatTemplateKwargs, ReasoningEffort, and
+// EnableThinking — all serve the same purpose: suppress reasoning-mode
+// output on reasoning-capable backends (Qwen3+, GLM-4-Reasoning, OpenAI
+// o-series, DeepSeek-R1, …). Deadzone's extraction task has zero use
+// for a chain of thought — the system prompt already says "output only
+// Markdown, no commentary" — and reasoning-on burns 3–6× the latency
+// per URL (268× on trivial ping traffic, measured against oMLX +
+// Qwen3.5-9B-MLX-4bit on 2026-04-11; see #60 for the full table).
+//
+// There is no standardized OpenAI field for "disable reasoning"; each
+// server family picked its own convention. Servers silently ignore
+// fields they don't recognize (this is part of the OpenAI spec's
+// permissive request handling), so we send all three in every request
+// and one code path covers every reasoning backend we might meet. If
+// a future reviewer thinks these fields are unused and wants to strip
+// them, the answer is in #60 — they are load-bearing on any 2026-era
+// reasoning model and silently ignored everywhere else.
 type chatRequest struct {
 	Model       string        `json:"model"`
 	Messages    []chatMessage `json:"messages"`
 	Temperature float64       `json:"temperature"`
 	Stream      bool          `json:"stream"`
+
+	// ChatTemplateKwargs carries Jinja-template kwargs to servers
+	// that pass them through to the model's chat template — oMLX,
+	// vLLM, Ollama, sglang. Setting {"enable_thinking": false}
+	// disables reasoning on Qwen3+ and GLM-4-Reasoning.
+	ChatTemplateKwargs map[string]any `json:"chat_template_kwargs,omitempty"`
+
+	// ReasoningEffort is the OpenAI o-series knob (o1/o3/o5). We
+	// send "minimal" to cap reasoning at the lowest tier; other
+	// servers ignore this field.
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+
+	// EnableThinking is the DeepSeek-R1 family's top-level toggle.
+	// *bool so the encoder distinguishes "unset" (nil → omitted)
+	// from "explicit false" — omitempty on a plain bool would drop
+	// the false we need to send.
+	EnableThinking *bool `json:"enable_thinking,omitempty"`
+}
+
+// disableReasoning populates the three reasoning-off knobs on req.
+// Applied by both Ping and Extract before do(). See chatRequest for
+// per-field rationale and #60 for the empirical token measurement.
+func disableReasoning(req *chatRequest) {
+	req.ChatTemplateKwargs = map[string]any{"enable_thinking": false}
+	req.ReasoningEffort = "minimal"
+	off := false
+	req.EnableThinking = &off
 }
 
 type chatMessage struct {
@@ -186,6 +231,7 @@ func (a *Agent) Ping(ctx context.Context) error {
 		Temperature: 0,
 		Stream:      false,
 	}
+	disableReasoning(&req)
 	if _, err := a.do(ctx, req); err != nil {
 		return fmt.Errorf("agent ping: %w", err)
 	}
@@ -229,6 +275,7 @@ func (a *Agent) Extract(ctx context.Context, content, contentType string) (strin
 		Temperature: 0,
 		Stream:      false,
 	}
+	disableReasoning(&req)
 
 	resp, err := a.do(ctx, req)
 	if err != nil {

--- a/internal/scraper/agent_test.go
+++ b/internal/scraper/agent_test.go
@@ -67,6 +67,47 @@ type capturedRequest struct {
 	parsedBody    chatRequest
 }
 
+// assertReasoningDisabled fails the test if the captured request body
+// is missing any of the three reasoning-off fields the agent must
+// always send. See agent.go's chatRequest doc and #60 for the why.
+//
+// Both the parsed body and the raw bytes are checked: omitempty on
+// these fields would silently drop a wrong-typed value and make a
+// parsed-only assertion trivially pass, so we walk the JSON literal
+// too and prove the fields actually serialize on the wire.
+func assertReasoningDisabled(t *testing.T, captured *capturedRequest) {
+	t.Helper()
+
+	if captured.parsedBody.ChatTemplateKwargs == nil {
+		t.Errorf("chat_template_kwargs missing from request body")
+	} else {
+		v, ok := captured.parsedBody.ChatTemplateKwargs["enable_thinking"]
+		if !ok {
+			t.Errorf("chat_template_kwargs.enable_thinking key missing")
+		} else if b, isBool := v.(bool); !isBool || b {
+			t.Errorf("chat_template_kwargs.enable_thinking = %v (bool=%v), want false", v, isBool)
+		}
+	}
+	if captured.parsedBody.ReasoningEffort != "minimal" {
+		t.Errorf("reasoning_effort = %q, want %q", captured.parsedBody.ReasoningEffort, "minimal")
+	}
+	if captured.parsedBody.EnableThinking == nil {
+		t.Errorf("enable_thinking is nil, want explicit false (omitempty + *bool)")
+	} else if *captured.parsedBody.EnableThinking {
+		t.Errorf("enable_thinking = true, want false")
+	}
+
+	if !bytes.Contains(captured.rawBody, []byte(`"chat_template_kwargs":{"enable_thinking":false}`)) {
+		t.Errorf("raw body missing literal `\"chat_template_kwargs\":{\"enable_thinking\":false}`, got: %s", captured.rawBody)
+	}
+	if !bytes.Contains(captured.rawBody, []byte(`"reasoning_effort":"minimal"`)) {
+		t.Errorf("raw body missing literal `\"reasoning_effort\":\"minimal\"`, got: %s", captured.rawBody)
+	}
+	if !bytes.Contains(captured.rawBody, []byte(`"enable_thinking":false`)) {
+		t.Errorf("raw body missing literal `\"enable_thinking\":false`, got: %s", captured.rawBody)
+	}
+}
+
 // --- NewAgentFromEnv ---------------------------------------------------
 
 func TestNewAgentFromEnv_MissingEnvErrors(t *testing.T) {
@@ -166,6 +207,12 @@ func TestAgentExtract_RequestBodyShape(t *testing.T) {
 	if !strings.Contains(captured.parsedBody.Messages[1].Content, "<html>") {
 		t.Errorf("user message missing source content, got %q", captured.parsedBody.Messages[1].Content)
 	}
+	// #60: every Extract call must opt out of reasoning-mode output
+	// on Qwen3+ / DeepSeek-R1 / OpenAI o-series. Reasoning is pure
+	// waste for HTML→Markdown extraction (3–6× latency, up to 268×
+	// on trivial pings) and the system prompt already says "no
+	// commentary".
+	assertReasoningDisabled(t, captured)
 }
 
 func TestAgentExtract_AuthHeaderWhenAPIKeySet(t *testing.T) {
@@ -205,6 +252,29 @@ func TestAgentExtract_EmptyContentRejected(t *testing.T) {
 	}
 }
 
+func TestAgentExtract_DropsReasoningContentFromResponse(t *testing.T) {
+	// #60 safety net: if a server ignores our reasoning-off hint
+	// (or the user is on a backend that doesn't honor any of the
+	// three knobs), the response will look like Qwen3+ / DeepSeek-R1
+	// shape — content plus reasoning_content side-by-side. Our
+	// chatResponse struct only declares Content, so reasoning_content
+	// must drop on the json.Unmarshal floor and never reach the
+	// caller. Lock that behavior in.
+	reply := `{"choices":[{"message":{"role":"assistant","content":"# Clean output\n","reasoning_content":"Thinking Process: let me carefully consider how to extract this page..."}}]}`
+	agent, _, _ := startFakeAgent(t, reply, http.StatusOK)
+
+	out, err := agent.Extract(context.Background(), "<html><body>hi</body></html>", "text/html")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if out != "# Clean output" {
+		t.Errorf("Extract returned %q, want %q", out, "# Clean output")
+	}
+	if strings.Contains(out, "Thinking Process") {
+		t.Errorf("Extract leaked reasoning_content into output: %q", out)
+	}
+}
+
 func TestAgentExtract_TruncatesOversizedInput(t *testing.T) {
 	agent, captured, _ := startFakeAgent(t, fakeAgentResponse("# truncated"), http.StatusOK)
 
@@ -235,6 +305,18 @@ func TestAgentPing_Succeeds(t *testing.T) {
 	if captured.path != "/v1/chat/completions" {
 		t.Errorf("Ping hit %q, want /v1/chat/completions", captured.path)
 	}
+}
+
+func TestAgentPing_DisablesReasoning(t *testing.T) {
+	// #60: Ping is just as wasteful as Extract on a reasoning-mode
+	// model — without the disable, a one-token health check burns
+	// ~268 completion tokens on Qwen3.5-9B. Verify the same three
+	// fields apply to the ping path.
+	agent, captured, _ := startFakeAgent(t, fakeAgentResponse("ok"), http.StatusOK)
+	if err := agent.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	assertReasoningDisabled(t, captured)
 }
 
 func TestAgentPing_FailsOnUnreachable(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds three reasoning-off fields to `chatRequest` (`chat_template_kwargs`, `reasoning_effort`, `enable_thinking`) covering Qwen3+/GLM-4, OpenAI o-series, and DeepSeek-R1 backends respectively
- Applies `disableReasoning()` to both `Ping` and `Extract` code paths — servers silently ignore unrecognized fields, so all three are sent unconditionally
- Avoids 3–6× latency overhead on Extract and up to 268× on Ping when hitting reasoning-capable models (measured against oMLX + Qwen3.5-9B-MLX-4bit)

## Test plan
- `assertReasoningDisabled` helper validates all three fields in both parsed body and raw JSON bytes
- `TestAgentExtract_RequestBodyShape` — verifies reasoning fields present on Extract
- `TestAgentPing_DisablesReasoning` — verifies reasoning fields present on Ping
- `TestAgentExtract_DropsReasoningContentFromResponse` — confirms `reasoning_content` in server response is silently dropped

Refs: #60

<!-- emdash-issue-footer:start -->
Fixes #60
<!-- emdash-issue-footer:end -->