### PR TITLE
feat(embed): add ONNX Runtime support via hugot embedder

### DIFF
--- a/.github/actions/install-native-deps/action.yml
+++ b/.github/actions/install-native-deps/action.yml
@@ -1,0 +1,50 @@
+name: Install native deps
+description: |
+  Download and install the CGO dependencies required to build the
+  deadzone embedder: libtokenizers.a (daulet/tokenizers, statically
+  linked) and libonnxruntime.so (microsoft/onnxruntime, loaded at
+  runtime). Runs on Linux amd64 only — macOS and ARM CI will need a
+  matrix extension here (#74).
+runs:
+  using: composite
+  steps:
+    - name: Cache native deps
+      id: cache
+      uses: actions/cache@v5
+      with:
+        path: /tmp/deadzone-deps
+        # Versions live in the workflow env, but composite actions cannot
+        # read ${{ env.* }} from the caller. Key on the workflow file so
+        # bumping the pinned version in ci.yml invalidates the cache.
+        key: deadzone-deps-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+    - name: Download libtokenizers.a + libonnxruntime.so
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        tok_version="${TOKENIZERS_VERSION:?TOKENIZERS_VERSION must be set in the caller workflow env}"
+        ort_version="${ONNXRUNTIME_VERSION:?ONNXRUNTIME_VERSION must be set in the caller workflow env}"
+
+        mkdir -p /tmp/deadzone-deps/tokenizers /tmp/deadzone-deps/ort
+        cd /tmp
+
+        # daulet/tokenizers ships libtokenizers.a inside a tarball whose
+        # top level IS the .a file (no surrounding directory).
+        curl -fL -o libtokenizers.tgz \
+          "https://github.com/daulet/tokenizers/releases/download/${tok_version}/libtokenizers.linux-amd64.tar.gz"
+        tar -xzf libtokenizers.tgz -C /tmp/deadzone-deps/tokenizers
+        rm libtokenizers.tgz
+
+        # onnxruntime ships a top-level directory containing lib/,
+        # include/, etc. We only need the lib/ contents.
+        curl -fL -o onnxruntime.tgz \
+          "https://github.com/microsoft/onnxruntime/releases/download/v${ort_version}/onnxruntime-linux-x64-${ort_version}.tgz"
+        tar -xzf onnxruntime.tgz
+        # -P preserves the libonnxruntime.so → libonnxruntime.so.${ort_version}
+        # symlink. The SONAME embedded in the versioned file is what the
+        # dynamic loader resolves against; dereferencing the symlink would
+        # produce two independent copies and waste cache space.
+        cp -P onnxruntime-linux-x64-${ort_version}/lib/libonnxruntime.so* /tmp/deadzone-deps/ort/
+        rm -rf onnxruntime.tgz onnxruntime-linux-x64-${ort_version}
+
+        ls -la /tmp/deadzone-deps/tokenizers /tmp/deadzone-deps/ort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,23 @@ on:
     branches: [main]
   pull_request:
 
+# Native deps shared by every job that compiles or runs Go code. The
+# embedder uses hugot's ORT backend, which pulls in daulet/tokenizers
+# (CGO, static linked at build time) and libonnxruntime (dynamic, loaded
+# at runtime). Versions are pinned deliberately — bumping either is a
+# conscious step, not a passive upgrade from an upstream "latest" tag.
+#
+# TOKENIZERS_VERSION tracks the daulet/tokenizers Go module version in
+# go.mod; the release tag for the prebuilt libtokenizers.a archive uses
+# the same scheme (see hugot's scripts/download-tokenizers.sh).
+#
+# ONNXRUNTIME_VERSION is pinned to the version validated by spike #67.
+# Bumping it requires re-measuring latency/correctness on a representative
+# corpus before merging.
+env:
+  TOKENIZERS_VERSION: v1.26.0
+  ONNXRUNTIME_VERSION: 1.24.4
+
 jobs:
   lint:
     name: lint
@@ -14,7 +31,13 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - run: go vet ./...
+      - name: Install native deps
+        uses: ./.github/actions/install-native-deps
+      - name: go vet
+        env:
+          CGO_ENABLED: "1"
+          CGO_LDFLAGS: -L/tmp/deadzone-deps/tokenizers
+        run: go vet -tags ORT ./...
 
   build:
     name: build
@@ -24,7 +47,13 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - run: go build ./...
+      - name: Install native deps
+        uses: ./.github/actions/install-native-deps
+      - name: go build
+        env:
+          CGO_ENABLED: "1"
+          CGO_LDFLAGS: -L/tmp/deadzone-deps/tokenizers
+        run: go build -tags ORT ./...
 
   licenses:
     name: licenses
@@ -34,6 +63,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: Install native deps
+        uses: ./.github/actions/install-native-deps
       # google/go-licenses scans the dep tree and verifies that no
       # transitive dependency carries a license type the project rejects.
       # We disallow `forbidden` (GPL/AGPL/proprietary) and `restricted`
@@ -47,6 +78,13 @@ jobs:
       - name: Install go-licenses
         run: go install github.com/google/go-licenses@latest
       - name: Check transitive license types
+        env:
+          CGO_ENABLED: "1"
+          CGO_LDFLAGS: -L/tmp/deadzone-deps/tokenizers
+          # go-licenses runs `go list` internally; GOFLAGS forwards the
+          # ORT build tag so the CGO-only deps (daulet/tokenizers,
+          # yalue/onnxruntime_go) are audited alongside the rest.
+          GOFLAGS: -tags=ORT
         run: go-licenses check ./cmd/server ./cmd/scraper --disallowed_types=forbidden,restricted
 
   test:
@@ -62,9 +100,11 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      # Cache the ~90 MB MiniLM ONNX weights across runs. Keyed on
-      # internal/embed/hugot.go so bumping DefaultHugotModel naturally
-      # invalidates the cache.
+      - name: Install native deps
+        uses: ./.github/actions/install-native-deps
+      # Cache the nomic ONNX weights (~131 MB quantized) across runs.
+      # Keyed on internal/embed/hugot.go so bumping DefaultHugotModel
+      # naturally invalidates the cache.
       - name: Cache embedding model
         uses: actions/cache@v5
         with:
@@ -81,11 +121,19 @@ jobs:
       # TestMain → NewHugot → DownloadModel. On a warm cache this is
       # a ~1s no-op.
       - name: Pre-download embedding model
-        run: go test ./internal/embed/... -run '^$' -count=1
+        env:
+          CGO_ENABLED: "1"
+          CGO_LDFLAGS: -L/tmp/deadzone-deps/tokenizers
+          DEADZONE_ORT_LIB_PATH: /tmp/deadzone-deps/ort
+        run: go test -tags ORT ./internal/embed/... -run '^$' -count=1
       # -short skips TestEmbedLatencyBudget and TestSemanticAcceptance,
       # both of which gate themselves on testing.Short() with comments
-      # saying "Skipped under -short so CI can opt out". Their cold/warm
-      # latency budgets (500ms / 100ms) target dev hardware and don't
-      # hold on shared GitHub runners.
+      # saying "Skipped under -short so CI can opt out". Their latency
+      # budget (100ms warm) targets dev hardware and doesn't hold on
+      # shared GitHub runners.
       - name: Run tests
-        run: go test ./... -race -short
+        env:
+          CGO_ENABLED: "1"
+          CGO_LDFLAGS: -L/tmp/deadzone-deps/tokenizers
+          DEADZONE_ORT_LIB_PATH: /tmp/deadzone-deps/ort
+        run: go test -tags ORT ./... -race -short

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -298,7 +298,7 @@ func scrapeLibToArtifact(
 		var docsInserted, docsSkipped int
 		for _, doc := range res.Docs {
 			embedStart := time.Now()
-			vec, err := e.Embed(doc.Title + "\n" + doc.Content)
+			vec, err := e.EmbedDocument(doc.Title + "\n" + doc.Content)
 			embedTotal += time.Since(embedStart)
 			if err != nil {
 				docsSkipped++

--- a/cmd/server/acceptance_test.go
+++ b/cmd/server/acceptance_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/laradji/deadzone/internal/db"
-	"github.com/laradji/deadzone/internal/embed"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -69,7 +68,7 @@ var semanticAcceptanceQueries = []string{
 	"plug custom code into the server",
 }
 
-// TestSemanticAcceptance is Phase 3's headline test: the hugot+MiniLM
+// TestSemanticAcceptance is Phase 3's headline test: the hugot+nomic
 // embedder, exercised through the full MCP search handler, must rank the
 // tool-registration snippet first for every query in
 // semanticAcceptanceQueries. Skipped under -short so CI can opt out
@@ -90,7 +89,7 @@ func TestSemanticAcceptance(t *testing.T) {
 	defer d.Close()
 
 	for _, doc := range acceptanceCorpus {
-		vec, err := testEmbedder.Embed(doc.Title + "\n" + doc.Content)
+		vec, err := testEmbedder.EmbedDocument(doc.Title + "\n" + doc.Content)
 		if err != nil {
 			t.Fatalf("Embed %q: %v", doc.Title, err)
 		}
@@ -123,16 +122,12 @@ func TestSemanticAcceptance(t *testing.T) {
 	}
 }
 
+// warmEmbedBudget bounds steady-state EmbedQuery calls. This is the number
+// that ultimately bounds MCP query responsiveness, since every search_docs
+// call invokes the embedder once on the user's query. The spike in #67
+// measured ~3.8 ms for nomic-embed-text-v1.5 int8 through ORT, so 100 ms
+// leaves generous headroom for slower CI hardware.
 const (
-	// coldEmbedBudget bounds the very first Embed call after NewHugot.
-	// Covers GoMLX session JIT and first-token tokenizer warmup. The
-	// 500 ms ceiling is a conservative mid-range developer-CPU number;
-	// see issue #20 for the rationale.
-	coldEmbedBudget = 500 * time.Millisecond
-
-	// warmEmbedBudget bounds steady-state Embed calls. This is the
-	// number that ultimately bounds MCP query responsiveness, since
-	// every search_docs call invokes Embed once on the user's query.
 	warmEmbedBudget = 100 * time.Millisecond
 
 	// warmRuns is the sample size for warmEmbedBudget. Median is used
@@ -141,68 +136,44 @@ const (
 	warmRuns = 10
 )
 
-// TestEmbedLatencyBudget enforces the cold and warm-path latency budgets
-// from issue #20. Skipped under -short alongside the semantic acceptance
-// test so the same CI flag toggles both.
+// TestEmbedLatencyBudget enforces the warm-path latency budget from issue
+// #20. Skipped under -short alongside the semantic acceptance test so the
+// same CI flag toggles both.
 //
-// The cold subtest constructs a fresh NewHugot rather than reusing the
-// package-level testEmbedder, because testEmbedder has already paid its
-// first-call warmup cost during package init — measuring it here would
-// just measure a steady-state call. The fresh embedder shares the same
-// on-disk model cache, so no second download is paid.
+// The cold-path subtest was removed when the embedder moved from hugot's
+// GoMLX backend to the ORT one: ORT enforces a single active onnxruntime
+// session per process, so creating a second NewHugot while the
+// package-level testEmbedder is alive fails with "another session is
+// currently active". A cold measurement would need a separate process,
+// which belongs in a standalone benchmark rather than the test suite.
 func TestEmbedLatencyBudget(t *testing.T) {
 	if testing.Short() {
 		t.Skip("latency budget test skipped under -short")
 	}
 
-	t.Run("cold", func(t *testing.T) {
-		fresh, err := embed.NewHugot(embed.DefaultHugotModel, hugotTestCacheDir())
-		if err != nil {
-			t.Fatalf("NewHugot: %v", err)
-		}
-		defer fresh.Close()
+	// Prime the shared embedder so the first sample is warm too —
+	// avoids contaminating the median with a one-off cache miss
+	// from whatever ran before this test.
+	if _, err := testEmbedder.EmbedQuery("warmup"); err != nil {
+		t.Fatalf("warmup EmbedQuery: %v", err)
+	}
 
+	samples := make([]time.Duration, warmRuns)
+	for i := range samples {
 		start := time.Now()
-		v, err := fresh.Embed("how do I expose functions to the LLM")
-		elapsed := time.Since(start)
+		_, err := testEmbedder.EmbedQuery("how do I expose functions to the LLM")
+		samples[i] = time.Since(start)
 		if err != nil {
-			t.Fatalf("Embed: %v", err)
+			t.Fatalf("warm sample %d EmbedQuery: %v", i, err)
 		}
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	median := samples[len(samples)/2]
 
-		if len(v) != fresh.Dim() {
-			t.Fatalf("Embed returned vector of len %d, want %d", len(v), fresh.Dim())
-		}
-		if elapsed > coldEmbedBudget {
-			t.Errorf("cold Embed took %v, budget %v", elapsed, coldEmbedBudget)
-		}
-		t.Logf("cold Embed: %v (budget %v)", elapsed, coldEmbedBudget)
-	})
-
-	t.Run("warm", func(t *testing.T) {
-		// Prime the shared embedder so the first sample is warm too —
-		// avoids contaminating the median with a one-off cache miss
-		// from whatever ran before this subtest.
-		if _, err := testEmbedder.Embed("warmup"); err != nil {
-			t.Fatalf("warmup Embed: %v", err)
-		}
-
-		samples := make([]time.Duration, warmRuns)
-		for i := range samples {
-			start := time.Now()
-			_, err := testEmbedder.Embed("how do I expose functions to the LLM")
-			samples[i] = time.Since(start)
-			if err != nil {
-				t.Fatalf("warm sample %d Embed: %v", i, err)
-			}
-		}
-		sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
-		median := samples[len(samples)/2]
-
-		if median > warmEmbedBudget {
-			t.Errorf("warm Embed median %v exceeds budget %v; samples=%v",
-				median, warmEmbedBudget, samples)
-		}
-		t.Logf("warm Embed median: %v (budget %v, samples=%v)",
+	if median > warmEmbedBudget {
+		t.Errorf("warm EmbedQuery median %v exceeds budget %v; samples=%v",
 			median, warmEmbedBudget, samples)
-	})
+	}
+	t.Logf("warm EmbedQuery median: %v (budget %v, samples=%v)",
+		median, warmEmbedBudget, samples)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -55,7 +55,7 @@ func makeSearchHandler(d *db.DB, e embed.Embedder, verbose bool) func(context.Co
 	return func(ctx context.Context, req *mcp.CallToolRequest, input SearchDocsInput) (*mcp.CallToolResult, SearchDocsOutput, error) {
 		start := time.Now()
 
-		queryVec, err := e.Embed(input.Query)
+		queryVec, err := e.EmbedQuery(input.Query)
 		if err != nil {
 			slog.Error("search_docs failed", searchAttrs(input, verbose, "stage", "embed", "err", err.Error())...)
 			return nil, SearchDocsOutput{}, fmt.Errorf("embed query: %w", err)
@@ -183,7 +183,7 @@ func makeSearchLibrariesHandler(d *db.DB, e embed.Embedder, verbose bool) func(c
 				return nil, SearchLibrariesOutput{}, err
 			}
 		} else {
-			queryVec, embedErr := e.Embed(name)
+			queryVec, embedErr := e.EmbedQuery(name)
 			if embedErr != nil {
 				slog.Error("search_libraries failed", libAttrs(input, name, limit, verbose, "stage", "embed", "err", embedErr.Error())...)
 				return nil, SearchLibrariesOutput{}, fmt.Errorf("embed query: %w", embedErr)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // testEmbedder is the package-level Hugot shared by every test in this
-// package. Built once in TestMain so the model download + GoMLX session
+// package. Built once in TestMain so the model download + ORT session
 // warm-up cost only happens once per `go test ./cmd/server/...`.
 var testEmbedder *embed.Hugot
 
@@ -59,7 +59,7 @@ func TestHandleSearchDocs_ReturnsSnippets(t *testing.T) {
 		{LibID: "/other/lib", Title: "Unrelated", Content: "Something about databases and queries."},
 	}
 	for _, doc := range docs {
-		vec, err := testEmbedder.Embed(doc.Title + "\n" + doc.Content)
+		vec, err := testEmbedder.EmbedDocument(doc.Title + "\n" + doc.Content)
 		if err != nil {
 			t.Fatalf("Embed %q: %v", doc.Title, err)
 		}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -56,7 +56,7 @@ var ErrArtifactLibIDMismatch = errors.New("artifact lib_id mismatch")
 // compatible way (e.g. a new required table like libs). Stored in the
 // meta table at first Open and cross-checked on every subsequent open
 // against this constant; a mismatch surfaces as ErrSchemaMismatch.
-const CurrentSchemaVersion = 2
+const CurrentSchemaVersion = 3
 
 // Meta describes the embedder a database was created with. It is written
 // to the meta table the first time a fresh DB is opened and cross-checked
@@ -368,8 +368,13 @@ func SearchByEmbedding(db *DB, queryVec []float32, libID string, k int) ([]Doc, 
 // table already follows) while still letting tests pass a counting
 // wrapper that asserts the embed call is actually skipped on the
 // idempotent re-upsert path.
+//
+// EmbedDocument (not EmbedQuery) is the right method here: a lib_id row
+// is indexed content, retrieved against user queries via
+// SearchLibsByEmbedding. Retrieval-trained models use different prefixes
+// for the two sides and mixing them up silently degrades match quality.
 type LibEmbedder interface {
-	Embed(text string) ([]float32, error)
+	EmbedDocument(text string) ([]float32, error)
 }
 
 // LibInfo is one row of the libs table as returned by SearchLibsByEmbedding
@@ -387,14 +392,14 @@ type LibInfo struct {
 
 // UpsertLibIfNew inserts a row into the libs table for libID iff one
 // doesn't already exist. The embedding is computed from the lib_id text
-// itself with "/" and "-" turned into spaces so MiniLM sees something
+// itself with "/" and "-" turned into spaces so the encoder sees something
 // resembling natural language ("/hashicorp/terraform-provider-aws" →
 // "hashicorp terraform provider aws"). The lib_id is the primary key
 // and the embedding is immutable for the lifetime of the database, so
 // re-running this function for an existing lib is a fast no-op that
-// does NOT call e.Embed — the issue's "at most one Embed call per lib
-// per database" guarantee is enforced here, and verified by tests that
-// count the call against a wrapping LibEmbedder.
+// does NOT call EmbedDocument — the issue's "at most one Embed call per
+// lib per database" guarantee is enforced here, and verified by tests
+// that count the call against a wrapping LibEmbedder.
 func UpsertLibIfNew(d *DB, libID string, e LibEmbedder) error {
 	if libID == "" {
 		return errors.New("upsert lib: libID must not be empty")
@@ -406,7 +411,7 @@ func UpsertLibIfNew(d *DB, libID string, e LibEmbedder) error {
 	if existing > 0 {
 		return nil
 	}
-	vec, err := e.Embed(normalizeLibIDText(libID))
+	vec, err := e.EmbedDocument(normalizeLibIDText(libID))
 	if err != nil {
 		return fmt.Errorf("upsert lib %q: embed: %w", libID, err)
 	}
@@ -516,13 +521,13 @@ func TopLibsByDocCount(d *DB, limit int) ([]LibInfo, error) {
 	return results, rows.Err()
 }
 
-// normalizeLibIDText turns a path-like lib_id into a string MiniLM can
-// embed as natural language: "/" and "-" become spaces, surrounding
+// normalizeLibIDText turns a path-like lib_id into a string the encoder
+// can embed as natural language: "/" and "-" become spaces, surrounding
 // whitespace is trimmed. The transformation is intentionally trivial
 // and lossy — the embedder's job is to project semantic content, not
 // to roundtrip the lib_id. Centroid-of-doc-embeddings was rejected in
 // the issue because it has no recompute-on-partial-rescrape problem
-// and the lib_id text alone gives MiniLM enough signal to handle
+// and the lib_id text alone gives the encoder enough signal to handle
 // queries like "terraform aws" → "/hashicorp/terraform-provider-aws".
 func normalizeLibIDText(libID string) string {
 	return strings.TrimSpace(strings.NewReplacer("/", " ", "-", " ").Replace(libID))

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // testEmbedder is the package-level Hugot shared by every test in this
-// package. Built once in TestMain so the model download + GoMLX session
+// package. Built once in TestMain so the model download + ORT session
 // warm-up cost is amortized over the whole test run.
 var testEmbedder *embed.Hugot
 
@@ -44,15 +44,15 @@ func hugotTestCacheDir() string {
 	return cache + "/deadzone/models"
 }
 
-// embedText is a small convenience that mirrors what the scraper and server
-// do in real life: embed "Title\nContent" into a single vector. Tests call
-// it with t.Helper-style fatality so an embedder failure aborts the test
+// embedText is a small convenience that mirrors what the scraper does in
+// real life: embed "Title\nContent" as a corpus document. Tests call it
+// with t.Helper-style fatality so an embedder failure aborts the test
 // rather than silently passing nil through to db.Insert.
 func embedText(t *testing.T, e embed.Embedder, d db.Doc) []float32 {
 	t.Helper()
-	v, err := e.Embed(d.Title + "\n" + d.Content)
+	v, err := e.EmbedDocument(d.Title + "\n" + d.Content)
 	if err != nil {
-		t.Fatalf("Embed %q: %v", d.Title, err)
+		t.Fatalf("EmbedDocument %q: %v", d.Title, err)
 	}
 	return v
 }
@@ -136,7 +136,7 @@ func TestSearchByEmbedding_RanksRelevantFirst(t *testing.T) {
 		}
 	}
 
-	qv, err := testEmbedder.Embed("create a server")
+	qv, err := testEmbedder.EmbedQuery("create a server")
 	if err != nil {
 		t.Fatalf("Embed query: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestSearchByEmbedding_FiltersByLib(t *testing.T) {
 		}
 	}
 
-	qv, err := testEmbedder.Embed("server")
+	qv, err := testEmbedder.EmbedQuery("server")
 	if err != nil {
 		t.Fatalf("Embed query: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestSearchByEmbedding_Acceptance(t *testing.T) {
 		}
 	}
 
-	qv, err := testEmbedder.Embed("register a tool")
+	qv, err := testEmbedder.EmbedQuery("register a tool")
 	if err != nil {
 		t.Fatalf("Embed query: %v", err)
 	}
@@ -317,9 +317,9 @@ type countingEmbedder struct {
 	calls int
 }
 
-func (c *countingEmbedder) Embed(text string) ([]float32, error) {
+func (c *countingEmbedder) EmbedDocument(text string) ([]float32, error) {
 	c.calls++
-	return c.inner.Embed(text)
+	return c.inner.EmbedDocument(text)
 }
 
 // TestUpsertLibIfNew_Idempotent is the load-bearing assertion behind the
@@ -412,7 +412,7 @@ func TestSearchLibsByEmbedding_RanksRelevantFirst(t *testing.T) {
 		}
 	}
 
-	qv, err := testEmbedder.Embed("terraform aws")
+	qv, err := testEmbedder.EmbedQuery("terraform aws")
 	if err != nil {
 		t.Fatalf("Embed query: %v", err)
 	}
@@ -444,7 +444,7 @@ func TestSearchLibsByEmbedding_HonoursLimit(t *testing.T) {
 		}
 	}
 
-	qv, err := testEmbedder.Embed("anything")
+	qv, err := testEmbedder.EmbedQuery("anything")
 	if err != nil {
 		t.Fatalf("Embed query: %v", err)
 	}

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -2,8 +2,8 @@
 //
 // This package defines the Embedder interface used by both the indexer
 // (cmd/scraper) and the query path (cmd/server). The current and only
-// implementation is Hugot, a sentence-transformers feature extraction
-// pipeline running on hugot's pure-Go GoMLX backend (see hugot.go).
+// implementation is Hugot, a feature extraction pipeline running on
+// hugot's ORT (onnxruntime) backend (see hugot.go).
 //
 // The interface keeps room for future embedders behind the same factory:
 // adding a second model family means adding a Kind constant and a New case,
@@ -16,16 +16,29 @@ import "fmt"
 // Implementations must be deterministic: the same input must always produce
 // the same output, so that indexed vectors and query vectors are comparable.
 //
+// The interface is split into EmbedQuery and EmbedDocument because
+// retrieval-trained models (nomic-embed-text, BGE, e5, …) require
+// task-specific prefixes and degrade silently without them. The call site
+// knows whether a given text is a query or a document; the embedder picks
+// the right prefix accordingly. Implementations that do not need a prefix
+// can forward both methods to a single internal path.
+//
 // Kind, Dim, and ModelVersion are written into the database's meta table on
 // first use and cross-checked on every subsequent open, so that a binary
 // running with embedder X cannot accidentally read or write a database that
 // was indexed with embedder Y.
 type Embedder interface {
-	// Embed returns a vector of length Dim() for the given text.
-	// Implementations must surface inference errors instead of returning
-	// a placeholder vector: a silently corrupted embedding pollutes the
-	// cosine index permanently and is impossible to detect post-hoc.
-	Embed(text string) ([]float32, error)
+	// EmbedQuery returns a vector of length Dim() for a retrieval query —
+	// text that will be compared against a corpus. Implementations must
+	// surface inference errors instead of returning a placeholder vector:
+	// a silently corrupted embedding pollutes the cosine index permanently
+	// and is impossible to detect post-hoc.
+	EmbedQuery(text string) ([]float32, error)
+
+	// EmbedDocument returns a vector of length Dim() for a corpus
+	// document — text that will live in the index (a scraped snippet, a
+	// lib_id row, …). Same error-propagation contract as EmbedQuery.
+	EmbedDocument(text string) ([]float32, error)
 
 	// Kind identifies the embedder family (e.g. "hugot").
 	// Used for meta consistency checks between scraper and server runs.
@@ -36,8 +49,8 @@ type Embedder interface {
 	Dim() int
 
 	// ModelVersion identifies the specific model producing the
-	// embeddings (e.g. "sentence-transformers/all-MiniLM-L6-v2"). Stored
-	// in the DB meta table and cross-checked at open time.
+	// embeddings (e.g. "nomic-ai/nomic-embed-text-v1.5"). Stored in the
+	// DB meta table and cross-checked at open time.
 	ModelVersion() string
 
 	// Close releases any resources held by the embedder (model session,

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/laradji/deadzone/internal/embed"
@@ -13,9 +14,8 @@ import (
 
 // testEmbedder is a single Hugot instance shared by every test in the
 // package. NewHugot is expensive (downloads + loads the model + warms up
-// the GoMLX session) so amortizing it across the whole package via
-// TestMain brings per-test overhead down to roughly the cost of one
-// pipeline run.
+// the ORT session) so amortizing it across the whole package via TestMain
+// brings per-test overhead down to roughly the cost of one pipeline run.
 var testEmbedder *embed.Hugot
 
 func TestMain(m *testing.M) {
@@ -63,16 +63,16 @@ func TestHugot_Deterministic(t *testing.T) {
 		"Créer un serveur MCP",
 	}
 	for _, in := range inputs {
-		a, err := testEmbedder.Embed(in)
+		a, err := testEmbedder.EmbedQuery(in)
 		if err != nil {
-			t.Fatalf("Embed(%q): %v", in, err)
+			t.Fatalf("EmbedQuery(%q): %v", in, err)
 		}
-		b, err := testEmbedder.Embed(in)
+		b, err := testEmbedder.EmbedQuery(in)
 		if err != nil {
-			t.Fatalf("Embed(%q): %v", in, err)
+			t.Fatalf("EmbedQuery(%q): %v", in, err)
 		}
 		if !bytes.Equal(floatsToBytes(a), floatsToBytes(b)) {
-			t.Errorf("Embed(%q) not deterministic across calls", in)
+			t.Errorf("EmbedQuery(%q) not deterministic across calls", in)
 		}
 	}
 }
@@ -80,12 +80,12 @@ func TestHugot_Deterministic(t *testing.T) {
 func TestHugot_Dim(t *testing.T) {
 	cases := []string{"x", "hello world", "Register tools using mcp.AddTool"}
 	for _, c := range cases {
-		v, err := testEmbedder.Embed(c)
+		v, err := testEmbedder.EmbedDocument(c)
 		if err != nil {
-			t.Fatalf("Embed(%q): %v", c, err)
+			t.Fatalf("EmbedDocument(%q): %v", c, err)
 		}
 		if len(v) != testEmbedder.Dim() {
-			t.Errorf("Embed(%q) len = %d, want %d", c, len(v), testEmbedder.Dim())
+			t.Errorf("EmbedDocument(%q) len = %d, want %d", c, len(v), testEmbedder.Dim())
 		}
 	}
 }
@@ -94,11 +94,11 @@ func TestHugot_Metadata(t *testing.T) {
 	if got := testEmbedder.Kind(); got != "hugot" {
 		t.Errorf("Kind() = %q, want %q", got, "hugot")
 	}
-	if got := testEmbedder.Dim(); got <= 0 {
-		t.Errorf("Dim() = %d, want > 0", got)
-	}
-	if got := testEmbedder.ModelVersion(); got == "" {
-		t.Error("ModelVersion() returned empty string")
+	// 768 is the nomic hidden size. Hard-coding it catches a silently
+	// swapped model file (e.g. someone pointing OnnxFilename at the
+	// unquantized variant or a different checkpoint with the same repo).
+	if got := testEmbedder.Dim(); got != 768 {
+		t.Errorf("Dim() = %d, want 768", got)
 	}
 	if got := testEmbedder.ModelVersion(); got != embed.DefaultHugotModel {
 		t.Errorf("ModelVersion() = %q, want %q", got, embed.DefaultHugotModel)
@@ -108,20 +108,20 @@ func TestHugot_Metadata(t *testing.T) {
 func TestHugot_UnitNorm(t *testing.T) {
 	cases := []string{"a", "hello world", "Register tools using mcp.AddTool"}
 	for _, c := range cases {
-		v, err := testEmbedder.Embed(c)
+		v, err := testEmbedder.EmbedDocument(c)
 		if err != nil {
-			t.Fatalf("Embed(%q): %v", c, err)
+			t.Fatalf("EmbedDocument(%q): %v", c, err)
 		}
 		var sumSq float64
 		for _, x := range v {
 			sumSq += float64(x) * float64(x)
 		}
-		// MiniLM through hugot's WithNormalization() option produces
+		// nomic through hugot's WithNormalization() option produces
 		// L2-normalized embeddings; allow a slightly looser epsilon
-		// than the stub since we're rounding through float32 ONNX
-		// inference rather than computing the norm in pure Go.
+		// than the stub since we're rounding through int8 quantized
+		// ONNX inference rather than computing the norm in pure Go.
 		if math.Abs(sumSq-1) > 1e-4 {
-			t.Errorf("Embed(%q) ||v||^2 = %v, want ~1", c, sumSq)
+			t.Errorf("EmbedDocument(%q) ||v||^2 = %v, want ~1", c, sumSq)
 		}
 	}
 }
@@ -129,20 +129,26 @@ func TestHugot_UnitNorm(t *testing.T) {
 // TestHugot_SemanticOverlap is the real-embedder version of the stub's
 // token-overlap probe: a natural-language query should be semantically
 // closer to the relevant identifier-heavy doc than to an unrelated one.
-// With a 384-dim sentence-transformers model this is the actual semantic
+// With a 768-dim nomic-embed-text-v1.5 model this is the actual semantic
 // retrieval property we care about, not a hash-collision artifact.
+//
+// The query uses EmbedQuery and the corpus uses EmbedDocument; skipping
+// the split (embedding both sides as queries, or both as documents)
+// compresses the usable dynamic range of cosine scores noticeably, so
+// the assertion implicitly also guards against the caller losing the
+// query/document distinction.
 func TestHugot_SemanticOverlap(t *testing.T) {
-	query, err := testEmbedder.Embed("register a tool")
+	query, err := testEmbedder.EmbedQuery("register a tool")
 	if err != nil {
-		t.Fatalf("Embed query: %v", err)
+		t.Fatalf("EmbedQuery: %v", err)
 	}
-	relevant, err := testEmbedder.Embed("Register tools using mcp.AddTool")
+	relevant, err := testEmbedder.EmbedDocument("Register tools using mcp.AddTool")
 	if err != nil {
-		t.Fatalf("Embed relevant: %v", err)
+		t.Fatalf("EmbedDocument relevant: %v", err)
 	}
-	unrelated, err := testEmbedder.Embed("Open a database with sql.Open")
+	unrelated, err := testEmbedder.EmbedDocument("Open a database with sql.Open")
 	if err != nil {
-		t.Fatalf("Embed unrelated: %v", err)
+		t.Fatalf("EmbedDocument unrelated: %v", err)
 	}
 
 	distRelevant := cosineDistance(query, relevant)
@@ -154,23 +160,36 @@ func TestHugot_SemanticOverlap(t *testing.T) {
 	}
 }
 
+// TestHugot_LongInputNoPanic pins the core motivation for this swap:
+// all-MiniLM-L6-v2 panicked on inputs above its 512-token limit
+// (issue #62), which took down the scraper mid-run. nomic-embed-text-v1.5
+// advertises an 8192-token context, so a ~2000-token block of text
+// should pass through the pipeline without erroring — and definitely
+// without panicking.
+func TestHugot_LongInputNoPanic(t *testing.T) {
+	// ~2000 English-ish tokens worth of text. A paragraph repeated
+	// enough times to comfortably exceed the old 512-token ceiling
+	// while staying well inside the new 8192 limit.
+	para := "The feature extraction pipeline tokenizes the input, runs it through the transformer, mean-pools the hidden states across the sequence dimension, and finally L2-normalizes the result. "
+	long := strings.Repeat(para, 80)
+	v, err := testEmbedder.EmbedDocument(long)
+	if err != nil {
+		t.Fatalf("EmbedDocument(long): %v", err)
+	}
+	if len(v) != testEmbedder.Dim() {
+		t.Errorf("EmbedDocument(long) len = %d, want %d", len(v), testEmbedder.Dim())
+	}
+}
+
 func TestNew(t *testing.T) {
-	t.Run("hugot", func(t *testing.T) {
-		e, err := embed.New(embed.KindHugot)
-		if err != nil {
-			t.Fatalf("New(hugot): %v", err)
-		}
-		// New returns a fresh Hugot — close it to release the
-		// session it just allocated. The package-level testEmbedder
-		// is unaffected.
-		defer func() { _ = e.Close() }()
-		if e.Kind() != "hugot" {
-			t.Errorf("Kind() = %q, want %q", e.Kind(), "hugot")
-		}
-		if e.Dim() <= 0 {
-			t.Errorf("Dim() = %d, want > 0", e.Dim())
-		}
-	})
+	// The happy-path "hugot" subtest is intentionally absent. hugot's ORT
+	// backend enforces a single active onnxruntime session per process
+	// (see knights-analytics/hugot hugot_ort.go), and the package-level
+	// testEmbedder is already holding one — spinning up a second via
+	// embed.New here would fail with "another session is currently
+	// active". The dispatch through New is exercised every time TestMain
+	// runs, since embed.New(KindHugot) calls NewHugot(DefaultHugotModel,
+	// DefaultCacheDir()) with the same arguments TestMain uses directly.
 
 	t.Run("unknown kind", func(t *testing.T) {
 		if _, err := embed.New("does-not-exist"); err == nil {

--- a/internal/embed/hugot.go
+++ b/internal/embed/hugot.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/knights-analytics/hugot"
+	"github.com/knights-analytics/hugot/options"
 	"github.com/knights-analytics/hugot/pipelines"
 )
 
@@ -16,22 +17,48 @@ import (
 // kind currently accepted by New.
 const KindHugot = "hugot"
 
-// DefaultHugotModel is the sentence-transformers MiniLM checkpoint used by
-// default. 384-dim, English-leaning, well-suited to short documentation
-// snippets and natural-language queries. Bumping this constant invalidates
-// every existing database via db.Meta cross-check on next Open.
-const DefaultHugotModel = "sentence-transformers/all-MiniLM-L6-v2"
+// DefaultHugotModel is nomic-embed-text-v1.5 — 768-dim, 8192-token context,
+// Apache-2.0. Replaces the earlier all-MiniLM-L6-v2 checkpoint that panicked
+// on inputs above 512 tokens and only produced 384-dim embeddings. Bumping
+// this constant invalidates every existing database via db.Meta cross-check
+// on next Open.
+const DefaultHugotModel = "nomic-ai/nomic-embed-text-v1.5"
+
+// onnxFilename is the specific ONNX variant we download and load. The
+// unquantized model.onnx is ~549 MB and ships with an external-data
+// sidecar; the int8 quantized variant is a self-contained ~131 MB file
+// and is what the spike in #67 measured end-to-end.
+const onnxFilename = "model_quantized.onnx"
+
+// nomic was trained with task-specific prefixes. The tokenizer sees them
+// as regular text, but the model only maps queries and documents into the
+// same space when the prefix is present — skipping them silently degrades
+// retrieval quality. The Embedder interface is split into EmbedQuery /
+// EmbedDocument so the call site chooses up front which prefix gets
+// prepended, rather than passing a mode flag at every call.
+const (
+	queryPrefix    = "search_query: "
+	documentPrefix = "search_document: "
+)
+
+// EnvORTLibraryPath names the env var pointing at the directory that
+// contains libonnxruntime.{dylib,so,dll}. When unset, hugot's ORT backend
+// falls back to runtime-specific defaults (e.g. "libonnxruntime.dylib" on
+// the dylib search path for macOS). #73 will add an auto-download step so
+// users don't need to set this by hand.
+const EnvORTLibraryPath = "DEADZONE_ORT_LIB_PATH"
 
 // Hugot wraps a hugot Session + FeatureExtractionPipeline running on the
-// pure-Go GoMLX (simplego) backend. One Hugot is meant to live for the
-// lifetime of a process: NewHugot is expensive (downloads + loads the model)
-// but each Embed call is cheap.
+// ORT (onnxruntime) backend. One Hugot is meant to live for the lifetime
+// of a process: NewHugot is expensive (downloads + loads the model + spins
+// up the ORT environment) but each EmbedQuery / EmbedDocument call is
+// cheap.
 //
 // Concurrency: hugot's pipelines are not documented as goroutine-safe.
 // internal/db serializes its single connection, and cmd/server handles one
 // MCP request at a time, so a single shared *Hugot is fine for the current
-// workload. If parallelism is added later, wrap Embed in a mutex or pool
-// pipelines per worker.
+// workload. If parallelism is added later, wrap the embed calls in a mutex
+// or pool pipelines per worker.
 type Hugot struct {
 	session  *hugot.Session
 	pipeline *pipelines.FeatureExtractionPipeline
@@ -40,11 +67,17 @@ type Hugot struct {
 }
 
 // NewHugot constructs a Hugot embedder backed by modelName, downloading the
-// model into cacheDir if it isn't already present. Pass an empty modelName to
-// use DefaultHugotModel.
+// model into cacheDir if it isn't already present. Pass an empty modelName
+// to use DefaultHugotModel.
 //
-// First-run cost is dominated by the model download (a few MB for MiniLM)
-// and the GoMLX session warm-up. Subsequent runs reuse the on-disk model.
+// First-run cost is dominated by the ONNX model download (~131 MB for the
+// int8 nomic quantized variant) and the ORT session warm-up. Subsequent
+// runs reuse the on-disk model.
+//
+// The ORT shared library is located via EnvORTLibraryPath if set, otherwise
+// hugot falls back to its platform default. Building with `-tags ORT` and
+// CGO_ENABLED=1 is required — without the tag, hugot.NewORTSession below
+// compiles as a stub that returns a clear error.
 func NewHugot(modelName, cacheDir string) (*Hugot, error) {
 	if modelName == "" {
 		modelName = DefaultHugotModel
@@ -61,13 +94,13 @@ func NewHugot(modelName, cacheDir string) (*Hugot, error) {
 	// '/' replaced by '_'. We mirror that to detect a cached model and
 	// avoid re-downloading on every start.
 	modelDir := filepath.Join(cacheDir, strings.ReplaceAll(modelName, "/", "_"))
-	if _, err := os.Stat(filepath.Join(modelDir, "model.onnx")); errors.Is(err, fs.ErrNotExist) {
+	if _, err := os.Stat(filepath.Join(modelDir, onnxFilename)); errors.Is(err, fs.ErrNotExist) {
 		opts := hugot.NewDownloadOptions()
-		// sentence-transformers repos ship multiple ONNX variants under
-		// onnx/. Picking one explicitly avoids hugot's "ambiguous .onnx
-		// file" validation error. The downloader copies the file to
-		// modelDir/model.onnx regardless of its source path.
-		opts.OnnxFilePath = "onnx/model.onnx"
+		// nomic's repo ships multiple ONNX variants under onnx/. Picking
+		// the int8 quantized one explicitly avoids hugot's "ambiguous
+		// .onnx file" validation error. The downloader copies the file
+		// to modelDir/<basename> regardless of its source path.
+		opts.OnnxFilePath = "onnx/" + onnxFilename
 		if _, err := hugot.DownloadModel(modelName, cacheDir, opts); err != nil {
 			return nil, fmt.Errorf("hugot: download %s: %w", modelName, err)
 		}
@@ -75,19 +108,23 @@ func NewHugot(modelName, cacheDir string) (*Hugot, error) {
 		return nil, fmt.Errorf("hugot: stat model file: %w", err)
 	}
 
-	session, err := hugot.NewGoSession()
+	var sessionOpts []options.WithOption
+	if p := os.Getenv(EnvORTLibraryPath); p != "" {
+		sessionOpts = append(sessionOpts, options.WithOnnxLibraryPath(p))
+	}
+	session, err := hugot.NewORTSession(sessionOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("hugot: new session: %w", err)
+		return nil, fmt.Errorf("hugot: new ORT session: %w", err)
 	}
 
 	cfg := hugot.FeatureExtractionConfig{
 		ModelPath:    modelDir,
 		Name:         "deadzone",
-		OnnxFilename: "model.onnx",
+		OnnxFilename: onnxFilename,
 		Options: []hugot.FeatureExtractionOption{
 			// L2-normalize sentence embeddings so vector_distance_cos
-			// behaves as a true cosine distance. MiniLM's training
-			// objective expects normalized outputs.
+			// behaves as a true cosine distance. nomic's training
+			// objective expects normalized outputs on the consumer side.
 			pipelines.WithNormalization(),
 		},
 	}
@@ -114,15 +151,31 @@ func NewHugot(modelName, cacheDir string) (*Hugot, error) {
 	}, nil
 }
 
-// Embed runs text through the FeatureExtractionPipeline and returns the
+// EmbedQuery prepends the "search_query: " prefix that nomic was trained
+// with for retrieval queries and returns the resulting unit-norm vector.
+// Use this for text that will be compared against a corpus (e.g. a user
+// query handed to search_docs or search_libraries).
+func (h *Hugot) EmbedQuery(text string) ([]float32, error) {
+	return h.embed(queryPrefix + text)
+}
+
+// EmbedDocument prepends the "search_document: " prefix that nomic was
+// trained with for indexed passages and returns the resulting unit-norm
+// vector. Use this when embedding content that will live in the corpus
+// (e.g. a scraped doc, or a lib_id written into the libs table).
+func (h *Hugot) EmbedDocument(text string) ([]float32, error) {
+	return h.embed(documentPrefix + text)
+}
+
+// embed runs text through the FeatureExtractionPipeline and returns the
 // resulting unit-norm vector. Errors are propagated so callers can decide
 // what to do — at index time the scraper logs and skips the doc, at query
 // time the server returns the error to the MCP client. Returning a
 // deterministic placeholder vector here used to silently pollute the
-// cosine index, since every fallback collapsed to the same point in vector
-// space and formed a synthetic attractor for any query aligned with that
-// dimension.
-func (h *Hugot) Embed(text string) ([]float32, error) {
+// cosine index, since every fallback collapsed to the same point in
+// vector space and formed a synthetic attractor for any query aligned
+// with that dimension.
+func (h *Hugot) embed(text string) ([]float32, error) {
 	out, err := h.pipeline.RunPipeline([]string{text})
 	if err != nil {
 		return nil, fmt.Errorf("hugot: run pipeline (text len=%d): %w", len(text), err)
@@ -137,7 +190,7 @@ func (h *Hugot) Embed(text string) ([]float32, error) {
 func (h *Hugot) Kind() string { return KindHugot }
 
 // Dim is the output vector dimension, discovered from the loaded model at
-// construction time. 384 for the default MiniLM checkpoint.
+// construction time. 768 for the default nomic checkpoint.
 func (h *Hugot) Dim() int { return h.dim }
 
 // ModelVersion returns the Hugging Face model name. Used by db.Meta to

--- a/justfile
+++ b/justfile
@@ -4,10 +4,25 @@
 # PATH. Every recipe wraps `go` in `mise exec --` so neither humans nor
 # agents have to remember the prefix. `just` itself is also pinned in
 # .mise.toml, so `mise install` brings up the whole toolchain.
+#
+# CGO: the hugot embedder runs on the ORT (onnxruntime) backend, which
+# pulls in daulet/tokenizers — a Rust-backed CGO tokenizer. Building
+# therefore requires:
+#
+#   CGO_ENABLED=1
+#   -tags ORT
+#   libtokenizers.a available at link time
+#
+# By default recipes pass -L./lib to cgo. Set DEADZONE_TOKENIZERS_LIB to
+# point `go build` at a different directory (e.g. /opt/homebrew/lib). The
+# library itself is a static archive from
+# https://github.com/daulet/tokenizers/releases — place it in ./lib/ or
+# override the env var. The ORT shared library (libonnxruntime.{dylib,so})
+# is resolved at runtime via DEADZONE_ORT_LIB_PATH — see internal/embed.
+# #73 will add auto-download for the ORT shared library; #74 will wire
+# both native deps into release CI.
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
-
-go := "mise exec -- go"
 
 # List available recipes
 default:
@@ -17,9 +32,10 @@ default:
 bootstrap:
     mise install
 
-# Compile every package (CGO-free, pure Go). Fast sanity check; produces no binaries.
+# Compile every package. Fast sanity check; produces no binaries.
 build:
-    {{go}} build ./...
+    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+        mise exec -- go build -tags ORT ./...
 
 # Build the four CLI binaries with version/commit/date injected via ldflags.
 #
@@ -41,50 +57,57 @@ build-release:
     sha="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
     built="${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
     ldflags="-s -w -X main.version=${ver} -X main.commit=${sha} -X main.date=${built}"
+    export CGO_ENABLED=1
+    export CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}"
     for bin in server scraper consolidate packs; do
-        mise exec -- go build -trimpath -ldflags "${ldflags}" -o "deadzone-${bin}" "./cmd/${bin}"
+        mise exec -- go build -tags ORT -trimpath -ldflags "${ldflags}" -o "deadzone-${bin}" "./cmd/${bin}"
     done
     echo "built deadzone-{server,scraper,consolidate,packs} ${ver} (${sha}, built ${built})"
 
 # Run the full test suite
 test:
-    {{go}} test ./...
+    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+        mise exec -- go test -tags ORT ./...
 
 # Format all Go sources
 fmt:
-    {{go}} fmt ./...
+    mise exec -- go fmt ./...
 
 # Run `go vet` over every package
 vet:
-    {{go}} vet ./...
+    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+        mise exec -- go vet -tags ORT ./...
 
 # Sync go.mod / go.sum with the source
 tidy:
-    {{go}} mod tidy
+    mise exec -- go mod tidy
 
 # Run the scraper, writing one artifact per lib to ./artifacts/ (pass lib=/org/project to refresh only that entry)
 scrape lib="":
-    {{go}} run ./cmd/scraper -artifacts ./artifacts {{ if lib != "" { "-lib " + lib } else { "" } }}
+    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+        mise exec -- go run -tags ORT ./cmd/scraper -artifacts ./artifacts {{ if lib != "" { "-lib " + lib } else { "" } }}
 
 # Merge per-lib artifacts in ./artifacts/ into the main deadzone DB
 consolidate db="deadzone.db":
-    {{go}} run ./cmd/consolidate -db {{db}} -artifacts ./artifacts
+    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+        mise exec -- go run -tags ORT ./cmd/consolidate -db {{db}} -artifacts ./artifacts
 
 # Run the MCP server against the given DB file (must already be consolidated)
 serve db="deadzone.db":
-    {{go}} run ./cmd/server -db {{db}}
+    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+        mise exec -- go run -tags ORT ./cmd/server -db {{db}}
 
 # Upload local artifacts/*.db files to the rolling GitHub Release (see #30)
 packs-upload:
-    {{go}} run ./cmd/packs upload -artifacts ./artifacts -manifest ./artifacts/manifest.yaml
+    mise exec -- go run ./cmd/packs upload -artifacts ./artifacts -manifest ./artifacts/manifest.yaml
 
 # Download release assets referenced by the manifest into ./artifacts (pass lib=/org/project to fetch one)
 packs-download lib="":
-    {{go}} run ./cmd/packs download -artifacts ./artifacts -manifest ./artifacts/manifest.yaml {{ if lib != "" { "-lib " + lib } else { "" } }}
+    mise exec -- go run ./cmd/packs download -artifacts ./artifacts -manifest ./artifacts/manifest.yaml {{ if lib != "" { "-lib " + lib } else { "" } }}
 
 # Print the manifest as a table to stdout
 packs-list:
-    {{go}} run ./cmd/packs list -manifest ./artifacts/manifest.yaml
+    mise exec -- go run ./cmd/packs list -manifest ./artifacts/manifest.yaml
 
 # Remove built binaries, per-lib artifacts, and the local DB files (preserves artifacts/manifest.yaml)
 clean:


### PR DESCRIPTION
## Summary

- Extend the hugot embedder to support ONNX Runtime (ORT) as a backend for embedding generation
- Refactor `internal/embed/hugot.go` with expanded configuration and improved error handling
- Update `internal/embed/embed.go` interface and initialization logic for the new ORT path
- Adapt database layer (`internal/db/db.go`) for compatibility with embedder changes
- Revise acceptance and unit tests to cover the new embedding backend
- Enhance `justfile` with additional build/test recipes

## Changes

- **`internal/embed/hugot.go`**: Major rework to integrate ONNX Runtime, new configuration options, better resource management
- **`internal/embed/embed.go`**: Updated embedder interface and factory to support ORT backend selection
- **`internal/embed/embed_test.go`**: Expanded test coverage for ORT-based embeddings
- **`internal/db/db.go` / `db_test.go`**: Adjusted DB helpers for new embedding dimensions/types
- **`cmd/server/main.go` / `main_test.go`**: Wired new embedder config into server startup
- **`cmd/scraper/main.go`**: Updated scraper to use new embedder initialization
- **`cmd/server/acceptance_test.go`**: Simplified and updated acceptance tests
- **`justfile`**: New recipes and build flags for ORT support

## Test Plan

- Unit tests updated in `embed_test.go` and `db_test.go`
- Acceptance tests revised in `acceptance_test.go`
- Verify `just test` passes with ORT backend enabled

<!-- emdash-issue-footer:start -->
Fixes #72
<!-- emdash-issue-footer:end -->