### PR TITLE
feat(packs): add per-artifact .db.state YAML sidecar metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,12 @@ mkdir -p artifacts
 curl -L -o artifacts/manifest.yaml \
   https://raw.githubusercontent.com/laradji/deadzone/main/artifacts/manifest.yaml
 
-./deadzone-packs download          # per-lib artifacts/*.db from the rolling release
+./deadzone-packs download          # pulls per-lib `.db` + `.db.state` pairs from the rolling release
 ./deadzone-consolidate             # artifacts/*.db → deadzone.db
 ./deadzone-server -db deadzone.db  # MCP stdio server
 ```
+
+Each `.db` ships with a small `.db.state` YAML sidecar (embedder, doc count, scrape dates) — `packs list` reads them to surface human-friendly columns and `packs upload` refuses to ship a `.db` without one.
 
 With the server running, point any MCP-capable client at it — see [Wire it into an MCP client](#wire-it-into-an-mcp-client) for the exact JSON snippet.
 

--- a/artifacts/manifest.yaml
+++ b/artifacts/manifest.yaml
@@ -9,6 +9,13 @@
 #   repo         optional default `owner/name` for downloads (the
 #                -repo CLI flag overrides this when explicitly set)
 #   packs        list of per-lib artifacts; one entry per lib_id
+#                (lib_id, asset, sha256, size, indexed_at — all
+#                describe the upload event)
+#
+# Content-level metadata (embedder, schema_version, url_count,
+# doc_count, created_at, updated_at) lives in the per-artifact
+# `<asset>.state` YAML sidecar published next to each `.db` on the
+# rolling release (#96).
 
 release_tag: packs
 repo: laradji/deadzone

--- a/cmd/packs/main.go
+++ b/cmd/packs/main.go
@@ -191,12 +191,16 @@ func runDownload(args []string) error {
 func runList(args []string) error {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 	manifestPath := fs.String("manifest", "./artifacts/manifest.yaml", "path to artifacts/manifest.yaml")
+	artifactsDir := fs.String("artifacts", "./artifacts", "directory to read local *.db.state sidecars from for the extended columns")
 	verbose := fs.Bool("verbose", false, "enable Debug-level slog output")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	slog.SetDefault(logs.New(os.Stderr, *verbose))
-	return packs.RunList(packs.ListOptions{ManifestPath: *manifestPath}, os.Stdout)
+	return packs.RunList(packs.ListOptions{
+		ManifestPath: *manifestPath,
+		ArtifactsDir: *artifactsDir,
+	}, os.Stdout)
 }
 
 // resolveRepo implements the three-tier repo resolution: explicit

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/laradji/deadzone/internal/db"
 	"github.com/laradji/deadzone/internal/embed"
 	"github.com/laradji/deadzone/internal/logs"
+	"github.com/laradji/deadzone/internal/packs"
 	"github.com/laradji/deadzone/internal/scraper"
 )
 
@@ -321,12 +322,35 @@ func scrapeLibToArtifact(
 	src scraper.ResolvedSource,
 ) (int, int, error) {
 	artifactPath := filepath.Join(artifactsDir, artifactFilename(src.LibID))
+	statePath := packs.StatePath(artifactPath)
+
+	// Read any pre-existing `.state` sidecar BEFORE the wipe loop so
+	// `created_at` survives a re-scrape. A missing file is the first-
+	// scrape case and is handled below by falling back to time.Now().
+	// Any other read/parse error is logged and treated as absent —
+	// the scraper is not going to abort a whole run because a sidecar
+	// is corrupt; the next successful write will overwrite it.
+	var existingState *packs.StateFile
+	if s, err := packs.LoadState(statePath); err == nil {
+		existingState = s
+	} else if !os.IsNotExist(err) {
+		slog.Warn("scraper.state_load_failed",
+			"lib_id", src.LibID,
+			"state_path", statePath,
+			"err", err.Error(),
+		)
+	}
 
 	// Wipe any prior artifact + tursogo sidecar files. The sidecars
 	// are journaling state; an orphaned -wal/-shm pointing at a now-
 	// deleted main file confuses the next Open. Errors from os.Remove
 	// for non-existent files are ignored — the only thing we care
 	// about is that nothing from a previous run survives this point.
+	//
+	// Note: we intentionally do NOT wipe the `.state` sidecar here —
+	// it carries the `created_at` value captured above. On a mid-scrape
+	// failure the `.state` is left untouched, still reflecting the last
+	// successful scrape (the re-run will overwrite both on success).
 	for _, p := range []string{artifactPath, artifactPath + "-wal", artifactPath + "-shm"} {
 		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
 			return 0, 0, fmt.Errorf("remove stale artifact %s: %w", p, err)
@@ -508,11 +532,39 @@ func scrapeLibToArtifact(
 		return docsTotal, skippedThisLib, fmt.Errorf("update lib count %q: %w", src.LibID, err)
 	}
 
+	// Write the `.state` sidecar AFTER the `.db` is committed and the
+	// libs catalog row is updated, so a failure mid-scrape leaves any
+	// pre-existing sidecar intact (operators can re-run the scrape to
+	// regenerate both). `created_at` is preserved from the sidecar we
+	// read before the wipe; absent or zero on the first scrape, in
+	// which case it is seeded from `now` below.
+	now := time.Now().UTC()
+	state := &packs.StateFile{
+		LibID:         src.LibID,
+		SchemaVersion: db.CurrentSchemaVersion,
+		Embedder: packs.EmbedderState{
+			Kind:  e.Kind(),
+			Model: e.ModelVersion(),
+			Dim:   e.Dim(),
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		URLCount:  len(src.URLs),
+		DocCount:  docsTotal,
+	}
+	if existingState != nil && !existingState.CreatedAt.IsZero() {
+		state.CreatedAt = existingState.CreatedAt
+	}
+	if err := state.Save(statePath); err != nil {
+		return docsTotal, skippedThisLib, fmt.Errorf("write state %s: %w", statePath, err)
+	}
+
 	slog.Info("scraper.lib_done",
 		"lib_id", src.LibID,
 		"docs_total", docsTotal,
 		"duration_ms", time.Since(libStart).Milliseconds(),
 		"artifact_path", artifactPath,
+		"state_path", statePath,
 	)
 	return docsTotal, skippedThisLib, nil
 }

--- a/cmd/scraper/main_test.go
+++ b/cmd/scraper/main_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/laradji/deadzone/internal/db"
+	"github.com/laradji/deadzone/internal/packs"
 	"github.com/laradji/deadzone/internal/scraper"
 )
 
@@ -186,6 +187,172 @@ func TestScrapeSources_UnknownKind(t *testing.T) {
 	}
 	if !strings.Contains(results[0].err.Error(), "unknown kind") {
 		t.Errorf("expected 'unknown kind' in err, got %v", results[0].err)
+	}
+}
+
+// markdownSrv spins up a minimal httptest.Server that returns a single
+// markdown page parsing into >=1 doc. Shared by the state-writing
+// tests to keep them dependency-free of the real internet.
+func markdownSrv(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown")
+		fmt.Fprint(w, "# Hi\n\n## Section\n\nContent body.\n")
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestScraper_WritesState_FirstScrape covers the happy first-scrape
+// path: no pre-existing `.state`, run scrape, assert sidecar appears
+// next to the `.db` with `created_at == updated_at` and the right
+// counts.
+func TestScraper_WritesState_FirstScrape(t *testing.T) {
+	t.Parallel()
+	srv := markdownSrv(t)
+
+	artifacts := t.TempDir()
+	e, meta := newStubMeta()
+	sources := []scraper.ResolvedSource{{
+		LibID: "/test/fresh", BaseLibID: "/test/fresh",
+		Kind: scraper.KindGithubMD, URLs: []string{srv.URL + "/p.md"},
+	}}
+
+	results := scrapeSources(context.Background(), http.DefaultClient, nil, e, meta, artifacts, sources,
+		map[string]int{scraper.KindGithubMD: 1})
+	if results[0].err != nil {
+		t.Fatalf("scrape failed: %v", results[0].err)
+	}
+
+	statePath := filepath.Join(artifacts, "test_fresh.db.state")
+	got, err := packs.LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState %s: %v", statePath, err)
+	}
+	if got.LibID != "/test/fresh" {
+		t.Errorf("LibID = %q", got.LibID)
+	}
+	if got.SchemaVersion != db.CurrentSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", got.SchemaVersion, db.CurrentSchemaVersion)
+	}
+	if got.Embedder.Kind != "stub" || got.Embedder.Dim != 8 {
+		t.Errorf("Embedder = %+v", got.Embedder)
+	}
+	if !got.CreatedAt.Equal(got.UpdatedAt) {
+		t.Errorf("first scrape: CreatedAt %v != UpdatedAt %v", got.CreatedAt, got.UpdatedAt)
+	}
+	if got.URLCount != 1 {
+		t.Errorf("URLCount = %d, want 1", got.URLCount)
+	}
+	if got.DocCount != results[0].docs {
+		t.Errorf("DocCount = %d, want docs from scrape = %d", got.DocCount, results[0].docs)
+	}
+}
+
+// TestScraper_WritesState_RescrapePreservesCreatedAt seeds a sidecar
+// with a past `created_at`, re-scrapes the same lib, and asserts the
+// `created_at` survives while `updated_at` advances.
+func TestScraper_WritesState_RescrapePreservesCreatedAt(t *testing.T) {
+	t.Parallel()
+	srv := markdownSrv(t)
+
+	artifacts := t.TempDir()
+	e, meta := newStubMeta()
+	libID := "/test/rescrape"
+	statePath := filepath.Join(artifacts, "test_rescrape.db.state")
+
+	pastCreated := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	seed := &packs.StateFile{
+		LibID: libID, SchemaVersion: 1,
+		Embedder:  packs.EmbedderState{Kind: "stale", Model: "stale-m", Dim: 8},
+		CreatedAt: pastCreated, UpdatedAt: pastCreated,
+		URLCount: 99, DocCount: 99,
+	}
+	if err := seed.Save(statePath); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	sources := []scraper.ResolvedSource{{
+		LibID: libID, BaseLibID: libID,
+		Kind: scraper.KindGithubMD, URLs: []string{srv.URL + "/p.md"},
+	}}
+	results := scrapeSources(context.Background(), http.DefaultClient, nil, e, meta, artifacts, sources,
+		map[string]int{scraper.KindGithubMD: 1})
+	if results[0].err != nil {
+		t.Fatalf("scrape failed: %v", results[0].err)
+	}
+
+	got, err := packs.LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if !got.CreatedAt.Equal(pastCreated) {
+		t.Errorf("CreatedAt = %v, want preserved %v", got.CreatedAt, pastCreated)
+	}
+	if !got.UpdatedAt.After(pastCreated) {
+		t.Errorf("UpdatedAt %v should be after CreatedAt %v", got.UpdatedAt, pastCreated)
+	}
+	// Counts and embedder identity should reflect the new run, not
+	// the seeded values.
+	if got.Embedder.Kind != "stub" {
+		t.Errorf("Embedder.Kind = %q, want stub (overwrite)", got.Embedder.Kind)
+	}
+	if got.URLCount != 1 {
+		t.Errorf("URLCount = %d, want 1 (overwrite)", got.URLCount)
+	}
+}
+
+// TestScraper_NoStateOnFailure: a pre-existing sidecar must be left
+// untouched if the scrape fails mid-way (the .db is wiped, but the
+// .state stays so an operator can still see the last successful
+// metadata until they re-run).
+func TestScraper_NoStateOnFailure(t *testing.T) {
+	t.Parallel()
+
+	failSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer failSrv.Close()
+
+	artifacts := t.TempDir()
+	e, meta := newStubMeta()
+	libID := "/test/keepstate"
+	statePath := filepath.Join(artifacts, "test_keepstate.db.state")
+
+	pastCreated := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	seed := &packs.StateFile{
+		LibID: libID, SchemaVersion: 1,
+		Embedder:  packs.EmbedderState{Kind: "old", Model: "old-m", Dim: 8},
+		CreatedAt: pastCreated, UpdatedAt: pastCreated,
+		URLCount: 99, DocCount: 7,
+	}
+	if err := seed.Save(statePath); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	originalBytes, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read seed: %v", err)
+	}
+
+	failURLs := make([]string, maxSkipsPerLib)
+	for i := range failURLs {
+		failURLs[i] = failSrv.URL + fmt.Sprintf("/x-%d.md", i)
+	}
+	sources := []scraper.ResolvedSource{{
+		LibID: libID, BaseLibID: libID, Kind: scraper.KindGithubMD, URLs: failURLs,
+	}}
+	results := scrapeSources(context.Background(), http.DefaultClient, nil, e, meta, artifacts, sources,
+		map[string]int{scraper.KindGithubMD: 1})
+	if results[0].err == nil {
+		t.Fatal("expected scrape to fail (skipped_ceiling)")
+	}
+
+	finalBytes, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read final state: %v", err)
+	}
+	if string(originalBytes) != string(finalBytes) {
+		t.Errorf("pre-existing .state was rewritten on failure\nbefore:\n%s\nafter:\n%s", originalBytes, finalBytes)
 	}
 }
 

--- a/docs/research/ingestion-architecture.md
+++ b/docs/research/ingestion-architecture.md
@@ -115,10 +115,21 @@ The main DB is a **derived view**; artifacts are the local source of truth.
 
 - Designed in #28, merged in #56
 - Companion: #29 (skip-unchanged consolidation, designed, in 0.1 milestone)
+- Sidecar metadata: #96 — see addendum below
 
 ### Holds at scale
 
 ✅ At 3,000 libs the artifacts directory is ~1 GB total, manageable on disk. The consolidate step is bounded by the number of changed artifacts (combined with #29 for skip-unchanged), not by total corpus size. Distribution is handled by decision 6 below.
+
+### Sidecar metadata (`<lib>.db.state`, #96)
+
+Each per-lib `.db` ships with a YAML sidecar at `<lib>.db.state` carrying *content* metadata that doesn't belong in the `.db` file itself or in the upload-event `manifest.yaml`:
+
+- `lib_id`, `schema_version`, `embedder.{kind,model,dim}`
+- `created_at` (preserved across re-scrapes), `updated_at`
+- `url_count`, `doc_count`
+
+The scraper writes the sidecar atomically after a successful lib finishes; `packs upload` ships `.db` + `.state` as sibling release assets and refuses to upload a `.db` whose sidecar is missing; `packs download` fetches both; `packs list` reads the local sidecar to surface embedder, doc count, and updated-at columns. The split keeps `manifest.yaml` describing **the upload event** (sha256, size, indexed_at) and the sidecar describing **the artifact contents**.
 
 ---
 

--- a/internal/packs/download.go
+++ b/internal/packs/download.go
@@ -149,6 +149,18 @@ func RunDownload(ctx context.Context, opts DownloadOptions) (DownloadSummary, er
 		}
 
 		if !needsDownload {
+			// `.db` is verified locally. Fetch the `.state` sidecar
+			// only if it is absent locally — the sidecar has no
+			// sha256 in the manifest, so we can't re-verify an
+			// existing local copy and "present means good enough".
+			// This keeps the idempotent "verified-only" run's HTTP
+			// count at zero.
+			if err := ensureStateIfMissing(ctx, opts.Fetcher, opts.Repo, manifest.ReleaseTag, opts.ArtifactsDir, p); err != nil {
+				slog.Warn("packs.state_download_failed",
+					"lib_id", p.LibID,
+					"err", err.Error(),
+				)
+			}
 			continue
 		}
 
@@ -169,9 +181,82 @@ func RunDownload(ctx context.Context, opts DownloadOptions) (DownloadSummary, er
 		} else {
 			summary.Downloaded++
 		}
+
+		// Fetch the sidecar alongside the `.db`. A sidecar fetch
+		// failure is non-fatal: the `.db` is still usable by
+		// consolidate/server, and `packs list` will just render
+		// em-dashes for the missing metadata. Surface it as a warning
+		// so an operator can spot the drift without a failed run.
+		if err := ensureStateDownloaded(ctx, opts.Fetcher, opts.Repo, manifest.ReleaseTag, opts.ArtifactsDir, p); err != nil {
+			slog.Warn("packs.state_download_failed",
+				"lib_id", p.LibID,
+				"err", err.Error(),
+			)
+		}
 	}
 
 	return summary, nil
+}
+
+// ensureStateIfMissing fetches the `.state` sidecar only when the
+// local file is absent, so the verified-local happy path remains a
+// zero-HTTP operation. Use ensureStateDownloaded when the sidecar is
+// always expected to be (re)fetched.
+func ensureStateIfMissing(ctx context.Context, fetcher Fetcher, repo, tag, artifactsDir string, p Pack) error {
+	destPath := filepath.Join(artifactsDir, p.Asset+".state")
+	if _, err := os.Stat(destPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat sidecar %s: %w", destPath, err)
+	}
+	return ensureStateDownloaded(ctx, fetcher, repo, tag, artifactsDir, p)
+}
+
+// ensureStateDownloaded fetches the `.state` sidecar for a pack into
+// ArtifactsDir, overwriting any existing sidecar. It is a best-effort
+// helper called after the "download fresh" branch — the sidecar has
+// no sha256 in the manifest and no verification step, it's just small
+// YAML metadata that travels with the `.db` on the rolling release.
+func ensureStateDownloaded(ctx context.Context, fetcher Fetcher, repo, tag, artifactsDir string, p Pack) error {
+	stateAsset := p.Asset + ".state"
+	destPath := filepath.Join(artifactsDir, stateAsset)
+	url := assetURL(repo, tag, stateAsset)
+
+	body, err := fetcher.Get(ctx, url)
+	if err != nil {
+		return fmt.Errorf("fetch sidecar %s: %w", url, err)
+	}
+	defer body.Close()
+
+	tmp := destPath + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create sidecar tmp %s: %w", tmp, err)
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmp)
+		}
+	}()
+
+	if _, err := io.Copy(f, body); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("stream sidecar %s: %w", url, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close sidecar tmp %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, destPath); err != nil {
+		return fmt.Errorf("rename sidecar %s -> %s: %w", tmp, destPath, err)
+	}
+	cleanup = false
+
+	slog.Info("packs.state_downloaded",
+		"lib_id", p.LibID,
+		"state_asset", stateAsset,
+	)
+	return nil
 }
 
 // streamToFileVerified fetches url and streams the body into <dest>.tmp,

--- a/internal/packs/download_test.go
+++ b/internal/packs/download_test.go
@@ -148,9 +148,14 @@ func TestDownload_AlreadyPresentSkipsHTTP(t *testing.T) {
 	fs := newFileServer(t, files)
 	artifactsDir, manifestPath := writeManifestWithPacks(t, files)
 
-	// Pre-populate the canonical file with the right contents.
+	// Pre-populate the canonical file with the right contents AND the
+	// `.state` sidecar — when both are present locally the verified
+	// path must issue zero HTTP requests.
 	if err := os.WriteFile(filepath.Join(artifactsDir, "x_y.db"), files["x_y.db"], 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactsDir, "x_y.db.state"), []byte("lib_id: /x/y\n"), 0o600); err != nil {
+		t.Fatalf("seed sidecar: %v", err)
 	}
 
 	summary, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
@@ -340,6 +345,66 @@ func TestDownload_MissingAssetOnServerErrors(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing asset, got nil")
+	}
+}
+
+// TestDownload_FetchesState asserts the sidecar is downloaded into
+// the artifacts dir alongside the .db on a fresh-clone run.
+func TestDownload_FetchesState(t *testing.T) {
+	files := map[string][]byte{
+		"x_y.db":       []byte("body-of-x-y"),
+		"x_y.db.state": []byte("lib_id: /x/y\n"),
+	}
+	fs := newFileServer(t, files)
+	// writeManifestWithPacks lists every key in `files` as a manifest
+	// entry, but the sidecar isn't a pack of its own — it's a sibling
+	// asset. Build the manifest with only the .db, while serving both.
+	manifestFiles := map[string][]byte{"x_y.db": files["x_y.db"]}
+	artifactsDir, manifestPath := writeManifestWithPacks(t, manifestFiles)
+
+	summary, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: artifactsDir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		Fetcher:      fs.fetcherFor(t),
+	})
+	if err != nil {
+		t.Fatalf("RunDownload: %v", err)
+	}
+	if summary.Downloaded != 1 {
+		t.Errorf("Downloaded = %d, want 1", summary.Downloaded)
+	}
+	for _, name := range []string{"x_y.db", "x_y.db.state"} {
+		if _, err := os.Stat(filepath.Join(artifactsDir, name)); err != nil {
+			t.Errorf("expected %s in artifactsDir: %v", name, err)
+		}
+	}
+}
+
+// TestDownload_StateMissingOnServerIsWarning asserts a sidecar 404 on
+// the server doesn't fail the run — the .db is still usable.
+func TestDownload_StateMissingOnServerIsWarning(t *testing.T) {
+	files := map[string][]byte{
+		"x_y.db": []byte("body-of-x-y"),
+		// No x_y.db.state on the server.
+	}
+	fs := newFileServer(t, files)
+	artifactsDir, manifestPath := writeManifestWithPacks(t, files)
+
+	summary, err := packs.RunDownload(context.Background(), packs.DownloadOptions{
+		ArtifactsDir: artifactsDir,
+		ManifestPath: manifestPath,
+		Repo:         "laradji/deadzone-test",
+		Fetcher:      fs.fetcherFor(t),
+	})
+	if err != nil {
+		t.Fatalf("RunDownload (sidecar 404 should warn, not fail): %v", err)
+	}
+	if summary.Downloaded != 1 {
+		t.Errorf("Downloaded = %d, want 1", summary.Downloaded)
+	}
+	if _, err := os.Stat(filepath.Join(artifactsDir, "x_y.db.state")); !os.IsNotExist(err) {
+		t.Error("sidecar should not exist locally when server lacks it")
 	}
 }
 

--- a/internal/packs/list.go
+++ b/internal/packs/list.go
@@ -3,8 +3,16 @@ package packs
 import (
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"text/tabwriter"
 )
+
+// emDash is the placeholder rendered in state-derived columns when the
+// `.state` sidecar is missing locally. Using an em-dash (rather than
+// "N/A" or a blank) keeps the table visibly aligned and makes missing
+// metadata obvious at a glance.
+const emDash = "—"
 
 // ListOptions is the input to the list subcommand.
 type ListOptions struct {
@@ -12,11 +20,18 @@ type ListOptions struct {
 	// fields are reserved for future filtering — kept as a struct so
 	// adding `-lib` later doesn't break the call signature.
 	ManifestPath string
+	// ArtifactsDir is the local directory where `.state` sidecars are
+	// read from. Empty = use the manifest's directory (this is the
+	// production behaviour — sidecars live next to the manifest in
+	// `./artifacts/`).
+	ArtifactsDir string
 }
 
 // RunList prints the manifest as a tabwriter table to w. The output is
 // optimized for human eyeballing on a terminal: columns are LIB_ID,
-// ASSET, SIZE, SHA256 (12-char prefix), INDEXED_AT (RFC3339).
+// ASSET, SIZE, SHA256 (12-char prefix), INDEXED_AT (RFC3339), plus
+// EMBEDDER, DOCS, and UPDATED_AT pulled from the per-artifact `.state`
+// sidecar when present locally (em-dash when not).
 //
 // Stdout vs. stderr separation: cmd/packs sends list output to stdout
 // while logs go to stderr (same convention as the rest of the binaries
@@ -27,19 +42,42 @@ func RunList(opts ListOptions, w io.Writer) error {
 		return fmt.Errorf("list: %w", err)
 	}
 
+	artifactsDir := opts.ArtifactsDir
+	if artifactsDir == "" {
+		artifactsDir = filepath.Dir(opts.ManifestPath)
+	}
+
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "LIB_ID\tASSET\tSIZE\tSHA256\tINDEXED_AT")
+	fmt.Fprintln(tw, "LIB_ID\tASSET\tSIZE\tSHA256\tINDEXED_AT\tEMBEDDER\tDOCS\tUPDATED_AT")
 	for _, p := range manifest.Packs {
 		short := p.SHA256
 		if len(short) > 12 {
 			short = short[:12]
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n",
+
+		embedder, docs, updatedAt := emDash, emDash, emDash
+		statePath := filepath.Join(artifactsDir, p.Asset+".state")
+		if s, err := LoadState(statePath); err == nil {
+			embedder = fmt.Sprintf("%s %s", s.Embedder.Kind, s.Embedder.Model)
+			docs = fmt.Sprintf("%d", s.DocCount)
+			if !s.UpdatedAt.IsZero() {
+				updatedAt = s.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z")
+			}
+		} else if !os.IsNotExist(err) {
+			// A corrupt sidecar shouldn't blow up the whole list; show
+			// em-dash and continue. The operator still sees a row.
+			embedder = emDash
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\n",
 			p.LibID,
 			p.Asset,
 			p.Size,
 			short,
 			p.IndexedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			embedder,
+			docs,
+			updatedAt,
 		)
 	}
 	if err := tw.Flush(); err != nil {

--- a/internal/packs/list_test.go
+++ b/internal/packs/list_test.go
@@ -2,8 +2,10 @@ package packs_test
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/laradji/deadzone/internal/packs"
 )
@@ -28,6 +30,49 @@ func TestList_PrintsHeaderAndRows(t *testing.T) {
 	}
 	if strings.Contains(out, "9f2e8c4b1a0d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f") {
 		t.Errorf("full sha256 leaked into output instead of prefix:\n%s", out)
+	}
+}
+
+func TestList_ShowsStateColumns(t *testing.T) {
+	manifestPath := writeManifest(t, validPackYAML)
+	dir := filepath.Dir(manifestPath)
+	state := &packs.StateFile{
+		LibID:         "/modelcontextprotocol/go-sdk",
+		SchemaVersion: 3,
+		Embedder:      packs.EmbedderState{Kind: "hugot", Model: "nomic-embed", Dim: 768},
+		CreatedAt:     time.Date(2026, 4, 12, 14, 0, 0, 0, time.UTC),
+		UpdatedAt:     time.Date(2026, 4, 13, 14, 32, 0, 0, time.UTC),
+		URLCount:      6,
+		DocCount:      42,
+	}
+	if err := state.Save(filepath.Join(dir, "modelcontextprotocol_go-sdk.db.state")); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := packs.RunList(packs.ListOptions{ManifestPath: manifestPath, ArtifactsDir: dir}, &buf); err != nil {
+		t.Fatalf("RunList: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"EMBEDDER", "DOCS", "UPDATED_AT", "hugot nomic-embed", "42", "2026-04-13T14:32:00Z"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestList_MissingStateShowsEmDash(t *testing.T) {
+	manifestPath := writeManifest(t, validPackYAML)
+	dir := filepath.Dir(manifestPath)
+	// Deliberately do NOT write a sidecar.
+
+	var buf bytes.Buffer
+	if err := packs.RunList(packs.ListOptions{ManifestPath: manifestPath, ArtifactsDir: dir}, &buf); err != nil {
+		t.Fatalf("RunList: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "—") {
+		t.Errorf("expected em-dash placeholder for missing state:\n%s", out)
 	}
 }
 

--- a/internal/packs/manifest.go
+++ b/internal/packs/manifest.go
@@ -52,13 +52,11 @@ var sha256HexRE = regexp.MustCompile(`^[0-9a-f]{64}$`)
 // always serializes lib_id first so the YAML diffs in PRs are easy to
 // read.
 type Pack struct {
-	LibID               string    `yaml:"lib_id"`
-	Asset               string    `yaml:"asset"`
-	SHA256              string    `yaml:"sha256"`
-	Size                int64     `yaml:"size"`
-	IndexedAt           time.Time `yaml:"indexed_at"`
-	ScrapedWithEmbedder string    `yaml:"scraped_with_embedder,omitempty"`
-	ScrapedWithModel    string    `yaml:"scraped_with_model,omitempty"`
+	LibID     string    `yaml:"lib_id"`
+	Asset     string    `yaml:"asset"`
+	SHA256    string    `yaml:"sha256"`
+	Size      int64     `yaml:"size"`
+	IndexedAt time.Time `yaml:"indexed_at"`
 }
 
 // Manifest is the parsed artifacts/manifest.yaml. ReleaseTag is the
@@ -107,9 +105,9 @@ func Load(path string) (*Manifest, error) {
 //   - lib_id is unique across all Packs
 //   - asset is unique across all Packs
 //
-// Embedder identity fields (scraped_with_embedder, scraped_with_model)
-// are intentionally optional — they're informational, not load-bearing,
-// and a manifest produced before #30 added them should still parse.
+// Content-level metadata (embedder identity, schema version, doc count,
+// scrape dates) lives in the per-artifact `<lib>.db.state` sidecar,
+// NOT in the manifest — see internal/packs/state.go.
 func (m *Manifest) validate() error {
 	if strings.TrimSpace(m.ReleaseTag) == "" {
 		return errors.New("release_tag is required")

--- a/internal/packs/manifest_test.go
+++ b/internal/packs/manifest_test.go
@@ -20,8 +20,6 @@ packs:
     sha256: 9f2e8c4b1a0d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f
     size: 152834
     indexed_at: 2026-04-10T16:23:00Z
-    scraped_with_embedder: hugot
-    scraped_with_model: sentence-transformers/all-MiniLM-L6-v2
 `
 
 func writeManifest(t *testing.T, contents string) string {

--- a/internal/packs/state.go
+++ b/internal/packs/state.go
@@ -1,0 +1,109 @@
+package packs
+
+// state.go implements the per-artifact `<lib>.db.state` YAML sidecar
+// introduced by #96.
+//
+// The sidecar carries metadata about an artifact's *contents* (embedder
+// identity, schema version, scrape lifecycle dates, doc counts). The
+// manifest.yaml entry next to it carries metadata about the *upload
+// event* (sha256, size, indexed_at). Keeping the two concepts in
+// separate files is the whole point of the split — don't conflate
+// them.
+//
+// Lifecycle, as implemented here and in cmd/scraper/main.go:
+//
+//   - The scraper reads the existing `.state` (if any) BEFORE wiping
+//     the `.db` + WAL/SHM sidecars, to capture `created_at` so it
+//     survives a re-scrape.
+//   - After a lib finishes successfully (after UpdateLibCount) the
+//     scraper writes a fresh `.state` with `created_at` preserved (or
+//     set to now on first scrape) and `updated_at = now`.
+//   - On lib failure the `.state` is NOT rewritten. The pre-existing
+//     `.state` stays in place even though the `.db` was wiped; an
+//     operator re-running the scrape overwrites both. This is a
+//     documented trade-off (see the scraper call-site).
+//   - `packs upload` ships the `.state` as a release asset alongside
+//     the `.db`, and `packs download` fetches both. `packs list`
+//     reads the downloaded `.state` to surface rich columns.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// StateFile is the deserialized shape of a `<lib>.db.state` YAML
+// sidecar. Field order is preserved on marshal via yaml.v3 tag
+// declaration order, so diffs in operator-visible `.state` files land
+// in a predictable shape.
+type StateFile struct {
+	LibID         string        `yaml:"lib_id"`
+	SchemaVersion int           `yaml:"schema_version"`
+	Embedder      EmbedderState `yaml:"embedder"`
+	CreatedAt     time.Time     `yaml:"created_at"`
+	UpdatedAt     time.Time     `yaml:"updated_at"`
+	URLCount      int           `yaml:"url_count"`
+	DocCount      int           `yaml:"doc_count"`
+}
+
+// EmbedderState mirrors the embedder identity triple the scraper also
+// writes into `db.Meta`. Kept structurally separate from db.Meta so the
+// packs package does not pull in the db package for this tiny struct.
+type EmbedderState struct {
+	Kind  string `yaml:"kind"`
+	Model string `yaml:"model"`
+	Dim   int    `yaml:"dim"`
+}
+
+// StatePath returns the canonical sidecar path for an artifact `.db`
+// path: the same path with a `.state` suffix appended. Keeping the
+// `.db` prefix ensures `ls artifacts/` groups each pair next to each
+// other and a glob like `*.db*` picks up both.
+func StatePath(dbPath string) string { return dbPath + ".state" }
+
+// LoadState reads and parses a sidecar. A missing file is surfaced as
+// an `os.IsNotExist`-detectable error so callers can branch cleanly
+// ("first scrape? use time.Now() for created_at").
+func LoadState(path string) (*StateFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var s StateFile
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse state %s: %w", path, err)
+	}
+	return &s, nil
+}
+
+// Save writes the sidecar atomically via temp-file + rename in the
+// same directory, matching the pattern used by Manifest.Save.
+func (s *StateFile) Save(path string) error {
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("marshal state %s: %w", path, err)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".state-*.yaml.tmp")
+	if err != nil {
+		return fmt.Errorf("create tmp state in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write tmp state %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close tmp state %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, path, err)
+	}
+	return nil
+}

