### PR TITLE
chore(scraper): harden error handling with soft/hard failure classification

### DIFF
--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -18,6 +18,16 @@ import (
 	"github.com/laradji/deadzone/internal/scraper"
 )
 
+// maxSkipsPerLib caps the number of per-URL failures tolerated inside a
+// single lib before the scraper aborts with "too many failed URLs".
+// Sized so a dead LLM endpoint or a fully unreachable documentation
+// host can't grind through a thousand-URL library producing zero docs,
+// while still absorbing the transient blips (one cold-start timeout,
+// one 5xx) that #63's smoke test showed were killing the lib on the
+// very first real run. Intentionally not configurable — tightening or
+// loosening this is a product decision, not an operational knob.
+const maxSkipsPerLib = 5
+
 func main() {
 	if err := run(); err != nil {
 		slog.Error("scraper fatal", "err", err.Error())
@@ -186,6 +196,7 @@ func scrapeLibToArtifact(
 
 	libStart := time.Now()
 	var docsTotal int
+	var skippedThisLib int
 
 	for _, u := range src.URLs {
 		// Per-URL fetch — split out from the embed/insert loop so the
@@ -209,23 +220,40 @@ func scrapeLibToArtifact(
 		}
 		fetchDur := time.Since(fetchStart)
 		if err != nil {
-			// Verification failure is a per-URL hallucination drop:
-			// log loudly, skip the URL, keep processing the rest of
-			// the source. Every other fetch error is fatal for the
-			// lib (the alternative is half-indexed artifacts).
-			if errors.Is(err, scraper.ErrAgentVerificationFailed) {
-				slog.Error("scraper.agent_verification_failed",
+			// Classify the failure. Verification drops, transient
+			// transport errors (timeouts, 5xx, reset connections),
+			// and per-URL content-type rejections (PDF, unknown
+			// binary) all soft-skip: log at url_skipped, count
+			// against maxSkipsPerLib, keep processing the rest of
+			// the lib. Anything else (auth, nil agent, insert
+			// failure downstream) is fatal for the lib — the
+			// alternative is a half-indexed artifact masquerading
+			// as complete.
+			reason, soft := classifyFetchErr(err)
+			if soft {
+				skippedThisLib++
+				slog.Error("scraper.url_skipped",
 					"lib_id", src.LibID,
 					"url", u,
+					"kind", fetcher,
+					"reason", reason,
+					"skipped_count", skippedThisLib,
+					"skipped_ceiling", maxSkipsPerLib,
 					"duration_ms", fetchDur.Milliseconds(),
 					"err", err.Error(),
 				)
+				if skippedThisLib >= maxSkipsPerLib {
+					return docsTotal, fmt.Errorf(
+						"too many failed URLs in %s (%d skipped, ceiling %d): %w",
+						src.LibID, skippedThisLib, maxSkipsPerLib, err)
+				}
 				continue
 			}
 			slog.Error("scraper.fetch_failed",
 				"lib_id", src.LibID,
 				"url", u,
 				"kind", fetcher,
+				"reason", reason,
 				"duration_ms", fetchDur.Milliseconds(),
 				"err", err.Error(),
 			)
@@ -319,6 +347,43 @@ func scrapeLibToArtifact(
 		"artifact_path", artifactPath,
 	)
 	return docsTotal, nil
+}
+
+// classifyFetchErr tags a fetch/extract error with a short reason and
+// reports whether it's soft-failable (per-URL skip) or fatal (abort the
+// lib). The tag goes straight into the scraper.url_skipped /
+// scraper.fetch_failed log line so an operator can grep for one class
+// of failure across a run without parsing wrapped error messages.
+//
+// Soft-failable errors:
+//   - ErrAgentVerificationFailed — hallucinated code block, per-URL drop
+//   - ErrPDFNotSupportedYet      — incidental PDF link in a doc index
+//   - context.DeadlineExceeded   — cold-start reload or slow first token
+//   - HTTP 5xx (via HTTPStatusError) — upstream blip
+//   - transient transport errors (ECONNRESET, EPIPE, EOF, net timeouts)
+//
+// Anything else (auth failures, 4xx other than above, decode errors)
+// is fatal for the lib.
+func classifyFetchErr(err error) (reason string, soft bool) {
+	switch {
+	case errors.Is(err, scraper.ErrAgentVerificationFailed):
+		return "verification_failed", true
+	case errors.Is(err, scraper.ErrPDFNotSupportedYet):
+		return "pdf_unsupported", true
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout", true
+	}
+	var httpErr *scraper.HTTPStatusError
+	if errors.As(err, &httpErr) {
+		if httpErr.Status >= 500 && httpErr.Status < 600 {
+			return fmt.Sprintf("http_%d", httpErr.Status), true
+		}
+		return fmt.Sprintf("http_%d", httpErr.Status), false
+	}
+	if scraper.IsTransientAgentError(err) {
+		return "transport", true
+	}
+	return "other", false
 }
 
 // artifactFilename derives the on-disk basename for a lib_id's

--- a/internal/scraper/agent.go
+++ b/internal/scraper/agent.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -40,12 +42,21 @@ const (
 // and multi-call extraction — which is the right place to revisit this.
 const agentInputMaxChars = 48 * 1024
 
-// agentDefaultTimeout caps a single LLM call. Local 7B models typically
-// finish HTML extraction in well under a minute; the timeout is sized
-// generously so the scraper doesn't abort a slow but progressing call,
-// and small enough that a stuck endpoint surfaces in the operator log
-// rather than hanging the run.
-const agentDefaultTimeout = 5 * time.Minute
+// agentDefaultTimeout caps a single LLM call. Sized so a cold-start
+// reload on consumer hardware (oMLX LRU-evicting the model, a first
+// large-context generation on a 9B class model) fits comfortably, while
+// a genuinely hung endpoint still surfaces in the operator log within
+// a reasonable window. 5 min turned out to be the exact failure point
+// during the FastAPI smoke test (see #63); 20 min gives 4× headroom.
+const agentDefaultTimeout = 20 * time.Minute
+
+// agentPingTimeout caps Ping independently of agentDefaultTimeout.
+// Ping is a startup health check: the operator wants a misconfigured
+// endpoint to surface in seconds, not minutes. 30 s covers slow
+// handshake + first-token latency on any reasonable local model and
+// bails fast if the endpoint is dead. Kept as a var, not a const, so
+// tests can shrink it without waiting the full budget.
+var agentPingTimeout = 30 * time.Second
 
 // systemPrompt is the extraction instruction shared by Ping and Extract.
 // Locked at temperature 0, single-shot, no streaming. The prompt itself
@@ -76,6 +87,53 @@ var ErrAgentNotConfigured = errors.New("agent endpoint not configured (set " + E
 // the source content (likely a hallucination). The doc is dropped and
 // the failure is logged at scraper.agent_verification_failed.
 var ErrAgentVerificationFailed = errors.New("agent output failed code-block verification")
+
+// HTTPStatusError carries a non-200 HTTP status code from either the
+// agent endpoint (Agent.do) or the source URL fetch (FetchOneViaAgent).
+// Exported so cmd/scraper can classify 5xx as transient-and-soft-fail
+// vs 4xx as likely-misconfiguration-and-hard-fail via errors.As.
+type HTTPStatusError struct {
+	Status int
+	URL    string
+	Body   string // truncated response body snippet, may be empty
+}
+
+func (e *HTTPStatusError) Error() string {
+	if e.Body != "" {
+		return fmt.Sprintf("HTTP %d from %s: %s", e.Status, e.URL, e.Body)
+	}
+	return fmt.Sprintf("HTTP %d from %s", e.Status, e.URL)
+}
+
+// IsTransientAgentError reports whether err represents a transient
+// failure that should soft-skip the URL rather than abort the whole
+// lib. Matches: context.DeadlineExceeded, net.Error.Timeout, ECONNRESET
+// / EPIPE, unexpected EOF during response read, and 5xx HTTP status.
+// Callers in cmd/scraper combine this with ErrAgentVerificationFailed
+// (intentional per-URL drop) under a shared skippedThisLib ceiling.
+func IsTransientAgentError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	var httpErr *HTTPStatusError
+	if errors.As(err, &httpErr) {
+		return httpErr.Status >= 500 && httpErr.Status < 600
+	}
+	return false
+}
 
 // Agent drives LLM-backed content extraction via an OpenAI-compatible
 // /v1/chat/completions endpoint. Deadzone does not host an LLM — the
@@ -222,6 +280,13 @@ type chatResponse struct {
 // response shape — so a successful Ping implies the actual extraction
 // calls have a working transport.
 func (a *Agent) Ping(ctx context.Context) error {
+	// Wrap the caller's context with agentPingTimeout (30s) so a dead
+	// endpoint surfaces fast regardless of the client's per-request
+	// timeout (20 min for Extract). Decoupled from agentDefaultTimeout
+	// so future bumps to Extract's budget don't slow Ping down.
+	pingCtx, cancel := context.WithTimeout(ctx, agentPingTimeout)
+	defer cancel()
+
 	req := chatRequest{
 		Model: a.model,
 		Messages: []chatMessage{
@@ -232,7 +297,7 @@ func (a *Agent) Ping(ctx context.Context) error {
 		Stream:      false,
 	}
 	disableReasoning(&req)
-	if _, err := a.do(ctx, req); err != nil {
+	if _, err := a.do(pingCtx, req); err != nil {
 		return fmt.Errorf("agent ping: %w", err)
 	}
 	return nil
@@ -349,7 +414,7 @@ func (a *Agent) do(ctx context.Context, body chatRequest) (*chatResponse, error)
 		if len(snippet) > 512 {
 			snippet = snippet[:512] + "…"
 		}
-		return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, url, snippet)
+		return nil, &HTTPStatusError{Status: resp.StatusCode, URL: url, Body: snippet}
 	}
 
 	var parsed chatResponse

--- a/internal/scraper/agent_test.go
+++ b/internal/scraper/agent_test.go
@@ -7,10 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // fakeAgentResponse builds a minimal OpenAI-compatible chat completion
@@ -480,6 +483,172 @@ func TestFetchOneViaAgent_PDFContentTypeRejected(t *testing.T) {
 	}
 	if !errors.Is(err, ErrPDFNotSupportedYet) {
 		t.Errorf("expected ErrPDFNotSupportedYet, got %v", err)
+	}
+}
+
+// TestAgentExtract_LongDeadline pins the default per-request timeout
+// to its post-#63 value. A regression to 5 min would re-open the
+// smoke-test failure mode (see #63's repro table), so this assertion
+// exists purely to make that regression loud.
+func TestAgentExtract_LongDeadline(t *testing.T) {
+	agent := NewAgent("http://example.invalid/v1", "test-model", "", nil)
+	got := agent.client.Timeout
+	if got < 15*time.Minute {
+		t.Errorf("default client timeout = %v, want ≥15m (post-#63 floor); 5m regresses the smoke test", got)
+	}
+}
+
+// TestAgentPing_FastTimeout verifies Ping honors agentPingTimeout
+// independently of the per-request HTTP client timeout. A stuck
+// endpoint with a 20-minute client timeout must still bail in ~ping
+// budget via the context deadline.
+func TestAgentPing_FastTimeout(t *testing.T) {
+	// Block the server past any reasonable ping budget. If Ping
+	// doesn't apply its own ctx deadline, the test would either time
+	// out on go-test itself or wait the full client timeout — both
+	// are louder failures than a green pass.
+	//
+	// serverDone is closed by t.Cleanup before srv.Close so the
+	// handler returns promptly; httptest.Server.Close() waits for
+	// active connections and would otherwise hang if r.Context().Done
+	// fires late relative to the client tearing down its side.
+	serverDone := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-serverDone:
+		}
+	}))
+	t.Cleanup(func() {
+		close(serverDone)
+		srv.Close()
+	})
+
+	// Shrink agentPingTimeout so the test takes ~200ms instead of 30s.
+	// Client timeout is deliberately long (mirrors production's 20m)
+	// so a pass proves the ping timeout — not the client — short-
+	// circuited the request.
+	prevPing := agentPingTimeout
+	agentPingTimeout = 200 * time.Millisecond
+	defer func() { agentPingTimeout = prevPing }()
+
+	agent := NewAgent(srv.URL+"/v1", "test-model", "", &http.Client{Timeout: 30 * time.Second})
+
+	start := time.Now()
+	err := agent.Ping(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error on hung endpoint")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded wrapped in err, got %v", err)
+	}
+	// Allow 2s slack for scheduler + handshake; production budget is
+	// 30s so this cap needs to be well under it to be meaningful.
+	if elapsed > 2*time.Second {
+		t.Errorf("Ping took %v, expected it to bail near agentPingTimeout (%v)", elapsed, agentPingTimeout)
+	}
+}
+
+// TestAgentDo_ReturnsHTTPStatusError verifies do() wraps non-200 as
+// *HTTPStatusError (reachable via errors.As) instead of a plain
+// fmt.Errorf. cmd/scraper relies on this to classify 5xx as transient.
+func TestAgentDo_ReturnsHTTPStatusError(t *testing.T) {
+	agent, _, _ := startFakeAgent(t, "", http.StatusServiceUnavailable)
+	_, err := agent.Extract(context.Background(), "hello", "text/plain")
+	if err == nil {
+		t.Fatal("expected error on HTTP 503")
+	}
+	var httpErr *HTTPStatusError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPStatusError via errors.As, got %T: %v", err, err)
+	}
+	if httpErr.Status != http.StatusServiceUnavailable {
+		t.Errorf("Status = %d, want 503", httpErr.Status)
+	}
+}
+
+// --- IsTransientAgentError --------------------------------------------
+
+func TestIsTransientAgentError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"wrapped deadline exceeded", fmt.Errorf("extract: %w", context.DeadlineExceeded), true},
+		{"canceled (not transient)", context.Canceled, false},
+		{"io.EOF", io.EOF, true},
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, true},
+		{"ECONNRESET", syscall.ECONNRESET, true},
+		{"EPIPE", syscall.EPIPE, true},
+		{"wrapped ECONNRESET", &net.OpError{Op: "read", Err: syscall.ECONNRESET}, true},
+		{"http 503", &HTTPStatusError{Status: 503, URL: "x"}, true},
+		{"http 500", &HTTPStatusError{Status: 500, URL: "x"}, true},
+		{"http 599", &HTTPStatusError{Status: 599, URL: "x"}, true},
+		{"http 401 (not transient)", &HTTPStatusError{Status: 401, URL: "x"}, false},
+		{"http 404 (not transient)", &HTTPStatusError{Status: 404, URL: "x"}, false},
+		{"wrapped http 502", fmt.Errorf("extract: %w", &HTTPStatusError{Status: 502, URL: "x"}), true},
+		{"plain string error", errors.New("something else"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsTransientAgentError(tc.err)
+			if got != tc.want {
+				t.Errorf("IsTransientAgentError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- FetchOneViaAgent: Content-Type gate before body read -------------
+
+// TestFetchOneViaAgent_GatesContentTypeBeforeRead verifies the
+// Content-Type gate runs before io.ReadAll so an unsupported response
+// (here a PDF) is rejected without the body ever being consumed.
+// Implementation: the server writes the headers, flushes, then blocks
+// until its request context cancels. If FetchOneViaAgent reads the
+// body it will hang on io.ReadAll and the test fails the 2-second
+// deadline; if it gates first, the call returns ErrPDFNotSupportedYet
+// within microseconds and the server handler unblocks via the client
+// closing the connection.
+func TestFetchOneViaAgent_GatesContentTypeBeforeRead(t *testing.T) {
+	serverDone := make(chan struct{})
+	defer close(serverDone)
+	sourceSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		select {
+		case <-r.Context().Done():
+		case <-serverDone:
+		}
+	}))
+	defer sourceSrv.Close()
+
+	agent, _, _ := startFakeAgent(t, fakeAgentResponse("ignored"), http.StatusOK)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := FetchOneViaAgent(context.Background(), sourceSrv.Client(), agent, "/test/lib", sourceSrv.URL+"/spec.pdf")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected ErrPDFNotSupportedYet, got nil")
+		}
+		if !errors.Is(err, ErrPDFNotSupportedYet) {
+			t.Errorf("expected ErrPDFNotSupportedYet, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("FetchOneViaAgent did not return within 2s; likely read the response body instead of gating on Content-Type")
 	}
 }
 

--- a/internal/scraper/preprocess.go
+++ b/internal/scraper/preprocess.go
@@ -26,10 +26,31 @@ const (
 	contentTypePDF      = "application/pdf"
 )
 
+// preprocessGate decides whether contentType is acceptable for the
+// agent path without needing the body. Split out so FetchOneViaAgent
+// can reject unsupported types (PDF, binary) before io.ReadAll eats a
+// potentially large response into memory. Returns nil for accepted
+// types, ErrPDFNotSupportedYet for PDFs, and a formatted "unsupported
+// content type" error for everything else (including empty headers).
+func preprocessGate(contentType string) error {
+	switch normalizeContentType(contentType) {
+	case contentTypeHTML, contentTypeXHTML,
+		contentTypeMarkdown, contentTypeXMD, contentTypePlain:
+		return nil
+	case contentTypePDF:
+		return ErrPDFNotSupportedYet
+	default:
+		// Empty Content-Type is most often a misconfigured static
+		// server; surface it as the same "unsupported" error rather
+		// than guessing.
+		return fmt.Errorf("unsupported content type %q", contentType)
+	}
+}
+
 // preprocess turns a raw HTTP response body into LLM-ready text for
 // Agent.Extract. The contentType argument is the raw Content-Type
 // response header (parameters and casing tolerated); preprocess does
-// the parsing.
+// the parsing via preprocessGate.
 //
 // Behaviour is intentionally minimal in v1: HTML, markdown, and plain
 // text are returned as-is — modern LLMs handle HTML natively and don't
@@ -38,19 +59,10 @@ const (
 // operator notices instead of feeding the model raw bytes that turn
 // into garbage downstream.
 func preprocess(body []byte, contentType string) (string, error) {
-	switch normalizeContentType(contentType) {
-	case contentTypeHTML, contentTypeXHTML:
-		return string(body), nil
-	case contentTypeMarkdown, contentTypeXMD, contentTypePlain:
-		return string(body), nil
-	case contentTypePDF:
-		return "", ErrPDFNotSupportedYet
-	default:
-		// Empty Content-Type is most often a misconfigured static
-		// server; surface it as the same "unsupported" error rather
-		// than guessing.
-		return "", fmt.Errorf("unsupported content type %q", contentType)
+	if err := preprocessGate(contentType); err != nil {
+		return "", err
 	}
+	return string(body), nil
 }
 
 // normalizeContentType strips media-type parameters (charset=, boundary=, …)

--- a/internal/scraper/preprocess_test.go
+++ b/internal/scraper/preprocess_test.go
@@ -77,6 +77,48 @@ func TestPreprocess_RejectsUnknownTypes(t *testing.T) {
 	}
 }
 
+// preprocessGate is the header-only gate used by FetchOneViaAgent to
+// refuse unsupported content types before io.ReadAll. Behavior must
+// stay in lockstep with preprocess so that "accepted by the gate" ⇒
+// "accepted by preprocess" for any body.
+func TestPreprocessGate_MatchesPreprocess(t *testing.T) {
+	cases := []struct {
+		contentType string
+		wantErrIs   error // nil means "no error expected"
+		wantUnknown bool  // true when preprocessGate should return the "unsupported" formatted error
+	}{
+		{"text/html", nil, false},
+		{"text/html; charset=utf-8", nil, false},
+		{"application/xhtml+xml", nil, false},
+		{"text/markdown", nil, false},
+		{"text/x-markdown", nil, false},
+		{"text/plain", nil, false},
+		{"application/pdf", ErrPDFNotSupportedYet, false},
+		{"image/png", nil, true},
+		{"application/octet-stream", nil, true},
+		{"", nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.contentType, func(t *testing.T) {
+			gateErr := preprocessGate(tc.contentType)
+			_, preErr := preprocess([]byte("body"), tc.contentType)
+			// Parity: whatever kind of error preprocessGate returns,
+			// preprocess must agree on (nil-or-not, same sentinel).
+			if (gateErr == nil) != (preErr == nil) {
+				t.Fatalf("parity broken: preprocessGate err=%v, preprocess err=%v", gateErr, preErr)
+			}
+			if tc.wantErrIs != nil && !errors.Is(gateErr, tc.wantErrIs) {
+				t.Errorf("preprocessGate(%q) = %v, want errors.Is %v", tc.contentType, gateErr, tc.wantErrIs)
+			}
+			if tc.wantUnknown {
+				if gateErr == nil || !strings.Contains(gateErr.Error(), "unsupported content type") {
+					t.Errorf("preprocessGate(%q) = %v, want 'unsupported content type'", tc.contentType, gateErr)
+				}
+			}
+		})
+	}
+}
+
 func TestNormalizeContentType_StripsParameters(t *testing.T) {
 	cases := map[string]string{
 		"text/html; charset=utf-8":               "text/html",

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -188,14 +188,24 @@ func FetchOneViaAgent(ctx context.Context, client *http.Client, agent *Agent, li
 		return FetchOneResult{}, fmt.Errorf("fetch %s: %w", url, err)
 	}
 
-	body, readErr := io.ReadAll(resp.Body)
+	// Inspect status + Content-Type before io.ReadAll so a 100 MB PDF
+	// or an unsupported binary doesn't get streamed into memory just
+	// to be thrown away by preprocess. HTTPStatusError is typed so
+	// cmd/scraper can route 5xx to the transient-soft-fail path.
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return FetchOneResult{}, &HTTPStatusError{Status: resp.StatusCode, URL: url}
+	}
 	contentType := resp.Header.Get("Content-Type")
+	if err := preprocessGate(contentType); err != nil {
+		resp.Body.Close()
+		return FetchOneResult{}, fmt.Errorf("preprocess %s: %w", url, err)
+	}
+
+	body, readErr := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if readErr != nil {
 		return FetchOneResult{}, fmt.Errorf("read body %s: %w", url, readErr)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return FetchOneResult{}, fmt.Errorf("fetch %s: HTTP %d", url, resp.StatusCode)
 	}
 
 	text, err := preprocess(body, contentType)


### PR DESCRIPTION
## Summary

- Classify fetch errors into soft-skippable (transient transport, 5xx, verification, PDF) vs hard-fatal (auth, 4xx, decode), with a per-lib ceiling (`maxSkipsPerLib = 5`) that aborts if too many URLs fail
- Bump `agentDefaultTimeout` from 5m to 20m to accommodate cold-start LLM reloads (ref #63), add a separate `agentPingTimeout` (30s) so health checks still bail fast
- Extract `preprocessGate()` to reject unsupported content types (PDF, binary) **before** `io.ReadAll`, avoiding large body reads that get thrown away
- Promote HTTP non-200 errors to typed `*HTTPStatusError` (via `errors.As`) so callers can branch on status code class
- Add `IsTransientAgentError()` helper matching deadline, EOF, ECONNRESET, EPIPE, net timeout, and 5xx

## Key changes

| File | What |
|---|---|
| `cmd/scraper/main.go` | `classifyFetchErr()` + `maxSkipsPerLib` soft-skip loop |
| `internal/scraper/agent.go` | `HTTPStatusError` type, `IsTransientAgentError()`, `agentPingTimeout`, timeout bump |
| `internal/scraper/preprocess.go` | `preprocessGate()` extracted from `preprocess()` |
| `internal/scraper/scraper.go` | Early status + content-type gate before `io.ReadAll` |
| `*_test.go` | Tests for ping timeout, HTTP status typing, transient classification, gate parity |

## Test plan

- [x] `go test ./internal/scraper/...` — new tests for `IsTransientAgentError`, `HTTPStatusError`, `preprocessGate` parity, ping fast-timeout, content-type gate before body read
- [ ] Smoke-test against a live local model endpoint to verify the 20m timeout no longer trips on cold starts
- [ ] Verify `maxSkipsPerLib` triggers abort after 5 soft failures in a single lib

<!-- emdash-issue-footer:start -->
Fixes #63
<!-- emdash-issue-footer:end -->