### PR TITLE
feat: ship prebuilt deadzone.db in tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,10 +114,10 @@ jobs:
     name: publish release
     needs: build
     runs-on: ubuntu-24.04
-    # Only publish on an actual tag push. workflow_dispatch runs the
-    # matrix (useful to validate the build on a branch) but does not
-    # touch the Releases page.
-    if: github.event_name == 'push' && github.ref_type == 'tag'
+    # The job itself runs for both tag pushes and workflow_dispatch so
+    # the dry-run path can validate the prebuilt-DB pipeline on a
+    # branch. Only the final `gh release create` step is gated on an
+    # actual tag push — see #90.
     permissions:
       contents: write
     steps:
@@ -129,23 +129,91 @@ jobs:
           merge-multiple: true
           path: dist
 
-      - name: Compute checksums
+      - name: Resolve version metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Mirror the build job: tag push → tag name, dispatch → git describe.
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="$(git describe --tags --dirty --always)"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract linux_amd64 tarball for bundled tools
+        shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          tar -xzf "dist/deadzone_${VERSION}_linux_amd64.tar.gz" -C /tmp
+          # Put deadzone-packs + deadzone-consolidate on PATH for the next steps.
+          echo "/tmp/deadzone_${VERSION}_linux_amd64" >> "$GITHUB_PATH"
+
+      - name: Build consolidated deadzone.db from rolling packs release
+        env:
+          # `deadzone-packs download` shells out to `gh release download`,
+          # which needs an auth token on ubuntu-24.04 runners.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Keep hugot's first-run model download inside the job workspace;
+          # second-run cache reuse is irrelevant for a single-shot CI job.
+          DEADZONE_HUGOT_CACHE: /tmp/deadzone-models
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts "$DEADZONE_HUGOT_CACHE"
+          # artifacts/manifest.yaml is committed in the repo; it names every
+          # per-lib .db asset on the rolling `packs` release. The operator
+          # runs `deadzone-packs upload` locally before tagging.
+          deadzone-packs download
+          deadzone-consolidate
+          ls -l deadzone.db
+          # Move into dist/ so the checksums + release upload steps see it
+          # alongside the per-platform tarballs.
+          mv deadzone.db dist/
+
+      - name: Compute checksums (tarballs + deadzone.db)
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
           cd dist
-          sha256sum deadzone_*.tar.gz > "deadzone_${GITHUB_REF_NAME}_checksums.txt"
-          cat "deadzone_${GITHUB_REF_NAME}_checksums.txt"
+          # Single checksums.txt covers every release asset — users who want
+          # to verify more than the DB hit one file, one command.
+          sha256sum deadzone_*.tar.gz deadzone.db > "deadzone_${VERSION}_checksums.txt"
+          # Standalone deadzone.db.sha256 for the one-curl UX in the README,
+          # so `sha256sum -c deadzone.db.sha256` Just Works without parsing
+          # the aggregated checksums file.
+          sha256sum deadzone.db > deadzone.db.sha256
+          cat "deadzone_${VERSION}_checksums.txt"
+
+      - name: Upload deadzone.db as workflow artifact (dry-run visibility)
+        uses: actions/upload-artifact@v4
+        with:
+          name: deadzone-db
+          path: |
+            dist/deadzone.db
+            dist/deadzone.db.sha256
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Create GitHub release
+        # Tag-push only; workflow_dispatch stops after the artifact upload.
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.meta.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
-          gh release create "$GITHUB_REF_NAME" \
+          gh release create "$VERSION" \
             --repo "$GITHUB_REPOSITORY" \
-            --title "$GITHUB_REF_NAME" \
+            --title "$VERSION" \
             --generate-notes \
             dist/deadzone_*.tar.gz \
-            "dist/deadzone_${GITHUB_REF_NAME}_checksums.txt"
+            "dist/deadzone_${VERSION}_checksums.txt" \
+            dist/deadzone.db \
+            dist/deadzone.db.sha256