--- a/internal/packs/state_test.go
+++ b/internal/packs/state_test.go
@@ -1,0 +1,126 @@
+package packs_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/laradji/deadzone/internal/packs"
+)
+
+func TestStateFile_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x_y.db.state")
+
+	created := time.Date(2026, 4, 12, 14, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 4, 13, 14, 32, 0, 0, time.UTC)
+	want := &packs.StateFile{
+		LibID:         "/x/y",
+		SchemaVersion: 3,
+		Embedder: packs.EmbedderState{
+			Kind:  "hugot",
+			Model: "nomic-ai/nomic-embed-text-v1.5",
+			Dim:   768,
+		},
+		CreatedAt: created,
+		UpdatedAt: updated,
+		URLCount:  6,
+		DocCount:  42,
+	}
+	if err := want.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := packs.LoadState(path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got.LibID != want.LibID {
+		t.Errorf("LibID = %q, want %q", got.LibID, want.LibID)
+	}
+	if got.SchemaVersion != want.SchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", got.SchemaVersion, want.SchemaVersion)
+	}
+	if got.Embedder != want.Embedder {
+		t.Errorf("Embedder = %+v, want %+v", got.Embedder, want.Embedder)
+	}
+	if !got.CreatedAt.Equal(want.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, want.CreatedAt)
+	}
+	if !got.UpdatedAt.Equal(want.UpdatedAt) {
+		t.Errorf("UpdatedAt = %v, want %v", got.UpdatedAt, want.UpdatedAt)
+	}
+	if got.URLCount != want.URLCount {
+		t.Errorf("URLCount = %d, want %d", got.URLCount, want.URLCount)
+	}
+	if got.DocCount != want.DocCount {
+		t.Errorf("DocCount = %d, want %d", got.DocCount, want.DocCount)
+	}
+}
+
+func TestStateFile_LoadMissingIsIsNotExist(t *testing.T) {
+	_, err := packs.LoadState(filepath.Join(t.TempDir(), "nope.state"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("err = %v, want os.IsNotExist", err)
+	}
+}
+
+func TestStateFile_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x_y.db.state")
+
+	// Concurrent writers thrashing on the same destination should
+	// never leave a partial / corrupt YAML behind. Each iteration
+	// rewrites with a different doc_count so a torn write would
+	// surface as a parse error or a doc_count outside the set we
+	// know we wrote.
+	const writers = 8
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			s := &packs.StateFile{
+				LibID:         "/x/y",
+				SchemaVersion: 3,
+				Embedder:      packs.EmbedderState{Kind: "hugot", Model: "m", Dim: 8},
+				CreatedAt:     time.Now().UTC(),
+				UpdatedAt:     time.Now().UTC(),
+				URLCount:      1,
+				DocCount:      i,
+			}
+			if err := s.Save(path); err != nil {
+				t.Errorf("writer %d Save: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := packs.LoadState(path)
+	if err != nil {
+		t.Fatalf("LoadState after concurrent writes: %v", err)
+	}
+	if got.DocCount < 0 || got.DocCount >= writers {
+		t.Errorf("DocCount = %d, want one of [0..%d)", got.DocCount, writers)
+	}
+
+	// And no .tmp file leaked.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("temp file leaked: %s", e.Name())
+		}
+	}
+}
+
+func TestStatePath(t *testing.T) {
+	if got := packs.StatePath("artifacts/openjdk_jdk.db"); got != "artifacts/openjdk_jdk.db.state" {
+		t.Errorf("StatePath = %q", got)
+	}
+}

