### PR TITLE
feat(ci): add CGO-native release workflow for multi-platform builds

### DIFF
--- a/.github/actions/install-native-deps/action.yml
+++ b/.github/actions/install-native-deps/action.yml
@@ -3,8 +3,13 @@ description: |
   Download and install the libtokenizers.a static archive that hugot's
   ORT backend links against at build time. The onnxruntime shared
   library is NOT installed here — internal/ort.Bootstrap downloads,
-  SHA256-verifies, and caches it at first use (see #73). Linux amd64
-  only for now; a macOS / arm64 matrix will land with #74.
+  SHA256-verifies, and caches it at first use (see #73).
+
+  Runs on Linux amd64/arm64 and macOS arm64. The asset is picked from
+  the daulet/tokenizers release matching `$TOKENIZERS_VERSION` (set in
+  the caller workflow env). Output lives at
+  /tmp/deadzone-deps/tokenizers/libtokenizers.a — point CGO_LDFLAGS or
+  DEADZONE_TOKENIZERS_LIB at that directory.
 runs:
   using: composite
   steps:
@@ -13,10 +18,13 @@ runs:
       uses: actions/cache@v5
       with:
         path: /tmp/deadzone-deps
-        # Versions live in the workflow env, but composite actions cannot
-        # read ${{ env.* }} from the caller. Key on the workflow file so
-        # bumping the pinned version in ci.yml invalidates the cache.
-        key: deadzone-deps-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+        # Composite actions cannot read ${{ env.* }} from the caller,
+        # so we key on the caller workflow file — bumping the pinned
+        # TOKENIZERS_VERSION there naturally invalidates the cache.
+        # runner.arch is in the key because ubuntu-24.04 and
+        # ubuntu-24.04-arm both report runner.os=Linux but need
+        # different .a archives.
+        key: deadzone-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/ci.yml', '.github/workflows/release.yml') }}
     - name: Download libtokenizers.a
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
@@ -24,13 +32,20 @@ runs:
         set -euo pipefail
         tok_version="${TOKENIZERS_VERSION:?TOKENIZERS_VERSION must be set in the caller workflow env}"
 
+        case "$(uname -sm)" in
+          "Darwin arm64")           asset="libtokenizers.darwin-arm64.tar.gz" ;;
+          "Linux x86_64")           asset="libtokenizers.linux-amd64.tar.gz" ;;
+          "Linux aarch64"|"Linux arm64") asset="libtokenizers.linux-arm64.tar.gz" ;;
+          *) echo "unsupported platform: $(uname -sm)" >&2; exit 1 ;;
+        esac
+
         mkdir -p /tmp/deadzone-deps/tokenizers
         cd /tmp
 
-        # daulet/tokenizers ships libtokenizers.a inside a tarball whose
-        # top level IS the .a file (no surrounding directory).
+        # daulet/tokenizers tarballs unpack a bare libtokenizers.a (no
+        # wrapping directory), so the extract target is the final dir.
         curl -fL -o libtokenizers.tgz \
