### PR TITLE
feat(ort): auto-download and cache ONNX Runtime shared library

### DIFF
--- a/.github/actions/install-native-deps/action.yml
+++ b/.github/actions/install-native-deps/action.yml
@@ -1,10 +1,10 @@
 name: Install native deps
 description: |
-  Download and install the CGO dependencies required to build the
-  deadzone embedder: libtokenizers.a (daulet/tokenizers, statically
-  linked) and libonnxruntime.so (microsoft/onnxruntime, loaded at
-  runtime). Runs on Linux amd64 only — macOS and ARM CI will need a
-  matrix extension here (#74).
+  Download and install the libtokenizers.a static archive that hugot's
+  ORT backend links against at build time. The onnxruntime shared
+  library is NOT installed here — internal/ort.Bootstrap downloads,
+  SHA256-verifies, and caches it at first use (see #73). Linux amd64
+  only for now; a macOS / arm64 matrix will land with #74.
 runs:
   using: composite
   steps:
@@ -17,15 +17,14 @@ runs:
         # read ${{ env.* }} from the caller. Key on the workflow file so
         # bumping the pinned version in ci.yml invalidates the cache.
         key: deadzone-deps-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
-    - name: Download libtokenizers.a + libonnxruntime.so
+    - name: Download libtokenizers.a
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -euo pipefail
         tok_version="${TOKENIZERS_VERSION:?TOKENIZERS_VERSION must be set in the caller workflow env}"
-        ort_version="${ONNXRUNTIME_VERSION:?ONNXRUNTIME_VERSION must be set in the caller workflow env}"
 
-        mkdir -p /tmp/deadzone-deps/tokenizers /tmp/deadzone-deps/ort
+        mkdir -p /tmp/deadzone-deps/tokenizers
         cd /tmp
 
         # daulet/tokenizers ships libtokenizers.a inside a tarball whose
@@ -35,16 +34,4 @@ runs:
         tar -xzf libtokenizers.tgz -C /tmp/deadzone-deps/tokenizers
         rm libtokenizers.tgz
 
-        # onnxruntime ships a top-level directory containing lib/,
-        # include/, etc. We only need the lib/ contents.
-        curl -fL -o onnxruntime.tgz \
-          "https://github.com/microsoft/onnxruntime/releases/download/v${ort_version}/onnxruntime-linux-x64-${ort_version}.tgz"
-        tar -xzf onnxruntime.tgz
-        # -P preserves the libonnxruntime.so → libonnxruntime.so.${ort_version}
-        # symlink. The SONAME embedded in the versioned file is what the
-        # dynamic loader resolves against; dereferencing the symlink would
-        # produce two independent copies and waste cache space.
-        cp -P onnxruntime-linux-x64-${ort_version}/lib/libonnxruntime.so* /tmp/deadzone-deps/ort/
-        rm -rf onnxruntime.tgz onnxruntime-linux-x64-${ort_version}
-
-        ls -la /tmp/deadzone-deps/tokenizers /tmp/deadzone-deps/ort
+        ls -la /tmp/deadzone-deps/tokenizers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,21 @@ on:
 
 # Native deps shared by every job that compiles or runs Go code. The
 # embedder uses hugot's ORT backend, which pulls in daulet/tokenizers
-# (CGO, static linked at build time) and libonnxruntime (dynamic, loaded
-# at runtime). Versions are pinned deliberately — bumping either is a
-# conscious step, not a passive upgrade from an upstream "latest" tag.
+# (CGO, static linked at build time). Versions are pinned deliberately
+# — bumping is a conscious step, not a passive upgrade from an upstream
+# "latest" tag.
 #
 # TOKENIZERS_VERSION tracks the daulet/tokenizers Go module version in
 # go.mod; the release tag for the prebuilt libtokenizers.a archive uses
 # the same scheme (see hugot's scripts/download-tokenizers.sh).
 #
-# ONNXRUNTIME_VERSION is pinned to the version validated by spike #67.
-# Bumping it requires re-measuring latency/correctness on a representative
-# corpus before merging.
+# The libonnxruntime shared library is NOT installed here. It is
+# fetched at first use by internal/ort.Bootstrap, SHA256-verified
+# against a pinned digest, and cached at DEADZONE_ORT_CACHE (below) so
+# actions/cache can persist it across jobs. Bumping the pinned version
+# is a one-line change in internal/ort/ort.go.
 env:
   TOKENIZERS_VERSION: v1.26.0
-  ONNXRUNTIME_VERSION: 1.24.4
 
 jobs:
   lint:
@@ -95,6 +96,10 @@ jobs:
       # actions/cache step below can persist it across runs. The test
       # helpers in internal/embed/embed_test.go honor this env var.
       DEADZONE_HUGOT_CACHE: ${{ github.workspace }}/.deadzone-cache/models
+      # Pin the ORT shared-library cache too. internal/ort.Bootstrap
+      # reads DEADZONE_ORT_CACHE and extracts the downloaded archive
+      # here, so actions/cache can persist the ~30 MB .so across jobs.
+      DEADZONE_ORT_CACHE: ${{ github.workspace }}/.deadzone-cache/ort
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -112,19 +117,30 @@ jobs:
           key: hugot-model-${{ runner.os }}-${{ hashFiles('internal/embed/hugot.go') }}
           restore-keys: |
             hugot-model-${{ runner.os }}-
-      # Pre-download the embedding model without -race. The upstream
-      # gomlx/go-huggingface concurrent-download path has a data race
-      # (hub/files.go:250) that trips the race detector on a cold cache.
-      # Once the model is on disk, NewHugot loads it without spawning
-      # download goroutines, so the -race pass below never hits it.
-      # `-run '^$'` matches no test functions, so this only invokes
-      # TestMain → NewHugot → DownloadModel. On a warm cache this is
-      # a ~1s no-op.
-      - name: Pre-download embedding model
+      # Cache the onnxruntime shared library that internal/ort.Bootstrap
+      # downloads on first use. Keyed on internal/ort/ort.go so bumping
+      # the pinned Version constant naturally invalidates the cache
+      # (matching the "bump ORT version → re-download" invariant).
+      - name: Cache ONNX Runtime library
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.DEADZONE_ORT_CACHE }}
+          key: ort-lib-${{ runner.os }}-${{ hashFiles('internal/ort/ort.go') }}
+          restore-keys: |
+            ort-lib-${{ runner.os }}-
+      # Pre-download the embedding model AND the ORT library without
+      # -race. The upstream gomlx/go-huggingface concurrent-download
+      # path has a data race (hub/files.go:250) that trips the race
+      # detector on a cold cache. Once both are on disk, NewHugot
+      # loads them without spawning download goroutines, so the -race
+      # pass below never hits it. `-run '^$'` matches no test
+      # functions, so this only runs TestMain → NewHugot →
+      # DownloadModel + ort.Bootstrap. On a warm cache this is a ~1s
+      # no-op.
+      - name: Pre-download embedding model + ORT library
         env:
           CGO_ENABLED: "1"
           CGO_LDFLAGS: -L/tmp/deadzone-deps/tokenizers