--- a/internal/packs/upload.go
+++ b/internal/packs/upload.go
@@ -118,8 +118,9 @@ func RunUpload(ctx context.Context, opts UploadOptions) (UploadSummary, error) {
 	sort.Strings(matches)
 
 	type pending struct {
-		path string
-		pack Pack
+		path      string
+		statePath string
+		pack      Pack
 	}
 	var (
 		toUpload []pending
@@ -158,16 +159,30 @@ func RunUpload(ctx context.Context, opts UploadOptions) (UploadSummary, error) {
 			continue
 		}
 
+		// Per #96: every uploaded `.db` must ship with its `.state`
+		// sidecar. Missing sidecars point at either a hand-copied `.db`
+		// or a pre-#96 artifact — both signal "re-scrape" so the
+		// rolling release never carries a `.db` whose contents are
+		// unreadable without opening the sqlite file.
+		statePath := StatePath(path)
+		if _, err := os.Stat(statePath); err != nil {
+			if os.IsNotExist(err) {
+				return summary, fmt.Errorf(
+					"upload: missing sidecar %s — re-run `just scrape %s` to regenerate",
+					statePath, meta.LibID)
+			}
+			return summary, fmt.Errorf("upload: stat sidecar %s: %w", statePath, err)
+		}
+
 		toUpload = append(toUpload, pending{
-			path: path,
+			path:      path,
+			statePath: statePath,
 			pack: Pack{
-				LibID:               meta.LibID,
-				Asset:               assetName,
-				SHA256:              hash,
-				Size:                fi.Size(),
-				IndexedAt:           time.Now().UTC(),
-				ScrapedWithEmbedder: meta.EmbedderKind,
-				ScrapedWithModel:    meta.ModelVersion,
+				LibID:     meta.LibID,
+				Asset:     assetName,
+				SHA256:    hash,
+				Size:      fi.Size(),
+				IndexedAt: time.Now().UTC(),
 			},
 		})
 	}
@@ -190,11 +205,15 @@ func RunUpload(ctx context.Context, opts UploadOptions) (UploadSummary, error) {
 			if err := opts.Releaser.Upload(ctx, opts.Repo, manifest.ReleaseTag, item.path); err != nil {
 				return summary, fmt.Errorf("upload: upload %s: %w", item.path, err)
 			}
+			if err := opts.Releaser.Upload(ctx, opts.Repo, manifest.ReleaseTag, item.statePath); err != nil {
+				return summary, fmt.Errorf("upload: upload sidecar %s: %w", item.statePath, err)
+			}
 			slog.Info("packs.upload.uploaded",
 				"lib_id", item.pack.LibID,
 				"asset", item.pack.Asset,
 				"sha256", item.pack.SHA256,
 				"size", item.pack.Size,
+				"state_asset", filepath.Base(item.statePath),
 			)
 			manifest.Replace(item.pack)
 			summary.Uploaded++

--- a/internal/packs/upload_test.go
+++ b/internal/packs/upload_test.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/laradji/deadzone/internal/packs"
 	_ "turso.tech/database/tursogo"
@@ -93,7 +95,37 @@ func fakeArtifact(t *testing.T, dir, basename, libID, body string) string {
 		}
 	}
 
+	// Every `.db` in these tests ships with a `.state` sidecar — the
+	// upload path requires it (#96), and scraper-produced artifacts
+	// always have one.
+	writeFakeState(t, path, libID)
+
 	return path
+}
+
+// writeFakeState writes a minimal, valid `.state` sidecar next to an
+// artifact `.db` path. Tests that want custom fields (past
+// created_at, zero doc_count, etc.) should call StateFile.Save
+// directly instead.
+func writeFakeState(t *testing.T, dbPath, libID string) {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Second)
+	s := &packs.StateFile{
+		LibID:         libID,
+		SchemaVersion: 3,
+		Embedder: packs.EmbedderState{
+			Kind:  "hugot",
+			Model: "sentence-transformers/all-MiniLM-L6-v2",
+			Dim:   384,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		URLCount:  1,
+		DocCount:  42,
+	}
+	if err := s.Save(packs.StatePath(dbPath)); err != nil {
+		t.Fatalf("write fake state: %v", err)
+	}
 }
 
 // seedManifest writes a placeholder manifest with no packs to artifactsDir,
