### PR TITLE
fix: remove dead  field from SearchDocsInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ Deadzone is a self-hosted alternative to [Context7](https://github.com/upstash/c
 Deadzone exposes two MCP tools to clients (Claude Code, Cursor, etc.):
 
 ```
-search_docs(query, lib_id?, topic?, tokens?) → []Snippet
+search_docs(query, lib_id?, tokens?) → []Snippet
 ```
 
 - `query` — natural-language search query (matched semantically against the indexed docs)
 - `lib_id` — optional `/org/project` filter (e.g. `/modelcontextprotocol/go-sdk`)
-- `topic` — optional section filter (not yet implemented)
 - `tokens` — response budget, default 5000, min 1000 (`~4 chars/token`)
 
 ```

--- a/cmd/deadzone/server.go
+++ b/cmd/deadzone/server.go
@@ -20,7 +20,6 @@ import (
 type SearchDocsInput struct {
 	Query  string `json:"query" jsonschema:"the search query"`
 	LibID  string `json:"lib_id,omitempty" jsonschema:"library ID in /org/project format (optional)"`
-	Topic  string `json:"topic,omitempty" jsonschema:"topic or section to focus on (optional)"`
 	Tokens int    `json:"tokens,omitempty" jsonschema:"max tokens to return, min 1000, default 5000 (optional)"`
 }
 


### PR DESCRIPTION
## Summary

- Remove the unimplemented `topic` field from `SearchDocsInput` struct in `cmd/deadzone/server.go`
- Update README to match by dropping the `topic` parameter from the `search_docs` tool signature and description

## Motivation

The `topic` parameter was declared but never wired up. Exposing it in the MCP schema misleads clients into thinking it does something. Removing it keeps the tool contract honest.

<!-- emdash-issue-footer:start -->
Fixes #39
<!-- emdash-issue-footer:end -->