### PR TITLE
feat: add fetch-tokenizers recipe to bootstrap libtokenizers.a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /artifacts/*.db
 /artifacts/*.db-wal
 /artifacts/*.db-shm
+# libtokenizers.a and friends land here via `just fetch-tokenizers`;
+# it's a dev artifact directory, never tracked.
+/lib/
 /.envrc
 .DS_Store
 .mcp.json

--- a/README.md
+++ b/README.md
@@ -64,18 +64,21 @@ Go 1.26.2 and [`just`](https://just.systems) are pinned via [`.mise.toml`](.mise
 # 1. Install the pinned toolchain — Go + just (one-time)
 mise install
 
-# 2. Build — no CGO required
-just build             # = mise exec -- go build ./...
+# 2. Fetch libtokenizers.a for your platform into ./lib/ (one-time, idempotent)
+just fetch-tokenizers  # darwin-arm64, linux-amd64, linux-arm64
 
-# 3. Pull pre-built per-lib artifacts from the rolling GitHub Release
+# 3. Build (CGO + -tags ORT, links ./lib/libtokenizers.a)
+just build             # = mise exec -- go build -tags ORT ./...
+
+# 4. Pull pre-built per-lib artifacts from the rolling GitHub Release
 just packs-download    # = mise exec -- go run ./cmd/packs download -artifacts ./artifacts -manifest ./artifacts/manifest.yaml
 # → reads artifacts/manifest.yaml and downloads every referenced .db
 # → verifies sha256 on the way down; aborts loudly on mismatch
 
-# 4. Merge the per-lib artifacts into the main deadzone.db
+# 5. Merge the per-lib artifacts into the main deadzone.db
 just consolidate       # = mise exec -- go run ./cmd/consolidate -db deadzone.db -artifacts ./artifacts
 
-# 5. Run the MCP server against the consolidated DB
+# 6. Run the MCP server against the consolidated DB
 just serve             # = mise exec -- go run ./cmd/server -db deadzone.db
 ```
 

--- a/justfile
+++ b/justfile
@@ -16,11 +16,13 @@
 # By default recipes pass -L./lib to cgo. Set DEADZONE_TOKENIZERS_LIB to
 # point `go build` at a different directory (e.g. /opt/homebrew/lib). The
 # library itself is a static archive from
-# https://github.com/daulet/tokenizers/releases — place it in ./lib/ or
-# override the env var. The ORT shared library (libonnxruntime.{dylib,so})
-# is downloaded + SHA256-verified + cached on first run by
-# internal/ort.Bootstrap; set DEADZONE_ORT_LIB_PATH to bypass the
-# download and point at a hand-positioned library (air-gapped installs).
+# https://github.com/daulet/tokenizers/releases — run `just
+# fetch-tokenizers` once after cloning to drop the right prebuilt into
+# ./lib/ for your platform (or hand-place one and override the env var).
+# The ORT shared library (libonnxruntime.{dylib,so}) is downloaded +
+# SHA256-verified + cached on first run by internal/ort.Bootstrap; set
+# DEADZONE_ORT_LIB_PATH to bypass the download and point at a
+# hand-positioned library (air-gapped installs).
 # #74 will wire libtokenizers.a into release CI.
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
@@ -32,6 +34,34 @@ default:
 # Install the pinned toolchain (Go + just) via mise — one-time bootstrap
 bootstrap:
     mise install
+
+# Idempotent: skips the download if the file already exists at the
+# expected path. Set TOKENIZERS_VERSION to override the pinned version
+# (default must match .github/workflows/ci.yml).
+#
+# Download libtokenizers.a for the current platform into ./lib/.
+fetch-tokenizers:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ver="${TOKENIZERS_VERSION:-v1.26.0}"
+    target="${DEADZONE_TOKENIZERS_LIB:-./lib}"
+    if [ -f "${target}/libtokenizers.a" ]; then
+        echo "libtokenizers.a already present at ${target}/"
+        exit 0
+    fi
+    case "$(uname -sm)" in
+        "Darwin arm64") asset="libtokenizers.darwin-arm64.tar.gz" ;;
+        "Linux x86_64") asset="libtokenizers.linux-amd64.tar.gz" ;;
+        "Linux aarch64"|"Linux arm64") asset="libtokenizers.linux-arm64.tar.gz" ;;
+        *) echo "unsupported platform: $(uname -sm)" >&2; exit 1 ;;
+    esac
+    mkdir -p "${target}"
+    url="https://github.com/daulet/tokenizers/releases/download/${ver}/${asset}"
+    echo "fetching ${url}"
+    curl -fL -o "${target}/tok.tgz" "${url}"
+    tar -C "${target}" -xzf "${target}/tok.tgz"
+    rm "${target}/tok.tgz"
+    echo "libtokenizers.a → ${target}/libtokenizers.a"
 
 # Compile every package. Fast sanity check; produces no binaries.
 build:


### PR DESCRIPTION
## Summary

- Add `just fetch-tokenizers` recipe that downloads the correct prebuilt `libtokenizers.a` archive for the current platform (darwin-arm64, linux-amd64, linux-arm64) into `./lib/`
- Idempotent — skips download when the file already exists; version is pinnable via `TOKENIZERS_VERSION` env var (default `v1.26.0`)
- Add `/lib/` to `.gitignore` so the downloaded artifact is never tracked
- Update README quickstart to include the new fetch step and renumber subsequent steps

<!-- emdash-issue-footer:start -->
Fixes #84
<!-- emdash-issue-footer:end -->