@@ -128,8 +160,16 @@ func TestUpload_FreshArtifactIsUploaded(t *testing.T) {
 	if len(rel.ensureCalls) != 1 {
 		t.Errorf("EnsureRelease called %d times, want 1", len(rel.ensureCalls))
 	}
-	if len(rel.uploadCalls) != 1 {
-		t.Errorf("Upload called %d times, want 1", len(rel.uploadCalls))
+	// Two Upload calls per lib since #96: the `.db` and its `.state`
+	// sidecar are pushed as sibling release assets.
+	if len(rel.uploadCalls) != 2 {
+		t.Errorf("Upload called %d times, want 2 (db + state)", len(rel.uploadCalls))
+	}
+	wantAssets := []string{"x_y.db", "x_y.db.state"}
+	for i, want := range wantAssets {
+		if got := filepath.Base(rel.uploadCalls[i].File); got != want {
+			t.Errorf("uploadCalls[%d].File basename = %q, want %q", i, got, want)
+		}
 	}
 
 	// Manifest should now have the new entry.
@@ -148,9 +188,6 @@ func TestUpload_FreshArtifactIsUploaded(t *testing.T) {
 	}
 	if len(m.Packs[0].SHA256) != 64 {
 		t.Errorf("SHA256 length = %d, want 64", len(m.Packs[0].SHA256))
-	}
-	if m.Packs[0].ScrapedWithEmbedder != "hugot" {
-		t.Errorf("ScrapedWithEmbedder = %q", m.Packs[0].ScrapedWithEmbedder)
 	}
 }
 
@@ -235,8 +272,8 @@ func TestUpload_ChangedArtifactIsReuploaded(t *testing.T) {
 	if summary.Uploaded != 1 || summary.Skipped != 0 {
 		t.Errorf("summary = %+v, want Uploaded:1 Skipped:0", summary)
 	}
-	if len(rel2.uploadCalls) != 1 {
-		t.Errorf("Upload called %d times, want 1", len(rel2.uploadCalls))
+	if len(rel2.uploadCalls) != 2 {
+		t.Errorf("Upload called %d times, want 2 (db + state)", len(rel2.uploadCalls))
 	}
 }
 
@@ -333,6 +370,61 @@ func TestUpload_RequiresRepo(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing Repo, got nil")
+	}
+}
+
+// TestUpload_IncludesState asserts both `.db` and `.db.state` are
+// pushed as siblings on the rolling release for every queued upload.
+func TestUpload_IncludesState(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := seedManifest(t, dir)
+	fakeArtifact(t, dir, "x_y.db", "/x/y", "body-1")
+
+	rel := &fakeReleaser{}
+	if _, err := packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: dir, ManifestPath: manifestPath, Repo: "laradji/deadzone-test", Releaser: rel,
+	}); err != nil {
+		t.Fatalf("RunUpload: %v", err)
+	}
+	if len(rel.uploadCalls) != 2 {
+		t.Fatalf("Upload calls = %d, want 2 (db + state)", len(rel.uploadCalls))
+	}
+	got := []string{filepath.Base(rel.uploadCalls[0].File), filepath.Base(rel.uploadCalls[1].File)}
+	want := []string{"x_y.db", "x_y.db.state"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("uploadCalls[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestUpload_FailsOnMissingState asserts the upload short-circuits
+// with a clear error pointing at the missing sidecar path.
+func TestUpload_FailsOnMissingState(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := seedManifest(t, dir)
+	// Build the .db then delete the auto-created .state to mimic a
+	// pre-#96 artifact / hand-copied .db.
+	dbPath := fakeArtifact(t, dir, "x_y.db", "/x/y", "body-1")
+	if err := os.Remove(packs.StatePath(dbPath)); err != nil {
+		t.Fatalf("rm sidecar: %v", err)
+	}
+
+	rel := &fakeReleaser{}
+	_, err := packs.RunUpload(context.Background(), packs.UploadOptions{
+		ArtifactsDir: dir, ManifestPath: manifestPath, Repo: "laradji/deadzone-test", Releaser: rel,
+	})
+	if err == nil {
+		t.Fatal("expected missing-sidecar error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing sidecar") {
+		t.Errorf("err = %v, want 'missing sidecar' in message", err)
+	}
+	if !strings.Contains(err.Error(), "x_y.db.state") {
+		t.Errorf("err = %v, want sidecar path in message", err)
+	}
+	if len(rel.uploadCalls) != 0 {
+		t.Errorf("Upload called despite missing sidecar: %d times", len(rel.uploadCalls))
 	}
 }
 


### PR DESCRIPTION
## Summary

Introduces a `.db.state` YAML sidecar for each per-lib artifact, separating **content metadata** (embedder identity, schema version, doc/URL counts, scrape lifecycle dates) from the **upload-event metadata** already tracked in `manifest.yaml` (sha256, size, indexed_at).

## Changes

- **`internal/packs/state.go`** — new `StateFile` type with `LoadState` / `Save` (atomic write via temp+rename)
- **`cmd/scraper/main.go`** — scraper writes `.state` after each successful lib scrape; preserves `created_at` across re-scrapes
- **`internal/packs/upload.go`** — refuses to upload a `.db` missing its `.state` sidecar; uploads both as sibling release assets
- **`internal/packs/download.go`** — fetches `.state` alongside `.db`; backfills missing sidecars on verified-local runs
- **`internal/packs/list.go`** — reads local `.state` to surface `EMBEDDER`, `DOCS`, and `UPDATED_AT` columns (em-dash when absent)
- **`internal/packs/manifest.go`** — removes now-redundant `scraped_with_embedder` / `scraped_with_model` fields from `Pack`
- Tests added for state round-trip, upload sidecar gate, download sidecar fetch, and list enriched output

## Design rationale

The manifest describes the **upload event** while the sidecar describes the **artifact contents**. This split avoids bloating `manifest.yaml` with per-lib content metadata and lets `packs list` render rich columns without opening each SQLite file.

Ref: #96

<!-- emdash-issue-footer:start -->
Fixes #96
<!-- emdash-issue-footer:end -->