--- a/README.md
+++ b/README.md
@@ -127,7 +127,33 @@ The single CGO surface (hugot's ORT backend + `libtokenizers.a`) is the 2026-04-
 
 ### Hello-world pipeline
 
-Fetch the artifact manifest, pull the pre-scraped library packs, merge them into a single database, and serve MCP over stdio:
+Two paths, pick one. The first is the fastest way to get a working `deadzone.db`; the second is what you want if you're tracking the rolling corpus between tagged releases.
+
+#### One-curl path (prebuilt DB, tagged releases)
+
+Starting with `v0.1.0`, every tagged release ships a prebuilt `deadzone.db` covering the libraries listed in [`libraries_sources.yaml`](libraries_sources.yaml). Grab the binary tarball, then the DB, and you're done:
+
+```bash
+VERSION=v0.1.0
+
+curl -L -o deadzone.db \
+  "https://github.com/laradji/deadzone/releases/download/${VERSION}/deadzone.db"
+curl -L -o deadzone.db.sha256 \
+  "https://github.com/laradji/deadzone/releases/download/${VERSION}/deadzone.db.sha256"
+
+# Linux
+sha256sum -c deadzone.db.sha256
+# macOS
+shasum -a 256 -c deadzone.db.sha256
+
+./deadzone-server -db deadzone.db  # MCP stdio server
+```
+
+The aggregated `deadzone_${VERSION}_checksums.txt` release asset also includes the `deadzone.db` hash, so `sha256sum --ignore-missing -c deadzone_${VERSION}_checksums.txt` works against everything in one shot.
+
+#### Three-step path (rolling corpus, latest per-lib artifacts)
+
+Use this when you want the freshest per-lib artifacts (refreshed between tags), or when you've pulled a single library via `deadzone-packs download lib=/org/project` and want to re-consolidate:
 
 ```bash
 mkdir -p artifacts

--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -49,3 +49,100 @@ libraries:
       - https://fastapi.tiangolo.com/tutorial/handling-errors/
       - https://fastapi.tiangolo.com/tutorial/dependencies/
       - https://fastapi.tiangolo.com/tutorial/security/
+
+  # OpenJDK — Java SE 21 API reference. Kind chosen because docs.oracle.com
+  # serves pre-rendered javadoc HTML, not raw markdown. Scrape operator may
+  # want to add more classes; these six are the highest-traffic entries.
+  - lib_id: /openjdk/jdk
+    kind: scrape-via-agent
+    urls:
+      - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/String.html
+      - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/List.html
+      - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Map.html
+      - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Optional.html
+      - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/stream/Stream.html
+      - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/CompletableFuture.html
+
+  # Python stdlib — docs.python.org is HTML (Sphinx-rendered).
+  - lib_id: /python/cpython
+    kind: scrape-via-agent
+    urls:
+      - https://docs.python.org/3/library/os.html
+      - https://docs.python.org/3/library/sys.html
+      - https://docs.python.org/3/library/pathlib.html
+      - https://docs.python.org/3/library/json.html
+      - https://docs.python.org/3/library/collections.html
+      - https://docs.python.org/3/library/itertools.html
+      - https://docs.python.org/3/library/functools.html
+      - https://docs.python.org/3/library/subprocess.html
+
+  # HashiCorp Terraform — developer.hashicorp.com is a Next.js site, HTML-only.
+  - lib_id: /hashicorp/terraform
+    kind: scrape-via-agent
+    urls:
+      - https://developer.hashicorp.com/terraform/intro
+      - https://developer.hashicorp.com/terraform/language
+      - https://developer.hashicorp.com/terraform/language/resources
+      - https://developer.hashicorp.com/terraform/language/values/variables
+      - https://developer.hashicorp.com/terraform/language/state
+      - https://developer.hashicorp.com/terraform/language/modules
+      - https://developer.hashicorp.com/terraform/language/providers
+      - https://developer.hashicorp.com/terraform/cli/commands
+
+  # OpenTofu — Docusaurus site at opentofu.org/docs (HTML).
+  - lib_id: /opentofu/opentofu
+    kind: scrape-via-agent
+    urls:
+      - https://opentofu.org/docs/intro/
+      - https://opentofu.org/docs/language/
+      - https://opentofu.org/docs/language/resources/
+      - https://opentofu.org/docs/language/modules/
+      - https://opentofu.org/docs/language/state/
+      - https://opentofu.org/docs/cli/commands/
+
+  # OVHcloud Go SDK — README is the canonical reference.
+  - lib_id: /ovh/go-ovh
+    kind: github-md
+    urls:
+      - https://raw.githubusercontent.com/ovh/go-ovh/master/README.md
+
+  # OVHcloud CLI (v2). Canonical repo name is `ovhcloud-cli`, not `ovh-cli`.
+  - lib_id: /ovh/ovhcloud-cli
+    kind: github-md
+    urls:
+      - https://raw.githubusercontent.com/ovh/ovhcloud-cli/main/README.md
+
+  # OVHcloud Terraform provider — README + top-level provider doc.
+  - lib_id: /ovh/terraform-provider-ovh
+    kind: github-md
+    urls:
+      - https://raw.githubusercontent.com/ovh/terraform-provider-ovh/master/README.md
+      - https://raw.githubusercontent.com/ovh/terraform-provider-ovh/master/docs/index.md
+
+  # Scaleway Go SDK — canonical Scaleway SDK.
+  - lib_id: /scaleway/scaleway-sdk-go
+    kind: github-md
+    urls:
+      - https://raw.githubusercontent.com/scaleway/scaleway-sdk-go/main/README.md
+
+  # Scaleway CLI — README + cookbook + v2 migration guide.
+  - lib_id: /scaleway/scaleway-cli
+    kind: github-md
+    urls:
+      - https://raw.githubusercontent.com/scaleway/scaleway-cli/main/README.md
+      - https://raw.githubusercontent.com/scaleway/scaleway-cli/main/docs/cookbook.md
+      - https://raw.githubusercontent.com/scaleway/scaleway-cli/main/docs/migration_guide_v2.md
+
+  # Scaleway Terraform provider — README + top-level provider doc.
+  - lib_id: /scaleway/terraform-provider-scaleway
+    kind: github-md
+    urls:
+      - https://raw.githubusercontent.com/scaleway/terraform-provider-scaleway/main/README.md
+      - https://raw.githubusercontent.com/scaleway/terraform-provider-scaleway/main/docs/index.md
+
+  # opencode (AI coding CLI, formerly sst/opencode, transferred to anomalyco).
+  # Default branch is `dev`, not `main`.
+  - lib_id: /anomalyco/opencode
+    kind: github-md
+    urls:
+      - https://raw.githubusercontent.com/anomalyco/opencode/dev/README.md


### PR DESCRIPTION
## Summary

- Extend the release workflow to build a consolidated `deadzone.db` from the rolling packs release and ship it alongside platform tarballs, with a standalone `deadzone.db.sha256` for one-command verification
- Gate the `gh release create` step (not the whole job) on tag pushes, so `workflow_dispatch` runs validate the full prebuilt-DB pipeline as a dry-run with artifact upload
- Add a "one-curl path" to the README for users who just want the prebuilt DB from a tagged release, keeping the existing three-step rolling-corpus path as an alternative
- Expand `libraries_sources.yaml` with 11 new library sources: OpenJDK, Python stdlib, Terraform, OpenTofu, OVH Go SDK, OVHcloud CLI, OVH Terraform provider, Scaleway Go SDK, Scaleway CLI, Scaleway Terraform provider, and opencode

## Key changes

- **`.github/workflows/release.yml`** — new steps: resolve version metadata, extract linux_amd64 tarball for bundled tools, `deadzone-packs download` + `deadzone-consolidate`, checksums covering `deadzone.db`, workflow artifact upload for dry-run visibility
- **`README.md`** — two-path hello-world: one-curl (prebuilt DB) and three-step (rolling corpus)
- **`libraries_sources.yaml`** — 11 new `scrape-via-agent` and `github-md` entries

## Test plan

- [ ] Trigger `workflow_dispatch` on this branch and verify the dry-run uploads `deadzone-db` as a workflow artifact with both `deadzone.db` and `deadzone.db.sha256`
- [ ] Verify the `sha256sum -c deadzone.db.sha256` check passes against the downloaded artifact
- [ ] Confirm `gh release create` step is skipped on dispatch (no release created)
- [ ] After merge, tag a release and confirm `deadzone.db` + `deadzone.db.sha256` appear in the GitHub release assets

<!-- emdash-issue-footer:start -->
Fixes #90
<!-- emdash-issue-footer:end -->