-          DEADZONE_ORT_LIB_PATH: /tmp/deadzone-deps/ort
         run: go test -tags ORT ./internal/embed/... -run '^$' -count=1
       # -short skips TestEmbedLatencyBudget and TestSemanticAcceptance,
       # both of which gate themselves on testing.Short() with comments
@@ -135,5 +151,4 @@ jobs:
         env:
           CGO_ENABLED: "1"
           CGO_LDFLAGS: -L/tmp/deadzone-deps/tokenizers
-          DEADZONE_ORT_LIB_PATH: /tmp/deadzone-deps/ort
         run: go test -tags ORT ./... -race -short

--- a/internal/embed/hugot.go
+++ b/internal/embed/hugot.go
@@ -11,6 +11,8 @@ import (
 	"github.com/knights-analytics/hugot"
 	"github.com/knights-analytics/hugot/options"
 	"github.com/knights-analytics/hugot/pipelines"
+
+	"github.com/laradji/deadzone/internal/ort"
 )
 
 // KindHugot is the Kind() value reported by the Hugot embedder, and the only
@@ -41,13 +43,6 @@ const (
 	documentPrefix = "search_document: "
 )
 
-// EnvORTLibraryPath names the env var pointing at the directory that
-// contains libonnxruntime.{dylib,so,dll}. When unset, hugot's ORT backend
-// falls back to runtime-specific defaults (e.g. "libonnxruntime.dylib" on
-// the dylib search path for macOS). #73 will add an auto-download step so
-// users don't need to set this by hand.
-const EnvORTLibraryPath = "DEADZONE_ORT_LIB_PATH"
-
 // Hugot wraps a hugot Session + FeatureExtractionPipeline running on the
 // ORT (onnxruntime) backend. One Hugot is meant to live for the lifetime
 // of a process: NewHugot is expensive (downloads + loads the model + spins
