### PR TITLE
fix: wire -version flag and build-time ldflags into all CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ The `artifacts/*.db` files and `deadzone.db` are both gitignored — `artifacts/
 
 Run `just` (no args) to list every recipe. Override the DB path with positional args: `just consolidate foo.db` / `just serve foo.db`. If you'd rather call `go` directly, prefix every command with `mise exec --` so you pick up the pinned toolchain.
 
+### Building release binaries
+
+`just build` is a fast compile check (`go build ./...` — produces no output binaries). To produce the four named CLIs at the repo root with version info embedded, use `just build-release`:
+
+```bash
+# Local dev build — version/commit/date default from git describe + rev-parse + UTC now
+just build-release
+./deadzone-server -version
+# → deadzone-server v0.1.0-2-gabc1234-dirty (abc1234, built 2026-04-12T12:00:00Z)
+
+# Release build — CI sets VERSION/COMMIT/DATE explicitly from the workflow
+VERSION=v0.1.0 COMMIT=$(git rev-parse --short HEAD) DATE=$(date -u +%FT%TZ) just build-release
+./deadzone-server -version
+# → deadzone-server v0.1.0 (abc1234, built 2026-04-12T12:00:00Z)
+```
+
+All four binaries accept `-version` (server, scraper, consolidate) or `version` as a subcommand (packs), which prints the banner and exits without touching the DB or embedder. The recipe compiles with `-trimpath -ldflags "-s -w -X main.version=… -X main.commit=… -X main.date=…"`, so absolute build-host paths never leak into the binary and the stripped output stays small despite the CGO ORT dependency.
+
 ### Refreshing a single library
 
 The per-lib artifact layout means one library can be re-scraped, re-uploaded, and re-distributed without touching the others. The flow has four steps and is the same for both single-version libs and multi-version (`/facebook/react/v18`, `/facebook/react/v19`, …) entries:

--- a/cmd/consolidate/main.go
+++ b/cmd/consolidate/main.go
@@ -19,9 +19,18 @@ import (
 	"os"
 	"time"
 
+	"github.com/laradji/deadzone/internal/buildinfo"
 	"github.com/laradji/deadzone/internal/db"
 	"github.com/laradji/deadzone/internal/embed"
 	"github.com/laradji/deadzone/internal/logs"
+)
+
+// Build-time values overridden by `-ldflags -X main.version=…` at
+// release build time (see justfile's build-release recipe).
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
 )
 
 func main() {
@@ -36,7 +45,15 @@ func run() error {
 	artifactsDir := flag.String("artifacts", "./artifacts", "directory containing per-lib artifact .db files")
 	embedderKind := flag.String("embedder", embed.KindHugot, "embedder to use (valid: hugot)")
 	verbose := flag.Bool("verbose", false, "verbose logging")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+
+	// Short-circuit before embedder load so `-version` works on a
+	// checkout with no model cache.
+	if *showVersion {
+		fmt.Println(buildinfo.Format("deadzone-consolidate", version, commit, date))
+		return nil
+	}
 
 	slog.SetDefault(logs.New(os.Stderr, *verbose))
 

--- a/cmd/packs/main.go
+++ b/cmd/packs/main.go
@@ -25,8 +25,17 @@ import (
 	"os"
 	"time"
 
+	"github.com/laradji/deadzone/internal/buildinfo"
 	"github.com/laradji/deadzone/internal/logs"
 	"github.com/laradji/deadzone/internal/packs"
+)
+
+// Build-time values overridden by `-ldflags -X main.version=…` at
+// release build time (see justfile's build-release recipe).
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
 )
 
 func main() {
@@ -54,6 +63,9 @@ func run(sub string, args []string) error {
 	case "-h", "--help", "help":
 		usage()
 		return nil
+	case "-version", "--version", "version":
+		fmt.Println(buildinfo.Format("deadzone-packs", version, commit, date))
+		return nil
 	default:
 		usage()
 		return fmt.Errorf("unknown subcommand %q", sub)
@@ -67,6 +79,7 @@ Subcommands:
   upload    Upload local artifacts/*.db to the rolling GitHub Release
   download  Download release assets referenced by the manifest into ./artifacts
   list      Print the manifest as a table
+  version   Print version and exit
 
 Run "deadzone-packs <subcommand> -h" for the flags supported by each.`)
 }

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -12,10 +12,19 @@ import (
 	"strings"
 	"time"
 
+	"github.com/laradji/deadzone/internal/buildinfo"
 	"github.com/laradji/deadzone/internal/db"
 	"github.com/laradji/deadzone/internal/embed"
 	"github.com/laradji/deadzone/internal/logs"
 	"github.com/laradji/deadzone/internal/scraper"
+)
+
+// Build-time values overridden by `-ldflags -X main.version=…` at
+// release build time (see justfile's build-release recipe).
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
 )
 
 func main() {
@@ -31,7 +40,16 @@ func run() error {
 	verbose := flag.Bool("verbose", false, "emit per-doc Debug log lines in addition to per-URL summaries")
 	configPath := flag.String("config", "libraries_sources.yaml", "path to libraries_sources.yaml registry")
 	libFilter := flag.String("lib", "", "scrape only this lib_id (matches base or /base/version); empty = scrape all")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+
+	// Short-circuit before any config load / embedder setup so
+	// `deadzone-scraper -version` works on a checkout with no env
+	// vars and no model cache.
+	if *showVersion {
+		fmt.Println(buildinfo.Format("deadzone-scraper", version, commit, date))
+		return nil
+	}
 
 	// stderr-only JSON logging keeps the scraper consistent with
 	// cmd/server (which has a hard stdout-is-JSON-RPC constraint).

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,13 +10,21 @@ import (
 	"strings"
 	"time"
 
+	"github.com/laradji/deadzone/internal/buildinfo"
 	"github.com/laradji/deadzone/internal/db"
 	"github.com/laradji/deadzone/internal/embed"
 	"github.com/laradji/deadzone/internal/logs"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const serverVersion = "v0.1.0"
+// Build-time values overridden by `-ldflags -X main.version=…` at
+// release build time (see justfile's build-release recipe). The
+// defaults are what an unflagged `go build ./cmd/server` produces.
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
 
 // Library IDs follow the format /org/project (e.g. /hashicorp/terraform)
 type SearchDocsInput struct {
@@ -234,7 +242,17 @@ func run() error {
 	dbPath := flag.String("db", "deadzone.db", "path to turso database file")
 	embedderKind := flag.String("embedder", embed.KindHugot, "embedder to use (valid: hugot)")
 	verbose := flag.Bool("verbose", false, "include the raw query text in per-call logs")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+
+	// -version is the fastest path through the binary: no embedder
+	// load, no DB stat, no slog wiring. Short-circuit before anything
+	// else so `deadzone-server -version` works in a container with no
+	// db and no model cache.
+	if *showVersion {
+		fmt.Println(buildinfo.Format("deadzone-server", version, commit, date))
+		return nil
+	}
 
 	// Wire slog before any other work so subsequent error paths emit
 	// structured JSON to stderr — never stdout, which is the MCP
@@ -285,7 +303,9 @@ func run() error {
 	}
 
 	slog.Info("server.start",
-		"version", serverVersion,
+		"version", version,
+		"commit", commit,
+		"build_date", date,
 		"db_path", *dbPath,
 		"embedder_kind", e.Kind(),
 		"embedding_dim", e.Dim(),
@@ -293,7 +313,7 @@ func run() error {
 		"doc_count", docCount,
 	)
 
-	s := mcp.NewServer(&mcp.Implementation{Name: "deadzone", Version: serverVersion}, nil)
+	s := mcp.NewServer(&mcp.Implementation{Name: "deadzone", Version: version}, nil)
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "search_docs",
 		Description: "Search documentation snippets for a library. Use lib_id in /org/project format to filter by library.",

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,20 @@
+// Package buildinfo formats the runtime version banner shared by all
+// four deadzone binaries. Each cmd/*/main.go owns its own package-level
+// version/commit/date vars (they have to live in each main package so
+// `-ldflags -X main.version=…` can target them) and calls Format to
+// render the banner for the -version flag and startup logs.
+package buildinfo
+
+import "fmt"
+
+// Format renders the standard "<name> <version> (<commit>, built
+// <date>)" banner, e.g.:
+//
+//	deadzone-server v0.1.0 (abc1234, built 2026-04-12T12:34:56Z)
+//
+// The three value strings come from ldflags injection at release build
+// time (see justfile's build-release recipe) or from their default
+// "dev" / "unknown" fallbacks when the binary was built without -X.
+func Format(name, version, commit, date string) string {
+	return fmt.Sprintf("%s %s (%s, built %s)", name, version, commit, date)
+}

--- a/justfile
+++ b/justfile
@@ -17,9 +17,34 @@ default:
 bootstrap:
     mise install
 
-# Compile every package (CGO-free, pure Go)
+# Compile every package (CGO-free, pure Go). Fast sanity check; produces no binaries.
 build:
     {{go}} build ./...
+
+# Build the four CLI binaries with version/commit/date injected via ldflags.
+#
+# Reads VERSION / COMMIT / DATE from the environment. Release CI sets them
+# explicitly from the workflow matrix (see #74's release.yml):
+#
+#   VERSION=v0.1.0 COMMIT=$GITHUB_SHA DATE=$(date -u +%FT%TZ) just build-release
+#
+# When unset, defaults fall back to `git describe --tags --dirty --always`,
+# `git rev-parse --short HEAD`, and the current UTC timestamp so local dev
+# binaries are self-labelling too.
+#
+# -trimpath strips absolute source paths from the binary (no $PWD leak),
+# -s -w strips debug info (keeps the CGO binary small).
+build-release:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ver="${VERSION:-$(git describe --tags --dirty --always 2>/dev/null || echo dev)}"
+    sha="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+    built="${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+    ldflags="-s -w -X main.version=${ver} -X main.commit=${sha} -X main.date=${built}"
+    for bin in server scraper consolidate packs; do
+        mise exec -- go build -trimpath -ldflags "${ldflags}" -o "deadzone-${bin}" "./cmd/${bin}"
+    done
+    echo "built deadzone-{server,scraper,consolidate,packs} ${ver} (${sha}, built ${built})"
 
 # Run the full test suite
 test:
@@ -63,6 +88,6 @@ packs-list:
 
 # Remove built binaries, per-lib artifacts, and the local DB files (preserves artifacts/manifest.yaml)
 clean:
-    rm -f deadzone deadzone-server deadzone-consolidate deadzone-packs
+    rm -f deadzone deadzone-server deadzone-scraper deadzone-consolidate deadzone-packs
     rm -f deadzone.db deadzone.db-wal deadzone.db-shm
     rm -f artifacts/*.db artifacts/*.db-wal artifacts/*.db-shm


### PR DESCRIPTION
## Summary

- Add `internal/buildinfo` package with a shared `Format` function for the version banner
- Wire `-version` flag into all four binaries (server, scraper, consolidate, packs) using build-time `ldflags -X main.version/commit/date`
- Replace the hardcoded `serverVersion` constant in `cmd/server` with injected build vars
- Add `build-release` justfile recipe that produces stripped, trimpath'd binaries with version metadata
- Update `clean` recipe to include `deadzone-scraper`
- Document the release build workflow in README

## Details

Each `cmd/*/main.go` owns its own `version`, `commit`, `date` vars (required by `-ldflags -X main.*`). The `-version` flag short-circuits before any embedder load, DB stat, or config parsing so it works in minimal environments (CI containers, fresh checkouts with no model cache).

The `build-release` recipe reads `VERSION`/`COMMIT`/`DATE` from the environment (for CI) and falls back to `git describe`/`rev-parse`/`date -u` for local dev builds.

## Test plan

- [ ] `just build-release` produces four binaries at repo root
- [ ] Each binary responds to `-version` (or `version` subcommand for packs) and exits 0
- [ ] `just build` still works as a fast compile check
- [ ] `just clean` removes all five binary names including `deadzone-scraper`

<!-- emdash-issue-footer:start -->
Fixes #77
<!-- emdash-issue-footer:end -->