-          "https://github.com/daulet/tokenizers/releases/download/${tok_version}/libtokenizers.linux-amd64.tar.gz"
+          "https://github.com/daulet/tokenizers/releases/download/${tok_version}/${asset}"
         tar -xzf libtokenizers.tgz -C /tmp/deadzone-deps/tokenizers
         rm libtokenizers.tgz
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+name: Release
+
+# Triggered by a tag push like `git tag v0.1.0-rc1 && git push --tags`.
+# Builds the four deadzone CLIs natively on one runner per target,
+# uploads per-platform tarballs as build artifacts, then aggregates
+# them into a GitHub Release with a sha256 checksums file.
+#
+# Native runners (no cross-compile) because the hugot ORT backend
+# requires CGO_ENABLED=1 and a matching libtokenizers.a — see #70 for
+# the full comparison against goreleaser-cross / Zig CC.
+on:
+  push:
+    tags: ['v*']
+  # Manual trigger for dry-run testing on a branch. The matrix still
+  # runs, but the aggregation job skips `gh release create` because
+  # there is no tag to attach assets to.
+  workflow_dispatch:
+
+# TOKENIZERS_VERSION is the daulet/tokenizers release tag; bumping is
+# a conscious step — the composite action keys its cache on this file
+# so a bump invalidates cached archives on all three runners.
+env:
+  TOKENIZERS_VERSION: v1.26.0
+
+jobs:
+  build:
+    name: build (${{ matrix.goos }}/${{ matrix.goarch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            goos: darwin
+            goarch: arm64
+          - runner: ubuntu-24.04
+            goos: linux
+            goarch: amd64
+          # GitHub's free public arm64 label is `ubuntu-24.04-arm`
+          # (not `-arm64` as the issue body suggests).
+          - runner: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      # mise supplies the Go + just versions pinned in .mise.toml, so
+      # CI builds with the same toolchain as a dev laptop running
+      # `just build-release`.
+      - uses: jdx/mise-action@v2
+
+      - name: Install native deps
+        uses: ./.github/actions/install-native-deps
+
+      - name: Resolve version metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          # On a tag push github.ref_name is the tag (v0.1.0); on
+          # workflow_dispatch it is the branch name, which we fall
+          # back to `git describe` to keep the binary self-labelling.
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="$(git describe --tags --dirty --always)"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      # `just build-release` wires VERSION/COMMIT/DATE into ldflags and
+      # passes -trimpath + -s -w. Keeping the build logic in the
+      # justfile (not inlined here) is deliberate — so the local
+      # `just build-release` on a dev laptop produces byte-identical
+      # flags to CI.
+      - name: Build binaries
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          COMMIT: ${{ github.sha }}
+          DATE: ${{ steps.meta.outputs.date }}
+          DEADZONE_TOKENIZERS_LIB: /tmp/deadzone-deps/tokenizers
+        run: just build-release
+
+      # Smoke test: the -version flag short-circuits embedder and DB
+      # load, so it runs on any machine without a model cache. This
+      # also proves ldflags injection actually landed.
+      - name: Smoke test -version
+        run: |
+          ./deadzone-server -version
+          ./deadzone-scraper -version
+          ./deadzone-consolidate -version
+          ./deadzone-packs -version
+
+      - name: Package archive
+        id: pkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          name="deadzone_${{ steps.meta.outputs.version }}_${{ matrix.goos }}_${{ matrix.goarch }}"
+          mkdir "${name}"
+          cp deadzone-server deadzone-scraper deadzone-consolidate deadzone-packs "${name}/"
+          cp LICENSE NOTICE README.md "${name}/"
+          tar -czf "${name}.tar.gz" "${name}"
+          echo "archive=${name}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: deadzone-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ${{ steps.pkg.outputs.archive }}
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-24.04
+    # Only publish on an actual tag push. workflow_dispatch runs the
+    # matrix (useful to validate the build on a branch) but does not
+    # touch the Releases page.
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: deadzone-*
+          merge-multiple: true
+          path: dist
+
+      - name: Compute checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum deadzone_*.tar.gz > "deadzone_${GITHUB_REF_NAME}_checksums.txt"
+          cat "deadzone_${GITHUB_REF_NAME}_checksums.txt"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            dist/deadzone_*.tar.gz \
+            "dist/deadzone_${GITHUB_REF_NAME}_checksums.txt"

--- a/justfile
+++ b/justfile
@@ -23,7 +23,6 @@
 # SHA256-verified + cached on first run by internal/ort.Bootstrap; set
 # DEADZONE_ORT_LIB_PATH to bypass the download and point at a
 # hand-positioned library (air-gapped installs).
-# #74 will wire libtokenizers.a into release CI.
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` — a tag-triggered release pipeline that builds all four deadzone CLIs natively (no cross-compile) on macOS arm64, Linux amd64, and Linux arm64 runners
- Update `.github/actions/install-native-deps` to support all three platforms via `uname -sm` detection, and add `runner.arch` to the cache key so Linux amd64/arm64 don't collide
- Remove stale `#74` TODO comment from justfile

## Details

The hugot ORT backend requires `CGO_ENABLED=1` with a platform-matched `libtokenizers.a`, making goreleaser-cross impractical (see #70). Instead, each target gets its own native runner:

| Target | Runner |
|---|---|
| darwin/arm64 | `macos-15` |
| linux/amd64 | `ubuntu-24.04` |
| linux/arm64 | `ubuntu-24.04-arm` |

The workflow:
1. Builds via `just build-release` (same ldflags as local dev)
2. Smoke-tests each binary with `-version`
3. Packages platform tarballs with LICENSE/NOTICE/README
4. Aggregates artifacts into a GitHub Release with SHA256 checksums

`workflow_dispatch` is supported for dry-run testing on branches (skips the release publish step).

## Test plan

- [ ] Trigger `workflow_dispatch` on this branch to validate all three matrix legs build successfully
- [ ] Verify cached deps are keyed correctly (cache miss on first run, hit on re-run)
- [ ] Tag a pre-release (`v0.x.0-rc1`) to validate end-to-end release creation with checksums

<!-- emdash-issue-footer:start -->
Fixes #74
<!-- emdash-issue-footer:end -->