@@ -74,10 +69,13 @@ type Hugot struct {
 // int8 nomic quantized variant) and the ORT session warm-up. Subsequent
 // runs reuse the on-disk model.
 //
-// The ORT shared library is located via EnvORTLibraryPath if set, otherwise
-// hugot falls back to its platform default. Building with `-tags ORT` and
-// CGO_ENABLED=1 is required — without the tag, hugot.NewORTSession below
-// compiles as a stub that returns a clear error.
+// The ORT shared library is resolved via internal/ort.Bootstrap: the
+// pinned release is downloaded + SHA256-verified + cached on first use
+// and re-used on every subsequent run. Set DEADZONE_ORT_LIB_PATH to
+// bypass the download and point at a hand-positioned library (air-gapped
+// installs, pinned mirrors). Building with `-tags ORT` and CGO_ENABLED=1
+// is required — without the tag, hugot.NewORTSession below compiles as a
+// stub that returns a clear error.
 func NewHugot(modelName, cacheDir string) (*Hugot, error) {
 	if modelName == "" {
 		modelName = DefaultHugotModel
@@ -108,11 +106,11 @@ func NewHugot(modelName, cacheDir string) (*Hugot, error) {
 		return nil, fmt.Errorf("hugot: stat model file: %w", err)
 	}
 
-	var sessionOpts []options.WithOption
-	if p := os.Getenv(EnvORTLibraryPath); p != "" {
-		sessionOpts = append(sessionOpts, options.WithOnnxLibraryPath(p))
+	libDir, err := ort.Bootstrap("")
+	if err != nil {
+		return nil, fmt.Errorf("hugot: bootstrap onnxruntime: %w", err)
 	}
-	session, err := hugot.NewORTSession(sessionOpts...)
+	session, err := hugot.NewORTSession(options.WithOnnxLibraryPath(libDir))
 	if err != nil {
 		return nil, fmt.Errorf("hugot: new ORT session: %w", err)
 	}

--- a/internal/ort/ort.go
+++ b/internal/ort/ort.go
@@ -1,0 +1,403 @@
+// Package ort bootstraps the libonnxruntime shared library that hugot's
+// ORT backend dlopen's at session creation time.
+//
+// The library is fetched from the upstream Microsoft release archive,
+// SHA256-verified against a pinned digest, extracted into a per-user
+// cache, and re-used on every subsequent run. This removes the "install
+// onnxruntime by hand, set LD_LIBRARY_PATH" step that otherwise gates
+// every first-time `deadzone serve` on a fresh machine.
+//
+// The version is pinned deliberately (see Version). Bumping it is a
+// three-line change — Version + the SHA256 map — and should be a
+// deliberate step, not a passive "upgrade to latest" on every build.
+//
+// Air-gapped / corp-proxy escape hatch: set DEADZONE_ORT_LIB_PATH to the
+// directory containing a pre-positioned libonnxruntime.{dylib,so,dll}
+// and Bootstrap returns that path without touching the network.
+package ort
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Version is the pinned onnxruntime release this binary expects. The
+// SHA256 table in pinnedReleases must carry an entry for the same
+// version. Bumping it is a deliberate step — re-measure on a
+// representative corpus before merging, and refresh the hashes from
+// `gh api repos/microsoft/onnxruntime/releases/tags/v<N>`.
+const Version = "1.24.4"
+
+// EnvLibPath names the env var that points at a directory containing a
+// pre-positioned libonnxruntime shared library. When set, Bootstrap
+// skips the download and returns the directory verbatim — the escape
+// hatch for air-gapped machines and pinned-mirror corp environments.
+const EnvLibPath = "DEADZONE_ORT_LIB_PATH"
+
+// EnvCacheDir overrides the default cache root used by DefaultCacheDir.
+// CI uses it to pin the cache to a workspace-local path that
+// actions/cache can persist across runs.
+const EnvCacheDir = "DEADZONE_ORT_CACHE"
+
+// releaseBaseURL is the GitHub release download endpoint. Split out so
+// tests can point Bootstrap at a local fixture server.
+var releaseBaseURL = "https://github.com/microsoft/onnxruntime/releases/download"
+
+// httpClient is used for the download. The explicit timeout is a last-
+// resort safety net; the real timeout is the io.Copy stall budget
+// enforced by the OS-level socket keepalive. 10 minutes is long enough
+// for slow residential links fetching the ~8-30 MB tarball but short
+// enough that a wedged CI runner fails loud instead of hanging the job.
+var httpClient = &http.Client{Timeout: 10 * time.Minute}
+
+// release describes one platform-specific artifact in the upstream
+// onnxruntime release. Everything it carries is pinned — a bump to
+// Version must refresh every SHA256.
+type release struct {
+	// Archive is the filename under
+	// releaseBaseURL/v<Version>/<Archive>. Template fields are filled
+	// via strings.Replace with {version} → Version.
+	Archive string
+	// SHA256 is the hex digest of the archive bytes, as published in
+	// the GitHub release metadata (`.assets[].digest`).
+	SHA256 string
+	// LibName is the file basename that hugot's getDefaultLibraryPaths
+	// expects inside the returned directory. Must match exactly or
+	// options.WithOnnxLibraryPath rejects the directory.
+	LibName string
+	// archiveKind is how to unpack Archive — "tgz" for .tgz, "zip"
+	// for .zip.
+	archiveKind string
+}
+
+// pinnedReleases maps runtime.GOOS+"/"+runtime.GOARCH to the release
+// that was validated against Version. Platforms that Microsoft no
+// longer publishes (e.g. osx-x86_64 was dropped at 1.19) are absent
+// — Bootstrap returns a clear error on those platforms pointing at
+// EnvLibPath.
+var pinnedReleases = map[string]release{
+	"darwin/arm64": {
+		Archive:     "onnxruntime-osx-arm64-{version}.tgz",
+		SHA256:      "93787795f47e1eee369182e43ed51b9e5da0878ab0346aecf4258979b8bba989",
+		LibName:     "libonnxruntime.dylib",
+		archiveKind: "tgz",
+	},
+	"linux/amd64": {
+		Archive:     "onnxruntime-linux-x64-{version}.tgz",
+		SHA256:      "3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747",
+		LibName:     "libonnxruntime.so",
+		archiveKind: "tgz",
+	},
+	"linux/arm64": {
+		Archive:     "onnxruntime-linux-aarch64-{version}.tgz",
+		SHA256:      "866109a9248d057671a039b9d725be4bd86888e3754140e6701ec621be9d4d7e",
+		LibName:     "libonnxruntime.so",
+		archiveKind: "tgz",
+	},
+	"windows/amd64": {
+		Archive:     "onnxruntime-win-x64-{version}.zip",
+		SHA256:      "d2319fddfb6ea4db99ccc4b60c85c517bcd855721f5daa6a06d40d7cb2ee2357",
+		LibName:     "onnxruntime.dll",
+		archiveKind: "zip",
+	},
+}
+
+// ErrUnsupportedPlatform is returned when the current GOOS/GOARCH has
+// no entry in pinnedReleases. Callers can recover by pointing
+// DEADZONE_ORT_LIB_PATH at a hand-installed copy of the library.
+var ErrUnsupportedPlatform = errors.New("ort: no pinned onnxruntime build for this platform — set DEADZONE_ORT_LIB_PATH")
+
+// Bootstrap returns the directory containing libonnxruntime for the
+// current platform, downloading + extracting the pinned release into
+// cacheDir on first call and re-using the on-disk copy on every
+// subsequent call.
+//
+// Resolution order:
+//
+//  1. DEADZONE_ORT_LIB_PATH — if set, return verbatim. The directory
+//     must already contain the right libonnxruntime file; Bootstrap
+//     does not validate it (hugot's options.WithOnnxLibraryPath does,
+//     and produces a better error message).
+//  2. Cached extraction at cacheDir/v<Version>/. If the expected
+//     library file exists there, return it.
+//  3. Download + SHA256-verify + extract.
+//
+// cacheDir may be empty, in which case DefaultCacheDir() is used.
+func Bootstrap(cacheDir string) (string, error) {
+	if p := os.Getenv(EnvLibPath); p != "" {
+		return p, nil
+	}
+
+	rel, ok := pinnedReleases[runtime.GOOS+"/"+runtime.GOARCH]
+	if !ok {
+		return "", fmt.Errorf("%w (GOOS=%s GOARCH=%s)", ErrUnsupportedPlatform, runtime.GOOS, runtime.GOARCH)
+	}
+
+	if cacheDir == "" {
+		cacheDir = DefaultCacheDir()
+	}
+
+	// Versioned subdir so multiple deadzone binaries pinned to
+	// different ORT versions can coexist in the same cache without
+	// one overwriting the other's extracted library.
+	versionDir := filepath.Join(cacheDir, "v"+Version)
+	libFile := filepath.Join(versionDir, rel.LibName)
+
+	if _, err := os.Stat(libFile); err == nil {
+		return versionDir, nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("ort: stat cached library: %w", err)
+	}
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", fmt.Errorf("ort: create cache dir %q: %w", cacheDir, err)
+	}
+
+	// Extract into a sibling scratch dir and rename atomically. A
+	// partial extraction left over from a crashed previous run would
+	// otherwise masquerade as a populated cache and fail at dlopen
+	// time with a much harder-to-diagnose error.
+	scratch, err := os.MkdirTemp(cacheDir, "v"+Version+".scratch-*")
+	if err != nil {
+		return "", fmt.Errorf("ort: create scratch dir: %w", err)
+	}
+	defer os.RemoveAll(scratch)
+
+	archiveName := strings.ReplaceAll(rel.Archive, "{version}", Version)
+	url := releaseBaseURL + "/v" + Version + "/" + archiveName
+
+	if err := downloadAndExtract(url, rel, scratch); err != nil {
+		return "", err
+	}
+
+	if _, err := os.Stat(filepath.Join(scratch, rel.LibName)); err != nil {
+		return "", fmt.Errorf("ort: expected %s in archive but not found after extraction: %w", rel.LibName, err)
+	}
+
+	if err := os.Rename(scratch, versionDir); err != nil {
+		// A racing bootstrap (two processes starting at once) may
+		// have populated versionDir between our Stat and Rename.
+		// If so, and the library is there, defer to their work.
+		if _, statErr := os.Stat(libFile); statErr == nil {
+			return versionDir, nil
+		}
+		return "", fmt.Errorf("ort: publish extracted library: %w", err)
+	}
+
+	return versionDir, nil
+}
+
+// DefaultCacheDir resolves the cache root used by Bootstrap when the
+// caller passes an empty cacheDir.
+//
+// Resolution:
+//
+//  1. $DEADZONE_ORT_CACHE if set.
+//  2. os.UserCacheDir() + /deadzone/ort — the platform default.
+//  3. ./.deadzone-cache/ort as a last-resort fallback so Bootstrap
+//     can still proceed when UserCacheDir fails.
+func DefaultCacheDir() string {
+	if dir := os.Getenv(EnvCacheDir); dir != "" {
+		return dir
+	}
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return filepath.Join(".deadzone-cache", "ort")
+	}
+	return filepath.Join(base, "deadzone", "ort")
+}
+
+// Supported reports whether the current platform has a pinned release.
+// Callers that want to offer a friendlier first-run error (e.g.
+// "install onnxruntime manually and set DEADZONE_ORT_LIB_PATH") can
+// branch on this before calling Bootstrap.
+func Supported() bool {
+	_, ok := pinnedReleases[runtime.GOOS+"/"+runtime.GOARCH]
+	return ok
+}
+
+// downloadAndExtract streams url through a sha256 hasher while
+// buffering it into a temp file, verifies the digest, then unpacks the
+// archive into destDir. The lib files (versioned binary + unversioned
+// symlink) are flattened to the top of destDir so hugot's
+// getDefaultLibraryPaths finds LibName directly under the returned
+// directory.
+func downloadAndExtract(url string, rel release, destDir string) error {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return fmt.Errorf("ort: download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ort: download %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	// Buffer to disk so we can rewind after the SHA256 check. The
+	// archives are 8-30 MB — small enough to hold on tmpfs, but
+	// holding them in memory wastes RSS when other packages are
+	// simultaneously loading the ONNX model.
+	tmp, err := os.CreateTemp(destDir, "download-*.archive")
+	if err != nil {
+		return fmt.Errorf("ort: create download tempfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	hasher := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, hasher), resp.Body); err != nil {
+		tmp.Close()
+		return fmt.Errorf("ort: stream download: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("ort: close download tempfile: %w", err)
+	}
+
+	got := hex.EncodeToString(hasher.Sum(nil))
+	if got != rel.SHA256 {
+		return fmt.Errorf("ort: sha256 mismatch for %s: got %s, want %s", url, got, rel.SHA256)
+	}
+
+	switch rel.archiveKind {
+	case "tgz":
+		return extractTgz(tmpPath, rel.LibName, destDir)
+	case "zip":
+		return extractZip(tmpPath, rel.LibName, destDir)
+	default:
+		return fmt.Errorf("ort: unknown archive kind %q", rel.archiveKind)
+	}
+}
+
+// extractTgz walks the tarball and copies out every file under
+// */lib/ that matches the library's versioned or unversioned form.
+// Symlinks are preserved; everything else (headers, cmake files,
+// testdata, dSYM bundles) is discarded.
+func extractTgz(archivePath, libName, destDir string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("ort: open archive: %w", err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("ort: gzip reader: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ort: tar next: %w", err)
+		}
+		base := path.Base(hdr.Name)
+		if !isLibArtifact(base, libName) {
+			continue
+		}
+		// Guard against absolute paths or traversal in a malicious
+		// archive, even though we trust the Microsoft release. base
+		// is already sanitized by path.Base, but reject overt
+		// nastiness before writing.
+		if strings.Contains(base, "..") || strings.ContainsRune(base, filepath.Separator) {
+			return fmt.Errorf("ort: refusing suspicious archive entry %q", hdr.Name)
+		}
+		dest := filepath.Join(destDir, base)
+		switch hdr.Typeflag {
+		case tar.TypeSymlink:
+			_ = os.Remove(dest)
+			if err := os.Symlink(hdr.Linkname, dest); err != nil {
+				return fmt.Errorf("ort: create symlink %s -> %s: %w", dest, hdr.Linkname, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := writeReg(dest, tr, hdr.FileInfo().Mode()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// extractZip mirrors extractTgz for Windows zip archives. ZIP entries
+// lack the TypeSymlink / TypeReg distinction of tar; we only see
+// regular files and treat them accordingly.
+func extractZip(archivePath, libName, destDir string) error {
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return fmt.Errorf("ort: open zip: %w", err)
+	}
+	defer zr.Close()
+	for _, f := range zr.File {
+		base := path.Base(f.Name)
+		if !isLibArtifact(base, libName) {
+			continue
+		}
+		if strings.Contains(base, "..") || strings.ContainsRune(base, filepath.Separator) {
+			return fmt.Errorf("ort: refusing suspicious archive entry %q", f.Name)
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("ort: open zip entry %s: %w", f.Name, err)
+		}
+		dest := filepath.Join(destDir, base)
+		if err := writeReg(dest, rc, f.Mode()); err != nil {
+			rc.Close()
+			return err
+		}
+		rc.Close()
+	}
+	return nil
+}
+
+// isLibArtifact recognizes the library filename itself and every
+// versioned sibling / symlink alias that sits next to it. We keep
+// "libonnxruntime.1.24.4.dylib" (the real Mach-O), "libonnxruntime.dylib"
+// (the symlink), and the corresponding Linux ".so.<version>" forms —
+// dropping one of these would leave the other with a dangling link
+// target.
+func isLibArtifact(name, libName string) bool {
+	if name == libName {
+		return true
+	}
+	// Linux: libonnxruntime.so.1.24.4 alongside libonnxruntime.so.
+	if strings.HasPrefix(name, libName+".") {
+		return true
+	}
+	// Darwin: libonnxruntime.1.24.4.dylib alongside libonnxruntime.dylib.
+	if strings.HasPrefix(libName, "libonnxruntime.") && strings.HasSuffix(libName, ".dylib") {
+		if strings.HasPrefix(name, "libonnxruntime.") && strings.HasSuffix(name, ".dylib") {
+			return true
+		}
+	}
+	return false
+}
+
+func writeReg(dest string, r io.Reader, mode fs.FileMode) error {
+	_ = os.Remove(dest)
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return fmt.Errorf("ort: create %s: %w", dest, err)
+	}
+	if _, err := io.Copy(out, r); err != nil {
+		out.Close()
+		return fmt.Errorf("ort: write %s: %w", dest, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("ort: close %s: %w", dest, err)
+	}
+	return nil
+}

--- a/internal/ort/ort_test.go
+++ b/internal/ort/ort_test.go
@@ -1,0 +1,288 @@
+package ort
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestBootstrap exercises the full download → verify → extract → cache
+// pipeline against an httptest-served fake release. The pinned SHA256
+// map is swapped at test start so the archive we generate in-memory
+// matches the "pinned" digest Bootstrap checks against — this proves
+// the verification path runs and accepts only the right bytes, without
+// depending on the live GitHub release (which would break CI whenever
+// GitHub is slow or the caller is air-gapped).
+func TestBootstrap(t *testing.T) {
+	rel, ok := pinnedReleases[runtime.GOOS+"/"+runtime.GOARCH]
+	if !ok {
+		t.Skipf("no pinned release for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	archive, digest := buildFakeArchive(t, rel)
+
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if !strings.HasSuffix(r.URL.Path, "/v"+Version+"/"+strings.ReplaceAll(rel.Archive, "{version}", Version)) {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	withOverrides(t, srv.URL, rel.Archive, digest, rel.LibName, rel.archiveKind)
+
+	cacheDir := t.TempDir()
+
+	// Ensure neither env var leaks in from the dev machine. Both
+	// would short-circuit the very code path we're trying to test.
+	t.Setenv(EnvLibPath, "")
+	t.Setenv(EnvCacheDir, "")
+
+	// First call: must download.
+	got, err := Bootstrap(cacheDir)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	libPath := filepath.Join(got, rel.LibName)
+	if _, err := os.Stat(libPath); err != nil {
+		t.Fatalf("expected library at %s: %v", libPath, err)
+	}
+	if n := requests.Load(); n != 1 {
+		t.Errorf("first Bootstrap issued %d HTTP requests, want 1", n)
+	}
+
+	// Second call: must reuse the on-disk cache and NOT hit the
+	// network. This is the acceptance criterion from #73 ("Second
+	// run uses cached library").
+	got2, err := Bootstrap(cacheDir)
+	if err != nil {
+		t.Fatalf("Bootstrap (cached): %v", err)
+	}
+	if got2 != got {
+		t.Errorf("cached Bootstrap returned %q, want %q", got2, got)
+	}
+	if n := requests.Load(); n != 1 {
+		t.Errorf("cached Bootstrap issued %d HTTP requests, want 1 (no new download)", n)
+	}
+}
+
+// TestBootstrap_SHAMismatch pins the "SHA256 mismatch → clear error"
+// acceptance criterion from #73. A corrupted download, a mirror
+// serving the wrong bytes, or a pinned-version bump that forgot to
+// refresh the hash all surface through this path; returning OK on a
+// bad hash would silently load arbitrary bytes into CGO.
+func TestBootstrap_SHAMismatch(t *testing.T) {
+	rel, ok := pinnedReleases[runtime.GOOS+"/"+runtime.GOARCH]
+	if !ok {
+		t.Skipf("no pinned release for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	archive, _ := buildFakeArchive(t, rel)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	// Register a hash that does NOT match the archive bytes.
+	wrong := "0000000000000000000000000000000000000000000000000000000000000000"
+	withOverrides(t, srv.URL, rel.Archive, wrong, rel.LibName, rel.archiveKind)
+
+	t.Setenv(EnvLibPath, "")
+	t.Setenv(EnvCacheDir, "")
+	_, err := Bootstrap(t.TempDir())
+	if err == nil {
+		t.Fatal("Bootstrap on corrupt archive returned nil, want sha256 mismatch error")
+	}
+	if !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Errorf("error does not mention sha256 mismatch: %v", err)
+	}
+}
+
+// TestBootstrap_EnvShortcut pins the air-gap acceptance criterion:
+// DEADZONE_ORT_LIB_PATH must bypass the download entirely and return
+// the operator-provided directory verbatim. Any HTTP request at all
+// would break `--no-network` installs.
+func TestBootstrap_EnvShortcut(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected HTTP request to %s when %s is set", r.URL, EnvLibPath)
+		http.Error(w, "should not be called", http.StatusTeapot)
+	}))
+	defer srv.Close()
+
+	old := releaseBaseURL
+	releaseBaseURL = srv.URL
+	t.Cleanup(func() { releaseBaseURL = old })
+
+	preset := t.TempDir()
+	t.Setenv(EnvLibPath, preset)
+
+	got, err := Bootstrap(t.TempDir())
+	if err != nil {
+		t.Fatalf("Bootstrap with %s set: %v", EnvLibPath, err)
+	}
+	if got != preset {
+		t.Errorf("Bootstrap returned %q, want preset %q", got, preset)
+	}
+}
+
+// TestBootstrap_UnsupportedPlatform verifies that a GOOS/GOARCH with
+// no pinned release surfaces ErrUnsupportedPlatform rather than a
+// generic 404 from GitHub or a silent stall. Without this, Windows
+// arm64 users (today's unlisted platform) would get a confusing
+// "HTTP 404" instead of the "set DEADZONE_ORT_LIB_PATH" guidance.
+func TestBootstrap_UnsupportedPlatform(t *testing.T) {
+	old := pinnedReleases
+	pinnedReleases = map[string]release{}
+	t.Cleanup(func() { pinnedReleases = old })
+
+	t.Setenv(EnvLibPath, "")
+	t.Setenv(EnvCacheDir, "")
+
+	_, err := Bootstrap(t.TempDir())
+	if !errors.Is(err, ErrUnsupportedPlatform) {
+		t.Errorf("Bootstrap on unsupported platform: got %v, want ErrUnsupportedPlatform", err)
+	}
+}
+
+// TestDefaultCacheDir_EnvOverride guards the CI convention: pointing
+// DEADZONE_ORT_CACHE at a workspace-local path so actions/cache can
+// persist the download across runs. Drift here silently re-downloads
+// the 30 MB archive on every CI job.
+func TestDefaultCacheDir_EnvOverride(t *testing.T) {
+	t.Setenv(EnvCacheDir, "/tmp/custom-ort-cache")
+	if got := DefaultCacheDir(); got != "/tmp/custom-ort-cache" {
+		t.Errorf("DefaultCacheDir() = %q, want /tmp/custom-ort-cache", got)
+	}
+}
+
+// withOverrides installs a single release mapping for the current
+// platform plus a test-owned releaseBaseURL, restoring both when the
+// test completes. Centralising it keeps the per-test boilerplate
+// short and prevents one test from leaking overrides into another.
+func withOverrides(t *testing.T, baseURL, archiveTmpl, sha256Hex, libName, kind string) {
+	t.Helper()
+	oldURL := releaseBaseURL
+	oldMap := pinnedReleases
+	releaseBaseURL = baseURL
+	pinnedReleases = map[string]release{
+		runtime.GOOS + "/" + runtime.GOARCH: {
+			Archive:     archiveTmpl,
+			SHA256:      sha256Hex,
+			LibName:     libName,
+			archiveKind: kind,
+		},
+	}
+	t.Cleanup(func() {
+		releaseBaseURL = oldURL
+		pinnedReleases = oldMap
+	})
+}
+
+// buildFakeArchive produces a minimal release archive — either a
+// gzip-wrapped tarball or a zip — that mirrors the upstream layout
+// closely enough to exercise the extractor. The returned digest is
+// the sha256 of the archive bytes, which the caller pins into
+// pinnedReleases so Bootstrap accepts the archive as authentic.
+func buildFakeArchive(t *testing.T, rel release) ([]byte, string) {
+	t.Helper()
+	dummy := []byte("not a real shared library — test fixture")
+	var buf bytes.Buffer
+	switch rel.archiveKind {
+	case "tgz":
+		gz := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gz)
+		// lib/<libName> as a regular file, plus a sibling symlink
+		// to exercise the TypeSymlink branch. The "top-level dir"
+		// mirrors the upstream layout (onnxruntime-osx-arm64-<v>/),
+		// even though extractor only looks at path.Base.
+		top := "onnxruntime-fixture/"
+		write := func(name string, body []byte) {
+			h := &tar.Header{
+				Name:     top + "lib/" + name,
+				Mode:     0o644,
+				Size:     int64(len(body)),
+				Typeflag: tar.TypeReg,
+			}
+			if err := tw.WriteHeader(h); err != nil {
+				t.Fatalf("tar header: %v", err)
+			}
+			if _, err := tw.Write(body); err != nil {
+				t.Fatalf("tar write: %v", err)
+			}
+		}
+		// Versioned sibling first (holds the real bytes), then the
+		// symlink alias that most callers open by name.
+		var versioned string
+		if strings.HasSuffix(rel.LibName, ".dylib") {
+			versioned = strings.TrimSuffix(rel.LibName, ".dylib") + ".1.24.4.dylib"
+		} else {
+			versioned = rel.LibName + ".1.24.4"
+		}
+		write(versioned, dummy)
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     top + "lib/" + rel.LibName,
+			Mode:     0o777,
+			Typeflag: tar.TypeSymlink,
+			Linkname: versioned,
+		}); err != nil {
+			t.Fatalf("tar symlink header: %v", err)
+		}
+		// Noise entries that the extractor must ignore — a
+		// non-library file next to the dylib, and a file outside
+		// lib/ entirely. If the filter regresses and grabs these,
+		// the cache fills up with garbage.
+		if err := tw.WriteHeader(&tar.Header{
+			Name: top + "LICENSE", Mode: 0o644, Size: 4, Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("tar noise header: %v", err)
+		}
+		if _, err := tw.Write([]byte("MIT\n")); err != nil {
+			t.Fatalf("tar noise write: %v", err)
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatalf("tar close: %v", err)
+		}
+		if err := gz.Close(); err != nil {
+			t.Fatalf("gzip close: %v", err)
+		}
+	case "zip":
+		zw := zip.NewWriter(&buf)
+		w, err := zw.Create("onnxruntime-fixture/lib/" + rel.LibName)
+		if err != nil {
+			t.Fatalf("zip create: %v", err)
+		}
+		if _, err := w.Write(dummy); err != nil {
+			t.Fatalf("zip write: %v", err)
+		}
+		nw, err := zw.Create("onnxruntime-fixture/LICENSE")
+		if err != nil {
+			t.Fatalf("zip noise create: %v", err)
+		}
+		if _, err := nw.Write([]byte("MIT\n")); err != nil {
+			t.Fatalf("zip noise write: %v", err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatalf("zip close: %v", err)
+		}
+	default:
+		t.Fatalf("unknown archive kind %q", rel.archiveKind)
+	}
+	sum := sha256.Sum256(buf.Bytes())
+	return buf.Bytes(), hex.EncodeToString(sum[:])
+}

--- a/justfile
+++ b/justfile
@@ -18,9 +18,10 @@
 # library itself is a static archive from
 # https://github.com/daulet/tokenizers/releases — place it in ./lib/ or
 # override the env var. The ORT shared library (libonnxruntime.{dylib,so})
-# is resolved at runtime via DEADZONE_ORT_LIB_PATH — see internal/embed.
-# #73 will add auto-download for the ORT shared library; #74 will wire
-# both native deps into release CI.
+# is downloaded + SHA256-verified + cached on first run by
+# internal/ort.Bootstrap; set DEADZONE_ORT_LIB_PATH to bypass the
+# download and point at a hand-positioned library (air-gapped installs).
+# #74 will wire libtokenizers.a into release CI.
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
 


### PR DESCRIPTION
## Summary

- Add `internal/ort` package that downloads the pinned ONNX Runtime release from GitHub, SHA256-verifies the archive, extracts the shared library into a per-user cache (`~/.cache/deadzone/ort/v1.24.4/`), and reuses it on subsequent runs
- Wire `ort.Bootstrap` into `internal/embed.NewHugot` so users no longer need to manually install libonnxruntime or set `DEADZONE_ORT_LIB_PATH`
- Remove the ORT download step from CI's `install-native-deps` action — the library is now fetched at test time and cached via `actions/cache` keyed on `internal/ort/ort.go`

## Details

### `internal/ort/ort.go`
- Pinned release table for `darwin/arm64`, `linux/amd64`, `linux/arm64`, `windows/amd64` with SHA256 digests
- Atomic extraction via scratch dir + rename to prevent partial-cache corruption
- `DEADZONE_ORT_LIB_PATH` escape hatch for air-gapped / corp-proxy environments
- `DEADZONE_ORT_CACHE` env var for CI cache path control

### `internal/ort/ort_test.go`
- Full download → verify → extract → cache round-trip against `httptest` server
- SHA256 mismatch rejection
- `DEADZONE_ORT_LIB_PATH` bypass
- Unsupported platform error surfacing

### CI changes
- Removed `ONNXRUNTIME_VERSION` env and manual ORT download from `install-native-deps`
- Added `DEADZONE_ORT_CACHE` env and `actions/cache` step for the ORT library
- Removed `DEADZONE_ORT_LIB_PATH` from test steps (Bootstrap handles it)

## Test plan

- [x] `go test -tags ORT ./internal/ort/...` passes locally
- [ ] CI green on `linux/amd64` (cold + warm cache)
- [ ] Verify `DEADZONE_ORT_LIB_PATH=/some/dir` still bypasses download

<!-- emdash-issue-footer:start -->
Fixes #73
<!-- emdash-issue-footer:end -->