### PR TITLE
feat(db): auto-fetch and auto-upgrade deadzone.db from GitHub Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ End users usually only touch the first three. `deadzone scrape` is for contribut
 
 | Subcommand | What it's for |
 |---|---|
-| `deadzone server` | MCP stdio server — what your AI client talks to |
-| `deadzone consolidate` | Merges per-lib artifacts into a single `deadzone.db` |
+| `deadzone server` | MCP stdio server — what your AI client talks to. Auto-fetches `deadzone.db` on first run and auto-upgrades it when a newer release ships (see [Data](#data)). |
+| `deadzone fetch-db` | Explicit cache-warmup / refresh of `deadzone.db` (useful before going offline, or in scripted setups). `-force` re-fetches even when the cache is current. |
+| `deadzone consolidate` | Merges per-lib artifacts into a single `deadzone.db` (contributor flow) |
 | `deadzone scrape` | Re-scrapes a library from its configured sources |
 | `deadzone dbrelease` | Operator-driven: uploads `deadzone.db` + `.sha256` to a tagged GitHub Release |
 | `deadzone packs` | Disabled (see [#101](https://github.com/laradji/deadzone/issues/101)); use `dbrelease` |
@@ -130,27 +131,37 @@ The single CGO surface (hugot's ORT backend + `libtokenizers.a`) is the 2026-04-
 
 ### Hello-world pipeline
 
-Tagged releases ship a prebuilt `deadzone.db` covering the libraries listed in [`libraries_sources.yaml`](libraries_sources.yaml). Grab the binary tarball, then the DB, and you're done:
+Tagged releases ship a prebuilt `deadzone.db` covering the libraries listed in [`libraries_sources.yaml`](libraries_sources.yaml). After extracting the binary, just run the server — the DB is downloaded on first launch into the platform data dir, sha256-verified, and cached. Subsequent launches auto-upgrade transparently when a newer release is available.
 
 ```bash
-VERSION=v0.1.0
-
-curl -L -o deadzone.db \
-  "https://github.com/laradji/deadzone/releases/download/${VERSION}/deadzone.db"
-curl -L -o deadzone.db.sha256 \
-  "https://github.com/laradji/deadzone/releases/download/${VERSION}/deadzone.db.sha256"
-
-# Linux
-sha256sum -c deadzone.db.sha256
-# macOS
-shasum -a 256 -c deadzone.db.sha256
-
-./deadzone server -db deadzone.db  # MCP stdio server
+./deadzone server  # downloads deadzone.db on first run, then serves
 ```
 
 The per-platform binary tarballs and their aggregated `deadzone_${VERSION}_checksums.txt` are uploaded by CI when the tag is pushed; `deadzone.db` and `deadzone.db.sha256` are uploaded separately by the maintainer via `deadzone dbrelease` (see [Releasing a new `deadzone.db`](#releasing-a-new-deadzonedb) below). The two halves live on the same release object.
 
-With the server running, point any MCP-capable client at it — see [Wire it into an MCP client](#wire-it-into-an-mcp-client) for the exact JSON snippet.
+With the server running, point any MCP-capable client at it — see [Wire it into an MCP client](#wire-it-into-an-mcp-client) for the exact JSON snippet. To pin a specific version, hand-place the file and run with `./deadzone server -db /path/to/deadzone.db` — explicit `-db` bypasses the auto-fetch and auto-upgrade entirely.
+
+### Data
+
+`deadzone server` (and `deadzone fetch-db`) cache `deadzone.db` under the platform's standard per-user data directory:
+
+| Platform | Default cache path |
+|---|---|
+| macOS | `~/Library/Application Support/deadzone/deadzone.db` |
+| Linux | `$XDG_DATA_HOME/deadzone/deadzone.db` (falls back to `~/.local/share/deadzone/deadzone.db`) |
+| Windows | `%LOCALAPPDATA%\deadzone\deadzone.db` |
+
+A sibling `deadzone.db.release` text file records the release tag the cache was fetched from; subsequent startups compare it against the latest release's tag (without re-hashing the DB) and only re-download when the tag has changed.
+
+**Env-var escape hatches** (matching the `DEADZONE_ORT_*` / `DEADZONE_HUGOT_*` pattern):
+
+| Env var | Effect |
+|---|---|
+| `DEADZONE_DB_CACHE` | Override the cache directory. |
+| `DEADZONE_DB_NO_AUTO_UPGRADE=1` | Skip the staleness check; serve whatever is cached. First-run fetch still happens when the cache is empty. |
+| `DEADZONE_DB_OFFLINE=1` | Never make a network call. Fails loudly on first run if nothing is cached — hand-place a `deadzone.db` at the path above to satisfy it. |
+
+`deadzone fetch-db` is the explicit refresh path: useful for pre-populating the cache before going offline, for force-refreshing without restarting the server (`deadzone fetch-db -force`), or for CI / scripted setups that want a deterministic "fetch now" step.
 
 ## Stack
 
@@ -188,7 +199,7 @@ just consolidate       # = mise exec -- go run -tags ORT ./cmd/deadzone consolid
 just serve             # = mise exec -- go run -tags ORT ./cmd/deadzone server -db deadzone.db
 ```
 
-The per-lib artifact folders under `./artifacts/<slug>/` (each containing `artifact.db` + `state.yaml`) and `deadzone.db` are all gitignored — they're local build outputs. The committed [`artifacts/manifest.yaml`](artifacts/manifest.yaml) records the most recent `deadzone.db` release (tag, sha256, embedder, counts) as a release-history trace; it's rewritten by `deadzone dbrelease`, not by hand. The server refuses to start if `deadzone.db` is missing and tells you to run `consolidate` first; it never auto-creates an empty file.
+The per-lib artifact folders under `./artifacts/<slug>/` (each containing `artifact.db` + `state.yaml`) and `deadzone.db` are all gitignored — they're local build outputs. The committed [`artifacts/manifest.yaml`](artifacts/manifest.yaml) records the most recent `deadzone.db` release (tag, sha256, embedder, counts) as a release-history trace; it's rewritten by `deadzone dbrelease`, not by hand. When `-db` points at a missing file the server errors out and points at both auto-fetch (run without `-db`) and `consolidate` (build from local artifacts); it never auto-creates an empty file.
 
 > **Note.** The per-artifact GitHub Release distribution flow (`deadzone packs {upload,download,list}`) is paused as of [#101](https://github.com/laradji/deadzone/issues/101) — contributors who want a working DB run `just scrape && just consolidate` locally. Releases carry `deadzone.db` as a single consolidated asset; per-artifact distribution will return when CI takes over at scale.
 
@@ -369,11 +380,13 @@ Add to your client's MCP config (Claude Code, Cursor, etc.):
     "deadzone": {
       "type": "stdio",
       "command": "/path/to/deadzone",
-      "args": ["server", "-db", "/path/to/deadzone.db"]
+      "args": ["server"]
     }
   }
 }
 ```
+
+The server resolves `deadzone.db` from the platform data dir on first launch (see [Data](#data) for cache paths and env-var overrides) and auto-upgrades it on subsequent launches. To pin a specific DB file, add `"-db", "/path/to/deadzone.db"` to `args`.
 
 Then call the `search_docs` or `search_libraries` tool from the client.
 
@@ -413,7 +426,7 @@ Every subcommand emits structured JSON logs to **stderr** using `log/slog`. Stdo
 - **Scraper.** `just scrape` writes logs straight to your terminal. Look for `scraper.start`, a `scraper.lib_start` per resolved library (with the `artifact_path` it's writing to), one `scraper.fetch` per URL (with `bytes`, `duration_ms`, `docs_extracted`, and `kind`), `scraper.indexed` summaries, a `scraper.lib_done` per library, and a final `scraper.done`. The "silently stalls on one URL" failure mode shows up as a missing `scraper.fetch` event for that URL. Errors land as `scraper.fetch_failed` / `scraper.insert_failed` with the URL and wrapped error. When any source uses `kind: scrape-via-agent`, expect `scraper.agent_configured` and `scraper.agent_ping_ok` once at startup; per-doc hallucination drops show up as `scraper.agent_verification_failed`, and oversized inputs as `agent.input_truncated`.
 - **Consolidate.** `just consolidate` emits a `consolidate.start` and a `consolidate.done` with the `artifacts` count, `docs_merged`, `libs_merged`, and `duration_ms`. A failure aborts before any write reaches the main DB; the wrapped error names the offending artifact.
 - **DB release.** `just dbrelease v0.1.0` emits `dbrelease.start` (with `db_path`, `tag`, `repo`), then `packs.dbrelease.uploaded` per uploaded asset (`deadzone.db` + `deadzone.db.sha256`), and a final `dbrelease.done` line carrying `sha256`, `size`, `lib_count`, `doc_count`, and the manifest path. The operator then commits the manifest diff to record the release.
-- **Server.** `deadzone server`'s stderr is captured by the MCP client. In Claude Code that's the `~/Library/Logs/Claude/mcp-server-deadzone.log` file (macOS) or your client's equivalent — check the MCP client docs. On startup the server emits a `server.start` line with the embedder meta and the indexed `doc_count`; each `search_docs` call emits one `search_docs` line with `lib_id`, `tokens`, `results`, and `latency_ms`. If the configured `-db` is missing the server refuses to start and prints a one-liner pointing at `deadzone consolidate`.
+- **Server.** `deadzone server`'s stderr is captured by the MCP client. In Claude Code that's the `~/Library/Logs/Claude/mcp-server-deadzone.log` file (macOS) or your client's equivalent — check the MCP client docs. On startup the server emits a `server.start` line with the embedder meta and the indexed `doc_count`; each `search_docs` call emits one `search_docs` line with `lib_id`, `tokens`, `results`, and `latency_ms`. When `-db` is unset the server runs `db.Bootstrap` first; expect a `server.db_upgraded` line when an upgrade swap happened, or a `server.db_upgrade_failed` WARN if the network was unreachable on a stale-cache run (the cache is served anyway). If an explicit `-db <path>` is missing the server refuses to start and points at both the auto-fetch path (run without `-db`) and `deadzone consolidate`.
 - **Verbose mode.** Every subcommand takes `-verbose`. On the server it adds the raw `query` field to per-call logs (off by default because queries may contain user data). On the scraper it adds per-doc `scraper.doc_indexed` Debug lines, useful when debugging the parser on a new library.
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ End users usually only touch the first three. `deadzone scrape` is for contribut
 
 | Subcommand | What it's for |
 |---|---|
-| `deadzone server` | MCP stdio server — what your AI client talks to. Auto-fetches `deadzone.db` on first run and auto-upgrades it when a newer release ships (see [Data](#data)). |
-| `deadzone fetch-db` | Explicit cache-warmup / refresh of `deadzone.db` (useful before going offline, or in scripted setups). `-force` re-fetches even when the cache is current. |
+| `deadzone server` | MCP stdio server — what your AI client talks to. Auto-fetches the `deadzone.db` matching this binary's version on first run, and re-fetches only when the binary itself is upgraded (see [Data](#data)). |
+| `deadzone fetch-db` | Explicit cache-warmup / refresh of `deadzone.db` (useful before going offline, or to recover from local corruption with `-force`). |
 | `deadzone consolidate` | Merges per-lib artifacts into a single `deadzone.db` (contributor flow) |
 | `deadzone scrape` | Re-scrapes a library from its configured sources |
 | `deadzone dbrelease` | Operator-driven: uploads `deadzone.db` + `.sha256` to a tagged GitHub Release |
@@ -131,7 +131,7 @@ The single CGO surface (hugot's ORT backend + `libtokenizers.a`) is the 2026-04-
 
 ### Hello-world pipeline
 
-Tagged releases ship a prebuilt `deadzone.db` covering the libraries listed in [`libraries_sources.yaml`](libraries_sources.yaml). After extracting the binary, just run the server — the DB is downloaded on first launch into the platform data dir, sha256-verified, and cached. Subsequent launches auto-upgrade transparently when a newer release is available.
+Tagged releases ship a prebuilt `deadzone.db` covering the libraries listed in [`libraries_sources.yaml`](libraries_sources.yaml). After extracting the binary, just run the server — the DB matching this binary's own version is downloaded on first launch into the platform data dir, sha256-verified, and cached. Steady-state startup is zero-network: the cache sidecar tag is compared against the binary's version at startup, and only a binary version bump triggers a re-fetch.
 
 ```bash
 ./deadzone server  # downloads deadzone.db on first run, then serves
@@ -139,7 +139,7 @@ Tagged releases ship a prebuilt `deadzone.db` covering the libraries listed in [
 
 The per-platform binary tarballs and their aggregated `deadzone_${VERSION}_checksums.txt` are uploaded by CI when the tag is pushed; `deadzone.db` and `deadzone.db.sha256` are uploaded separately by the maintainer via `deadzone dbrelease` (see [Releasing a new `deadzone.db`](#releasing-a-new-deadzonedb) below). The two halves live on the same release object.
 
-With the server running, point any MCP-capable client at it — see [Wire it into an MCP client](#wire-it-into-an-mcp-client) for the exact JSON snippet. To pin a specific version, hand-place the file and run with `./deadzone server -db /path/to/deadzone.db` — explicit `-db` bypasses the auto-fetch and auto-upgrade entirely.
+With the server running, point any MCP-capable client at it — see [Wire it into an MCP client](#wire-it-into-an-mcp-client) for the exact JSON snippet. To pin a different DB, hand-place the file and run with `./deadzone server -db /path/to/deadzone.db` — explicit `-db` bypasses the auto-fetch entirely.
 
 ### Data
 
@@ -151,17 +151,24 @@ With the server running, point any MCP-capable client at it — see [Wire it int
 | Linux | `$XDG_DATA_HOME/deadzone/deadzone.db` (falls back to `~/.local/share/deadzone/deadzone.db`) |
 | Windows | `%LOCALAPPDATA%\deadzone\deadzone.db` |
 
-A sibling `deadzone.db.release` text file records the release tag the cache was fetched from; subsequent startups compare it against the latest release's tag (without re-hashing the DB) and only re-download when the tag has changed.
+A sibling `deadzone.db.release` text file records the release tag the cache was fetched from.
+
+**The cached DB is pinned to the binary's own version.** On every startup the server compares the cache sidecar tag against the binary's compiled-in version (set by `-ldflags -X main.version=...`, see `build-release` in the [`justfile`](justfile)):
+
+- **Tag matches** → zero-network fast path; the cache is served as-is. No GitHub API call.
+- **Tag differs** (the binary was upgraded) → fetch `/releases/tags/<binary-version>`, atomic-swap the cache, serve the new DB.
+- **Binary is a dev build** (literal `dev`, `-dirty` suffix, or `git describe` between-tags form) → fall back to `/releases/latest` with a `server.db_version_dev_fallback` WARN so local iteration stays ergonomic.
+
+The DB does not auto-upgrade independently of the binary: if upstream publishes a newer DB while this binary is still running, the server keeps using the cached DB it was pinned to. `deadzone upgrade` (or a tarball re-extract) is what changes the binary's version and, on next launch, triggers the DB swap.
 
 **Env-var escape hatches** (matching the `DEADZONE_ORT_*` / `DEADZONE_HUGOT_*` pattern):
 
 | Env var | Effect |
 |---|---|
 | `DEADZONE_DB_CACHE` | Override the cache directory. |
-| `DEADZONE_DB_NO_AUTO_UPGRADE=1` | Skip the staleness check; serve whatever is cached. First-run fetch still happens when the cache is empty. |
-| `DEADZONE_DB_OFFLINE=1` | Never make a network call. Fails loudly on first run if nothing is cached — hand-place a `deadzone.db` at the path above to satisfy it. |
+| `DEADZONE_DB_OFFLINE=1` | Never make a network call. Fails loudly on first run if nothing is cached; also fails loudly if the cache exists but its version doesn't match the binary — hand-place a `deadzone.db` that matches, or unset the env var so the auto-fetch can run. |
 
-`deadzone fetch-db` is the explicit refresh path: useful for pre-populating the cache before going offline, for force-refreshing without restarting the server (`deadzone fetch-db -force`), or for CI / scripted setups that want a deterministic "fetch now" step.
+`deadzone fetch-db` is the explicit refresh path: pre-populate the cache before going offline, or recover from local corruption with `deadzone fetch-db -force` (same binary version, fresh bytes, sha256-verified).
 
 ## Stack
 
@@ -426,7 +433,7 @@ Every subcommand emits structured JSON logs to **stderr** using `log/slog`. Stdo
 - **Scraper.** `just scrape` writes logs straight to your terminal. Look for `scraper.start`, a `scraper.lib_start` per resolved library (with the `artifact_path` it's writing to), one `scraper.fetch` per URL (with `bytes`, `duration_ms`, `docs_extracted`, and `kind`), `scraper.indexed` summaries, a `scraper.lib_done` per library, and a final `scraper.done`. The "silently stalls on one URL" failure mode shows up as a missing `scraper.fetch` event for that URL. Errors land as `scraper.fetch_failed` / `scraper.insert_failed` with the URL and wrapped error. When any source uses `kind: scrape-via-agent`, expect `scraper.agent_configured` and `scraper.agent_ping_ok` once at startup; per-doc hallucination drops show up as `scraper.agent_verification_failed`, and oversized inputs as `agent.input_truncated`.
 - **Consolidate.** `just consolidate` emits a `consolidate.start` and a `consolidate.done` with the `artifacts` count, `docs_merged`, `libs_merged`, and `duration_ms`. A failure aborts before any write reaches the main DB; the wrapped error names the offending artifact.
 - **DB release.** `just dbrelease v0.1.0` emits `dbrelease.start` (with `db_path`, `tag`, `repo`), then `packs.dbrelease.uploaded` per uploaded asset (`deadzone.db` + `deadzone.db.sha256`), and a final `dbrelease.done` line carrying `sha256`, `size`, `lib_count`, `doc_count`, and the manifest path. The operator then commits the manifest diff to record the release.
-- **Server.** `deadzone server`'s stderr is captured by the MCP client. In Claude Code that's the `~/Library/Logs/Claude/mcp-server-deadzone.log` file (macOS) or your client's equivalent — check the MCP client docs. On startup the server emits a `server.start` line with the embedder meta and the indexed `doc_count`; each `search_docs` call emits one `search_docs` line with `lib_id`, `tokens`, `results`, and `latency_ms`. When `-db` is unset the server runs `db.Bootstrap` first; expect a `server.db_upgraded` line when an upgrade swap happened, or a `server.db_upgrade_failed` WARN if the network was unreachable on a stale-cache run (the cache is served anyway). If an explicit `-db <path>` is missing the server refuses to start and points at both the auto-fetch path (run without `-db`) and `deadzone consolidate`.
+- **Server.** `deadzone server`'s stderr is captured by the MCP client. In Claude Code that's the `~/Library/Logs/Claude/mcp-server-deadzone.log` file (macOS) or your client's equivalent — check the MCP client docs. On startup the server emits a `server.start` line with the embedder meta and the indexed `doc_count`; each `search_docs` call emits one `search_docs` line with `lib_id`, `tokens`, `results`, and `latency_ms`. When `-db` is unset the server runs `db.Bootstrap` first; expect a `server.db_upgraded` line when the binary version bump triggered a cache swap, a `server.db_version_dev_fallback` WARN when running a dev build (dev builds use `/releases/latest` instead of pinning to a tag), or a `server.db_tag_sidecar_write_failed` WARN if the tag sidecar couldn't be persisted after a successful DB install (non-fatal — next startup will just re-fetch). If an explicit `-db <path>` is missing the server refuses to start and points at both the auto-fetch path (run without `-db`) and `deadzone consolidate`.
 - **Verbose mode.** Every subcommand takes `-verbose`. On the server it adds the raw `query` field to per-call logs (off by default because queries may contain user data). On the scraper it adds per-doc `scraper.doc_indexed` Debug lines, useful when debugging the parser on a new library.
 
 ## Roadmap

--- a/cmd/deadzone/fetchdb.go
+++ b/cmd/deadzone/fetchdb.go
@@ -1,0 +1,48 @@
+package main
+
+// fetchdb is the `deadzone fetch-db` subcommand introduced in #108.
+// It exposes the same db.Bootstrap flow `deadzone server` uses, as an
+// explicit cache-warmup / refresh entry point. Useful for:
+//
+//   - Pre-populating the cache before going offline.
+//   - Force-refreshing without restarting the server (combined with
+//     a separate restart afterwards — the running server holds the DB
+//     file open, so picking up a new release requires a restart).
+//   - CI / scripted setups that want a deterministic "fetch now" step
+//     instead of relying on the implicit on-startup path.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/laradji/deadzone/internal/db"
+	"github.com/laradji/deadzone/internal/logs"
+)
+
+func runFetchDB(args []string) error {
+	fs := flag.NewFlagSet("fetch-db", flag.ExitOnError)
+	force := fs.Bool("force", false, "re-fetch even when the cached DB tag matches the latest release")
+	repo := fs.String("repo", "", "GitHub owner/name (default: "+db.BootstrapDefaultRepo+")")
+	verbose := fs.Bool("verbose", false, "enable Debug-level slog output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	slog.SetDefault(logs.New(os.Stderr, *verbose))
+
+	path, upgraded, err := db.BootstrapWithOptions(context.Background(), db.BootstrapOptions{
+		Repo:  *repo,
+		Force: *force,
+	})
+	if err != nil {
+		return fmt.Errorf("fetch-db: %w", err)
+	}
+	if upgraded || *force {
+		fmt.Printf("deadzone.db upgraded to latest at %s\n", path)
+	} else {
+		fmt.Printf("deadzone.db already up to date at %s\n", path)
+	}
+	return nil
+}

--- a/cmd/deadzone/fetchdb.go
+++ b/cmd/deadzone/fetchdb.go
@@ -5,11 +5,15 @@ package main
 // explicit cache-warmup / refresh entry point. Useful for:
 //
 //   - Pre-populating the cache before going offline.
-//   - Force-refreshing without restarting the server (combined with
-//     a separate restart afterwards — the running server holds the DB
-//     file open, so picking up a new release requires a restart).
+//   - Recovering from local corruption via -force (same tag, fresh
+//     bytes, verified sha256).
 //   - CI / scripted setups that want a deterministic "fetch now" step
 //     instead of relying on the implicit on-startup path.
+//
+// Revised contract from PR #110 review: the fetched DB is pinned to
+// the binary's own version (same as `deadzone server`); fetch-db does
+// NOT pull "the newest DB on GitHub" unless the binary itself is a
+// dev build.
 
 import (
 	"context"
@@ -17,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
 
 	"github.com/laradji/deadzone/internal/db"
 	"github.com/laradji/deadzone/internal/logs"
@@ -24,17 +29,23 @@ import (
 
 func runFetchDB(args []string) error {
 	fs := flag.NewFlagSet("fetch-db", flag.ExitOnError)
-	force := fs.Bool("force", false, "re-fetch even when the cached DB tag matches the latest release")
-	repo := fs.String("repo", "", "GitHub owner/name (default: "+db.BootstrapDefaultRepo+")")
+	force := fs.Bool("force", false, "re-fetch even when the cached DB tag matches the binary's version (use to recover from local corruption)")
+	repo := fs.String("repo", "", "GitHub owner/name override — primarily for testing against a fork (default: "+db.BootstrapDefaultRepo+")")
 	verbose := fs.Bool("verbose", false, "enable Debug-level slog output")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	slog.SetDefault(logs.New(os.Stderr, *verbose))
 
-	path, upgraded, err := db.BootstrapWithOptions(context.Background(), db.BootstrapOptions{
-		Repo:  *repo,
-		Force: *force,
+	// SIGINT-aware context so Ctrl-C during the fetch tears down
+	// cleanly instead of letting the HTTP client run to its timeout.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	path, upgraded, err := db.BootstrapWithOptions(ctx, db.BootstrapOptions{
+		Repo:       *repo,
+		AppVersion: version,
+		Force:      *force,
 	})
 	if err != nil {
 		return fmt.Errorf("fetch-db: %w", err)

--- a/cmd/deadzone/main.go
+++ b/cmd/deadzone/main.go
@@ -5,6 +5,7 @@
 //	deadzone server        run the MCP stdio server against a deadzone.db
 //	deadzone scrape        index libraries_sources.yaml into ./artifacts
 //	deadzone consolidate   merge ./artifacts/<slug>/artifact.db into a single deadzone.db
+//	deadzone fetch-db      download/refresh the cached deadzone.db from the latest GH Release
 //	deadzone dbrelease     upload ./deadzone.db to a tagged GitHub Release
 //	deadzone packs {upload|download|list}
 //	                       DISABLED per #101; returns a clear error. See
@@ -50,6 +51,7 @@ Subcommands:
   server        run the MCP stdio server against a deadzone.db
   scrape        index libraries from libraries_sources.yaml into ./artifacts
   consolidate   merge ./artifacts/<slug>/artifact.db files into a single deadzone.db
+  fetch-db      download/refresh the cached deadzone.db from the latest GH Release
   dbrelease     upload ./deadzone.db to a tagged GitHub Release (operator-driven)
   packs         (disabled; see 'deadzone dbrelease')
 
@@ -94,6 +96,8 @@ func dispatch(args []string) error {
 		return runConsolidate(rest)
 	case "dbrelease":
 		return runDBRelease(rest)
+	case "fetch-db":
+		return runFetchDB(rest)
 	case "packs":
 		return runPacks(rest)
 	default:

--- a/cmd/deadzone/server.go
+++ b/cmd/deadzone/server.go
@@ -227,7 +227,7 @@ func libAttrs(input SearchLibrariesInput, name string, limit int, verbose bool, 
 // colliding with the sibling subcommands' flag definitions.
 func runServer(args []string) error {
 	fs := flag.NewFlagSet("server", flag.ExitOnError)
-	dbPath := fs.String("db", "deadzone.db", "path to turso database file")
+	dbPath := fs.String("db", "", "path to turso database file (default: auto-resolve from cache + auto-fetch/auto-upgrade)")
 	embedderKind := fs.String("embedder", embed.KindHugot, "embedder to use (valid: hugot)")
 	verbose := fs.Bool("verbose", false, "include the raw query text in per-call logs")
 	if err := fs.Parse(args); err != nil {
@@ -239,13 +239,26 @@ func runServer(args []string) error {
 	// JSON-RPC channel.
 	slog.SetDefault(logs.New(os.Stderr, *verbose))
 
-	// The server is a read-only consumer of the consolidated DB; it
-	// must NOT auto-create a fresh empty file (that would silently
-	// hide a missed `consolidate` step and serve zero results to
-	// every query). Stat first; if missing, point the operator at
-	// the consolidate subcommand before any other work happens.
-	if _, err := os.Stat(*dbPath); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("%s not found. Run `deadzone consolidate -db %s -artifacts ./artifacts` first to merge per-lib artifacts into the main database", *dbPath, *dbPath)
+	// Two -db modes (#108):
+	//   unset → auto-fetch from the latest GH Release into the
+	//           per-platform data dir, auto-upgrade on subsequent runs
+	//           when a newer release exists. The whole flow is bounded
+	//           by the DEADZONE_DB_OFFLINE / DEADZONE_DB_NO_AUTO_UPGRADE
+	//           env-var escape hatches.
+	//   set   → use the path verbatim. No fetch, no version check.
+	//           Error if missing — the operator opted into a specific
+	//           file and we respect that.
+	if *dbPath == "" {
+		resolved, upgraded, err := db.Bootstrap(context.Background())
+		if err != nil {
+			return fmt.Errorf("bootstrap deadzone.db: %w", err)
+		}
+		*dbPath = resolved
+		if upgraded {
+			slog.Info("server.db_upgraded", "db_path", *dbPath)
+		}
+	} else if _, err := os.Stat(*dbPath); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("%s not found. Either run without -db to auto-fetch the latest published DB, or run `deadzone consolidate -db %s -artifacts ./artifacts` to build it from local artifacts", *dbPath, *dbPath)
 	} else if err != nil {
 		return fmt.Errorf("stat db %s: %w", *dbPath, err)
 	}

--- a/cmd/deadzone/server.go
+++ b/cmd/deadzone/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
 	"strings"
 	"time"
 
@@ -249,7 +250,12 @@ func runServer(args []string) error {
 	//           Error if missing — the operator opted into a specific
 	//           file and we respect that.
 	if *dbPath == "" {
-		resolved, upgraded, err := db.Bootstrap(context.Background())
+		// SIGINT-aware context so a Ctrl-C during a 200 MB first-fetch
+		// tears down cleanly instead of letting the HTTP client run
+		// to its 15-minute timeout.
+		bootstrapCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+		resolved, upgraded, err := db.Bootstrap(bootstrapCtx, version)
+		stop()
 		if err != nil {
 			return fmt.Errorf("bootstrap deadzone.db: %w", err)
 		}

--- a/internal/db/bootstrap.go
+++ b/internal/db/bootstrap.go
@@ -1,25 +1,32 @@
-// bootstrap.go owns the consumer-side fetch + auto-upgrade flow for
-// deadzone.db, mirroring internal/ort/ort.go's symmetric flow for the
-// onnxruntime shared library. See issue #108 for the full design and
-// behavior matrix.
+// bootstrap.go owns the consumer-side fetch flow for deadzone.db,
+// mirroring internal/ort/ort.go's symmetric flow for the onnxruntime
+// shared library. See issue #108 for the full design.
 //
-// Three trigger paths share this implementation:
+// Contract (revised per PR #110 review): the cached deadzone.db is
+// pinned to the binary's own version. The DB does NOT auto-upgrade
+// across binary versions — that would risk pulling a schema/embedder
+// newer than the binary can read. Trigger paths:
 //
-//  1. First run, no cached DB → fetch latest release's deadzone.db into
-//     cache, serve.
-//  2. Subsequent run, cached DB tag matches latest → use cache, skip
-//     the asset download (still hits the API to compare tags; "no
-//     network" in the issue means "no asset transfer").
-//  3. Subsequent run, cached DB tag != latest → fetch new, atomic swap,
-//     serve new version.
+//  1. First run, no cached DB → fetch /releases/tags/<AppVersion>,
+//     install, serve.
+//  2. Subsequent run, cached tag matches AppVersion → use cache. Zero
+//     API calls. Instant start.
+//  3. Subsequent run, cached tag != AppVersion (i.e. the binary was
+//     upgraded) → fetch /releases/tags/<AppVersion>, atomic swap.
+//  4. AppVersion is a local/dev build (literal "dev", dirty working
+//     tree, or git-describe between-tags) → fall back to
+//     /releases/latest with a WARN so local dev is still ergonomic.
 //
 // Env-var escape hatches (matching DEADZONE_ORT_CACHE / DEADZONE_HUGOT_CACHE):
 //
-//   DEADZONE_DB_CACHE             — override the cache directory
-//   DEADZONE_DB_OFFLINE=1         — never make a network call; fail loud
-//                                   on first run if nothing cached
-//   DEADZONE_DB_NO_AUTO_UPGRADE=1 — skip the staleness check; first-run
-//                                   fetch still happens
+//   DEADZONE_DB_CACHE     — override the cache directory
+//   DEADZONE_DB_OFFLINE=1 — never make a network call; fail loud on
+//                           first run or when the cached DB's version
+//                           doesn't match the binary
+//
+// DEADZONE_DB_NO_AUTO_UPGRADE was removed in PR #110 review: the
+// per-startup API call it protected against no longer happens now that
+// the tag-match path is zero-network.
 
 package db
 
@@ -35,6 +42,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -43,56 +51,82 @@ import (
 // Cache / asset constants. The asset names match what `deadzone
 // dbrelease` uploads; changing either side requires changing both.
 const (
-	EnvCacheDir      = "DEADZONE_DB_CACHE"
-	EnvOffline       = "DEADZONE_DB_OFFLINE"
-	EnvNoAutoUpgrade = "DEADZONE_DB_NO_AUTO_UPGRADE"
+	EnvCacheDir = "DEADZONE_DB_CACHE"
+	EnvOffline  = "DEADZONE_DB_OFFLINE"
 
 	BootstrapDefaultRepo = "laradji/deadzone"
+
+	// DevVersion is the sentinel AppVersion for local / unreleased
+	// builds. Bootstrap falls back to /releases/latest on it.
+	DevVersion = "dev"
 
 	dbAssetName     = "deadzone.db"
 	sha256AssetName = "deadzone.db.sha256"
 	tagSidecarName  = "deadzone.db.release"
 )
 
-// httpClient bounds the worst-case download. The 50–200 MB DB on a
-// slow residential link can take a while; 15 minutes is the same upper
-// bound the ORT bootstrap uses (rounded up because the DB is larger).
-var httpClient = &http.Client{Timeout: 15 * time.Minute}
+// Two HTTP clients with different timeouts (PR #110 review item 2):
+// metadata responses are tiny JSON, so a hung API call shouldn't make
+// a user wait 15 minutes before failing. The asset download is the
+// bandwidth-heavy one and keeps the long ceiling.
+var (
+	metadataHTTPClient = &http.Client{Timeout: 30 * time.Second}
+	assetHTTPClient    = &http.Client{Timeout: 15 * time.Minute}
+)
 
 // releasesAPIBase is the GitHub API root. Split out so tests can point
 // Bootstrap at a local httptest server.
 var releasesAPIBase = "https://api.github.com"
 
-// BootstrapOptions lets callers (mainly the fetch-db subcommand and
-// tests) override what Bootstrap pulls from env / defaults. Zero value
-// matches Bootstrap's behavior exactly.
+// gitDescribeBetweenTagsRe recognises `git describe --tags --always`
+// output for commits that aren't themselves a tagged release:
+// "v0.1.0-2-g1234567" (with optional "-dirty"). Such builds aren't
+// published releases, so Bootstrap treats them as dev and falls back
+// to /releases/latest.
+var gitDescribeBetweenTagsRe = regexp.MustCompile(`-\d+-g[0-9a-f]{7,}(-dirty)?$`)
+
+// ErrNoReleaseForVersion is returned when the requested AppVersion has
+// no corresponding release on GitHub. Callers (main, tests) check via
+// errors.Is so the user-facing error message can be precise. Wraps
+// nothing — it IS the error.
+var ErrNoReleaseForVersion = errors.New("no deadzone.db published for this binary version")
+
+// BootstrapOptions lets callers (runServer, runFetchDB, tests)
+// override what Bootstrap pulls from env / defaults.
 type BootstrapOptions struct {
 	// CacheDir overrides DEADZONE_DB_CACHE / the platform default.
 	CacheDir string
 	// Repo overrides BootstrapDefaultRepo (owner/name).
 	Repo string
-	// Force re-fetches even when the cached tag matches the latest
-	// release. fetch-db --force uses this; the server path leaves it
-	// false so a no-op startup stays a no-op.
+	// AppVersion is the binary's own version string (e.g. "v0.1.0"
+	// from the justfile's -ldflags). Required in practice; an empty
+	// string is treated as DevVersion and triggers the /latest
+	// fallback.
+	AppVersion string
+	// Force re-fetches even when the cached tag matches AppVersion.
+	// fetch-db --force uses this; the server path leaves it false so
+	// a no-op startup stays zero-network.
 	Force bool
 }
 
 // Bootstrap ensures a deadzone.db is present at the default cache
-// location and returns its path. Handles first-fetch, the staleness
-// check, and the auto-upgrade swap, bounded by DEADZONE_DB_OFFLINE and
-// DEADZONE_DB_NO_AUTO_UPGRADE.
+// location, pinned to appVersion, and returns its path. See the file
+// banner for the full contract.
 //
-// Returns (path, upgraded, error) where upgraded is true when this call
-// just replaced a stale cache. First-fetch returns upgraded=false (no
-// previous file existed to "upgrade" from).
-func Bootstrap(ctx context.Context) (string, bool, error) {
-	return BootstrapWithOptions(ctx, BootstrapOptions{})
+// Returns (path, upgraded, error) where upgraded is true when this
+// call just replaced an existing cache file (version bump or -force).
+// First-fetch returns upgraded=false (no previous file existed).
+func Bootstrap(ctx context.Context, appVersion string) (string, bool, error) {
+	return BootstrapWithOptions(ctx, BootstrapOptions{AppVersion: appVersion})
 }
 
-// BootstrapWithOptions is the explicit-options form of Bootstrap. The
-// fetch-db subcommand uses it for -force; tests use it to inject a
-// CacheDir + Repo without touching env vars.
+// BootstrapWithOptions is the explicit-options form of Bootstrap.
+// fetch-db uses it for -force and -repo; tests use it to inject a
+// CacheDir without touching env vars.
 func BootstrapWithOptions(ctx context.Context, opts BootstrapOptions) (string, bool, error) {
+	if opts.AppVersion == "" {
+		opts.AppVersion = DevVersion
+	}
 	cacheDir := opts.CacheDir
 	if cacheDir == "" {
 		cacheDir = DefaultCacheDir()
@@ -111,44 +145,61 @@ func BootstrapWithOptions(ctx context.Context, opts BootstrapOptions) (string, b
 
 	cached := fileExists(dbPath)
 	offline := os.Getenv(EnvOffline) == "1"
-	noUpgrade := os.Getenv(EnvNoAutoUpgrade) == "1"
 
-	// Cached + (noUpgrade or offline) and not -force → short-circuit.
-	// This is the "no network" row of the matrix.
-	if cached && !opts.Force && (noUpgrade || offline) {
-		return dbPath, false, nil
+	cachedTag := ""
+	if b, err := os.ReadFile(tagPath); err == nil {
+		cachedTag = strings.TrimSpace(string(b))
 	}
-	// Not cached + offline → fail loud. We can't satisfy the request
-	// without a network call and the operator opted out of one.
-	if !cached && offline {
+
+	isDev := isDevVersion(opts.AppVersion)
+
+	// Fast path (zero API calls): cache exists, its tag matches the
+	// binary's AppVersion, caller did not force. For dev builds we
+	// accept any cached DB — "whatever you last fetched is fine,
+	// don't nag" is the ergonomic choice for local iteration.
+	if cached && !opts.Force {
+		if isDev || cachedTag == opts.AppVersion {
+			return dbPath, false, nil
+		}
+	}
+
+	// Offline: we can't fetch, so either serve cache (only if dev or
+	// matching tag, already handled above) or fail.
+	if offline {
+		if cached {
+			return "", false, fmt.Errorf("db: cached DB is version %q but binary is %q and %s=1 prevents fetch; unset the env var or hand-place a matching DB at %s", cachedTag, opts.AppVersion, EnvOffline, dbPath)
+		}
 		return "", false, fmt.Errorf("db: no cached %s and %s=1; hand-place a DB at %s or unset the env var", dbAssetName, EnvOffline, dbPath)
 	}
 
-	latest, err := fetchLatestRelease(ctx, repo)
+	// Resolve the release metadata. Dev builds fall back to /latest
+	// with a WARN; tagged builds fetch their own tag's release.
+	var meta releaseMeta
+	var err error
+	if isDev {
+		slog.Warn("server.db_version_dev_fallback", "app_version", opts.AppVersion)
+		meta, err = fetchLatestRelease(ctx, repo)
+	} else {
+		meta, err = fetchReleaseByTag(ctx, repo, opts.AppVersion)
+	}
 	if err != nil {
-		// Cached file present → degrade to "serve stale". Only the
-		// first-run no-cache path can promote a metadata error to a
-		// startup error.
+		// Version mismatch (or first fetch) + network/404 error:
+		// fail loud. Serving a stale cache at a different version
+		// than the binary expects risks schema/embedder drift, so the
+		// first-fetch error generalises to the mismatch case.
 		if cached {
-			slog.Warn("server.db_upgrade_failed", "err", err.Error())
-			return dbPath, false, nil
+			return "", false, fmt.Errorf("db: cached DB is version %q but binary is %q; could not fetch matching release: %w. Hints: check network reachability, pass -db <path> to pin a known-good file, or set %s=1 with a hand-placed file", cachedTag, opts.AppVersion, err, EnvOffline)
 		}
-		return "", false, fmt.Errorf("db: fetch latest release: %w", err)
+		return "", false, fmt.Errorf("db: fetch release for %q: %w", opts.AppVersion, err)
 	}
 
-	// Tag-match short circuit (skips the heavy asset download).
-	if cached && !opts.Force {
-		cachedTag, _ := os.ReadFile(tagPath)
-		if strings.TrimSpace(string(cachedTag)) == latest.Tag {
-			return dbPath, false, nil
-		}
+	// Dev fallback can still hit the zero-download short-circuit if
+	// the latest release's tag happens to match the cached sidecar.
+	if cached && !opts.Force && isDev && cachedTag == meta.Tag {
+		return dbPath, false, nil
 	}
 
-	if err := fetchAndInstall(ctx, latest, dbPath, tagPath); err != nil {
-		if cached {
-			slog.Warn("server.db_upgrade_failed", "err", err.Error())
-			return dbPath, false, nil
-		}
+	if err := fetchAndInstall(ctx, meta, dbPath, tagPath); err != nil {
 		return "", false, fmt.Errorf("db: install %s: %w", dbAssetName, err)
 	}
 	return dbPath, cached, nil
@@ -164,16 +215,15 @@ func BootstrapWithOptions(ctx context.Context, opts BootstrapOptions) (string, b
 //  3. ./.deadzone-cache/db as a last-resort fallback so Bootstrap can
 //     still proceed when the home dir lookup fails.
 //
-// Per-platform data dirs (matching the issue spec):
+// Per-platform data dirs:
 //
 //   - macOS:   ~/Library/Application Support/deadzone
 //   - Linux:   $XDG_DATA_HOME/deadzone (falls back to ~/.local/share/deadzone)
 //   - Windows: %LOCALAPPDATA%\deadzone (falls back to ~/AppData/Local/deadzone)
 //
 // We don't reuse os.UserCacheDir because the issue intentionally sites
-// the DB under the persistent data dir (Application Support / data),
-// not the volatile cache dir (Caches). The DB is the user's
-// installation, not a regenerable cache.
+// the DB under the persistent data dir, not the volatile cache dir.
+// The DB is the user's installation, not a regenerable cache.
 func DefaultCacheDir() string {
 	if dir := os.Getenv(EnvCacheDir); dir != "" {
 		return dir
@@ -203,6 +253,28 @@ func DefaultCacheDir() string {
 	return filepath.Join(base, "deadzone")
 }
 
+// isDevVersion recognises build strings that don't correspond to a
+// published release tag:
+//
+//   - "" / "dev" — default when no -ldflags -X main.version is set
+//   - anything ending in "-dirty" — justfile's build-release emits
+//     this for a dirty working tree
+//   - git-describe between-tags form ("v0.1.0-2-g1234567") — emitted
+//     when the HEAD commit isn't itself tagged
+//
+// All three trigger the /releases/latest fallback so local dev stays
+// ergonomic and CI's smoke build (which may not be at a tagged commit)
+// keeps working.
+func isDevVersion(v string) bool {
+	if v == "" || v == DevVersion {
+		return true
+	}
+	if strings.HasSuffix(v, "-dirty") {
+		return true
+	}
+	return gitDescribeBetweenTagsRe.MatchString(v)
+}
+
 // releaseMeta is the trimmed view Bootstrap needs from the GitHub
 // releases API: just the tag and the two asset URLs.
 type releaseMeta struct {
@@ -211,23 +283,41 @@ type releaseMeta struct {
 	SHA256URL string
 }
 
-// fetchLatestRelease hits /repos/{owner}/{repo}/releases/latest and
-// pulls out the tag plus the two asset download URLs. Both assets must
-// be present on the release; a release missing either is a packaging
-// bug on the publishing side and is surfaced as an error here so the
-// user sees it immediately, not after a partial install.
+// fetchLatestRelease hits /repos/{owner}/{repo}/releases/latest.
+// Only used by the dev-version fallback.
 func fetchLatestRelease(ctx context.Context, repo string) (releaseMeta, error) {
 	url := fmt.Sprintf("%s/repos/%s/releases/latest", releasesAPIBase, repo)
+	return decodeRelease(ctx, url, "")
+}
+
+// fetchReleaseByTag hits /repos/{owner}/{repo}/releases/tags/{tag}.
+// A 404 surfaces as ErrNoReleaseForVersion so the caller can wrap
+// with the actionable "downgrade the binary / hand-place a DB" hint.
+func fetchReleaseByTag(ctx context.Context, repo, tag string) (releaseMeta, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases/tags/%s", releasesAPIBase, repo, tag)
+	return decodeRelease(ctx, url, tag)
+}
+
+// decodeRelease is the shared HTTP+JSON parser for both release
+// endpoints. Passing the expected tag lets the 404 error message name
+// the version the user was asking for.
+func decodeRelease(ctx context.Context, url, expectedTag string) (releaseMeta, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return releaseMeta{}, fmt.Errorf("new request: %w", err)
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
-	resp, err := httpClient.Do(req)
+	resp, err := metadataHTTPClient.Do(req)
 	if err != nil {
 		return releaseMeta{}, fmt.Errorf("get %s: %w", url, err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		if expectedTag != "" {
+			return releaseMeta{}, fmt.Errorf("%w %q (hint: hand-place a DB with -db <path>, or downgrade the binary to a version with a published DB)", ErrNoReleaseForVersion, expectedTag)
+		}
+		return releaseMeta{}, fmt.Errorf("%w (no latest release on %s)", ErrNoReleaseForVersion, url)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return releaseMeta{}, fmt.Errorf("get %s: status %d", url, resp.StatusCode)
 	}
@@ -262,14 +352,20 @@ func fetchLatestRelease(ctx context.Context, repo string) (releaseMeta, error) {
 	return meta, nil
 }
 
-// fetchAndInstall does the heavy lifting: pull the sha256 sidecar, then
-// stream the DB into a temp file under the cache dir while hashing it,
-// verify, atomic rename into place, write the tag sidecar.
+// fetchAndInstall does the heavy lifting: pull the sha256 sidecar,
+// stream the DB into a temp file under the cache dir while hashing
+// it, verify, atomic rename into place, best-effort tag sidecar.
 //
 // The temp file lives in the same directory as the destination so
 // os.Rename is a true atomic-on-success move. On any failure between
 // CreateTemp and Rename, the destination file remains untouched and
 // the temp is cleaned up.
+//
+// Tag sidecar failure after a successful rename is logged as a WARN
+// but not returned as an error (PR #110 review item 4): the DB is in
+// place and serving. A missing/stale sidecar only means the next
+// startup will re-fetch thinking the cache is stale, which is
+// wasteful but correct.
 func fetchAndInstall(ctx context.Context, meta releaseMeta, dbPath, tagPath string) error {
 	wantHash, err := fetchSHA256(ctx, meta.SHA256URL)
 	if err != nil {
@@ -294,7 +390,7 @@ func fetchAndInstall(ctx context.Context, meta releaseMeta, dbPath, tagPath stri
 	if err != nil {
 		return fmt.Errorf("new request: %w", err)
 	}
-	resp, err := httpClient.Do(req)
+	resp, err := assetHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("get %s: %w", meta.DBURL, err)
 	}
@@ -322,10 +418,7 @@ func fetchAndInstall(ctx context.Context, meta releaseMeta, dbPath, tagPath stri
 	cleanup = false
 
 	if err := os.WriteFile(tagPath, []byte(meta.Tag+"\n"), 0o644); err != nil {
-		// The DB itself is in place; surface the sidecar failure but
-		// don't unwind the install. Worst case: next startup re-fetches
-		// thinking the cache is stale, which is wasteful but correct.
-		return fmt.Errorf("write tag sidecar %s: %w", tagPath, err)
+		slog.Warn("server.db_tag_sidecar_write_failed", "err", err.Error(), "path", tagPath)
 	}
 	return nil
 }
@@ -339,7 +432,7 @@ func fetchSHA256(ctx context.Context, url string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("new request: %w", err)
 	}
-	resp, err := httpClient.Do(req)
+	resp, err := assetHTTPClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("get %s: %w", url, err)
 	}

--- a/internal/db/bootstrap.go
+++ b/internal/db/bootstrap.go
@@ -1,0 +1,371 @@
+// bootstrap.go owns the consumer-side fetch + auto-upgrade flow for
+// deadzone.db, mirroring internal/ort/ort.go's symmetric flow for the
+// onnxruntime shared library. See issue #108 for the full design and
+// behavior matrix.
+//
+// Three trigger paths share this implementation:
+//
+//  1. First run, no cached DB → fetch latest release's deadzone.db into
+//     cache, serve.
+//  2. Subsequent run, cached DB tag matches latest → use cache, skip
+//     the asset download (still hits the API to compare tags; "no
+//     network" in the issue means "no asset transfer").
+//  3. Subsequent run, cached DB tag != latest → fetch new, atomic swap,
+//     serve new version.
+//
+// Env-var escape hatches (matching DEADZONE_ORT_CACHE / DEADZONE_HUGOT_CACHE):
+//
+//   DEADZONE_DB_CACHE             — override the cache directory
+//   DEADZONE_DB_OFFLINE=1         — never make a network call; fail loud
+//                                   on first run if nothing cached
+//   DEADZONE_DB_NO_AUTO_UPGRADE=1 — skip the staleness check; first-run
+//                                   fetch still happens
+
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Cache / asset constants. The asset names match what `deadzone
+// dbrelease` uploads; changing either side requires changing both.
+const (
+	EnvCacheDir      = "DEADZONE_DB_CACHE"
+	EnvOffline       = "DEADZONE_DB_OFFLINE"
+	EnvNoAutoUpgrade = "DEADZONE_DB_NO_AUTO_UPGRADE"
+
+	BootstrapDefaultRepo = "laradji/deadzone"
+
+	dbAssetName     = "deadzone.db"
+	sha256AssetName = "deadzone.db.sha256"
+	tagSidecarName  = "deadzone.db.release"
+)
+
+// httpClient bounds the worst-case download. The 50–200 MB DB on a
+// slow residential link can take a while; 15 minutes is the same upper
+// bound the ORT bootstrap uses (rounded up because the DB is larger).
+var httpClient = &http.Client{Timeout: 15 * time.Minute}
+
+// releasesAPIBase is the GitHub API root. Split out so tests can point
+// Bootstrap at a local httptest server.
+var releasesAPIBase = "https://api.github.com"
+
+// BootstrapOptions lets callers (mainly the fetch-db subcommand and
+// tests) override what Bootstrap pulls from env / defaults. Zero value
+// matches Bootstrap's behavior exactly.
+type BootstrapOptions struct {
+	// CacheDir overrides DEADZONE_DB_CACHE / the platform default.
+	CacheDir string
+	// Repo overrides BootstrapDefaultRepo (owner/name).
+	Repo string
+	// Force re-fetches even when the cached tag matches the latest
+	// release. fetch-db --force uses this; the server path leaves it
+	// false so a no-op startup stays a no-op.
+	Force bool
+}
+
+// Bootstrap ensures a deadzone.db is present at the default cache
+// location and returns its path. Handles first-fetch, the staleness
+// check, and the auto-upgrade swap, bounded by DEADZONE_DB_OFFLINE and
+// DEADZONE_DB_NO_AUTO_UPGRADE.
+//
+// Returns (path, upgraded, error) where upgraded is true when this call
+// just replaced a stale cache. First-fetch returns upgraded=false (no
+// previous file existed to "upgrade" from).
+func Bootstrap(ctx context.Context) (string, bool, error) {
+	return BootstrapWithOptions(ctx, BootstrapOptions{})
+}
+
+// BootstrapWithOptions is the explicit-options form of Bootstrap. The
+// fetch-db subcommand uses it for -force; tests use it to inject a
+// CacheDir + Repo without touching env vars.
+func BootstrapWithOptions(ctx context.Context, opts BootstrapOptions) (string, bool, error) {
+	cacheDir := opts.CacheDir
+	if cacheDir == "" {
+		cacheDir = DefaultCacheDir()
+	}
+	repo := opts.Repo
+	if repo == "" {
+		repo = BootstrapDefaultRepo
+	}
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", false, fmt.Errorf("db: create cache dir %q: %w", cacheDir, err)
+	}
+
+	dbPath := filepath.Join(cacheDir, dbAssetName)
+	tagPath := filepath.Join(cacheDir, tagSidecarName)
+
+	cached := fileExists(dbPath)
+	offline := os.Getenv(EnvOffline) == "1"
+	noUpgrade := os.Getenv(EnvNoAutoUpgrade) == "1"
+
+	// Cached + (noUpgrade or offline) and not -force → short-circuit.
+	// This is the "no network" row of the matrix.
+	if cached && !opts.Force && (noUpgrade || offline) {
+		return dbPath, false, nil
+	}
+	// Not cached + offline → fail loud. We can't satisfy the request
+	// without a network call and the operator opted out of one.
+	if !cached && offline {
+		return "", false, fmt.Errorf("db: no cached %s and %s=1; hand-place a DB at %s or unset the env var", dbAssetName, EnvOffline, dbPath)
+	}
+
+	latest, err := fetchLatestRelease(ctx, repo)
+	if err != nil {
+		// Cached file present → degrade to "serve stale". Only the
+		// first-run no-cache path can promote a metadata error to a
+		// startup error.
+		if cached {
+			slog.Warn("server.db_upgrade_failed", "err", err.Error())
+			return dbPath, false, nil
+		}
+		return "", false, fmt.Errorf("db: fetch latest release: %w", err)
+	}
+
+	// Tag-match short circuit (skips the heavy asset download).
+	if cached && !opts.Force {
+		cachedTag, _ := os.ReadFile(tagPath)
+		if strings.TrimSpace(string(cachedTag)) == latest.Tag {
+			return dbPath, false, nil
+		}
+	}
+
+	if err := fetchAndInstall(ctx, latest, dbPath, tagPath); err != nil {
+		if cached {
+			slog.Warn("server.db_upgrade_failed", "err", err.Error())
+			return dbPath, false, nil
+		}
+		return "", false, fmt.Errorf("db: install %s: %w", dbAssetName, err)
+	}
+	return dbPath, cached, nil
+}
+
+// DefaultCacheDir resolves the cache root used by Bootstrap when the
+// caller passes an empty CacheDir / DEADZONE_DB_CACHE is unset.
+//
+// Resolution order:
+//
+//  1. $DEADZONE_DB_CACHE if set.
+//  2. Platform data dir (per-platform, see below).
+//  3. ./.deadzone-cache/db as a last-resort fallback so Bootstrap can
+//     still proceed when the home dir lookup fails.
+//
+// Per-platform data dirs (matching the issue spec):
+//
+//   - macOS:   ~/Library/Application Support/deadzone
+//   - Linux:   $XDG_DATA_HOME/deadzone (falls back to ~/.local/share/deadzone)
+//   - Windows: %LOCALAPPDATA%\deadzone (falls back to ~/AppData/Local/deadzone)
+//
+// We don't reuse os.UserCacheDir because the issue intentionally sites
+// the DB under the persistent data dir (Application Support / data),
+// not the volatile cache dir (Caches). The DB is the user's
+// installation, not a regenerable cache.
+func DefaultCacheDir() string {
+	if dir := os.Getenv(EnvCacheDir); dir != "" {
+		return dir
+	}
+	var base string
+	switch runtime.GOOS {
+	case "darwin":
+		if home, err := os.UserHomeDir(); err == nil {
+			base = filepath.Join(home, "Library", "Application Support")
+		}
+	case "windows":
+		if v := os.Getenv("LOCALAPPDATA"); v != "" {
+			base = v
+		} else if home, err := os.UserHomeDir(); err == nil {
+			base = filepath.Join(home, "AppData", "Local")
+		}
+	default:
+		if v := os.Getenv("XDG_DATA_HOME"); v != "" {
+			base = v
+		} else if home, err := os.UserHomeDir(); err == nil {
+			base = filepath.Join(home, ".local", "share")
+		}
+	}
+	if base == "" {
+		return filepath.Join(".deadzone-cache", "db")
+	}
+	return filepath.Join(base, "deadzone")
+}
+
+// releaseMeta is the trimmed view Bootstrap needs from the GitHub
+// releases API: just the tag and the two asset URLs.
+type releaseMeta struct {
+	Tag       string
+	DBURL     string
+	SHA256URL string
+}
+
+// fetchLatestRelease hits /repos/{owner}/{repo}/releases/latest and
+// pulls out the tag plus the two asset download URLs. Both assets must
+// be present on the release; a release missing either is a packaging
+// bug on the publishing side and is surfaced as an error here so the
+// user sees it immediately, not after a partial install.
+func fetchLatestRelease(ctx context.Context, repo string) (releaseMeta, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", releasesAPIBase, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return releaseMeta{}, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return releaseMeta{}, fmt.Errorf("get %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return releaseMeta{}, fmt.Errorf("get %s: status %d", url, resp.StatusCode)
+	}
+	var body struct {
+		TagName string `json:"tag_name"`
+		Assets  []struct {
+			Name               string `json:"name"`
+			BrowserDownloadURL string `json:"browser_download_url"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return releaseMeta{}, fmt.Errorf("decode response: %w", err)
+	}
+	if body.TagName == "" {
+		return releaseMeta{}, errors.New("response has empty tag_name")
+	}
+	meta := releaseMeta{Tag: body.TagName}
+	for _, a := range body.Assets {
+		switch a.Name {
+		case dbAssetName:
+			meta.DBURL = a.BrowserDownloadURL
+		case sha256AssetName:
+			meta.SHA256URL = a.BrowserDownloadURL
+		}
+	}
+	if meta.DBURL == "" {
+		return releaseMeta{}, fmt.Errorf("release %s has no %s asset", body.TagName, dbAssetName)
+	}
+	if meta.SHA256URL == "" {
+		return releaseMeta{}, fmt.Errorf("release %s has no %s asset", body.TagName, sha256AssetName)
+	}
+	return meta, nil
+}
+
+// fetchAndInstall does the heavy lifting: pull the sha256 sidecar, then
+// stream the DB into a temp file under the cache dir while hashing it,
+// verify, atomic rename into place, write the tag sidecar.
+//
+// The temp file lives in the same directory as the destination so
+// os.Rename is a true atomic-on-success move. On any failure between
+// CreateTemp and Rename, the destination file remains untouched and
+// the temp is cleaned up.
+func fetchAndInstall(ctx context.Context, meta releaseMeta, dbPath, tagPath string) error {
+	wantHash, err := fetchSHA256(ctx, meta.SHA256URL)
+	if err != nil {
+		return fmt.Errorf("fetch sha256: %w", err)
+	}
+
+	cacheDir := filepath.Dir(dbPath)
+	tmp, err := os.CreateTemp(cacheDir, dbAssetName+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create tempfile in %s: %w", cacheDir, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, meta.DBURL, nil)
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("get %s: %w", meta.DBURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("get %s: status %d", meta.DBURL, resp.StatusCode)
+	}
+
+	hasher := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, hasher), resp.Body); err != nil {
+		return fmt.Errorf("stream %s: %w", meta.DBURL, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close tempfile %s: %w", tmpPath, err)
+	}
+
+	got := hex.EncodeToString(hasher.Sum(nil))
+	if got != wantHash {
+		return fmt.Errorf("sha256 mismatch on %s: got %s, want %s", meta.DBURL, got, wantHash)
+	}
+
+	if err := os.Rename(tmpPath, dbPath); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, dbPath, err)
+	}
+	cleanup = false
+
+	if err := os.WriteFile(tagPath, []byte(meta.Tag+"\n"), 0o644); err != nil {
+		// The DB itself is in place; surface the sidecar failure but
+		// don't unwind the install. Worst case: next startup re-fetches
+		// thinking the cache is stale, which is wasteful but correct.
+		return fmt.Errorf("write tag sidecar %s: %w", tagPath, err)
+	}
+	return nil
+}
+
+// fetchSHA256 reads the sha256 sidecar uploaded alongside deadzone.db.
+// Format is the standard GNU coreutils single-line "<hex>  filename"
+// emitted by `dbrelease`. We only care about the hex digest; the
+// filename is implicit.
+func fetchSHA256(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("new request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("get %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("get %s: status %d", url, resp.StatusCode)
+	}
+	// 4 KiB is generous for a one-line sha256 file; cap to make a
+	// hostile mirror responding with infinite bytes a clear OOM-free
+	// error instead of an exhausted process.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return "", fmt.Errorf("read sha256 body: %w", err)
+	}
+	fields := strings.Fields(string(body))
+	if len(fields) == 0 {
+		return "", errors.New("sha256 file is empty")
+	}
+	hash := strings.ToLower(fields[0])
+	if len(hash) != 64 {
+		return "", fmt.Errorf("malformed sha256 %q (want 64 hex chars)", hash)
+	}
+	return hash, nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/db/bootstrap_test.go
+++ b/internal/db/bootstrap_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -18,7 +19,7 @@ import (
 // dbBootstrapEnv lists the env vars Bootstrap reads. Every test
 // neutralizes them via t.Setenv so a developer's local
 // DEADZONE_DB_CACHE / DEADZONE_DB_OFFLINE doesn't bleed in.
-var dbBootstrapEnv = []string{EnvCacheDir, EnvOffline, EnvNoAutoUpgrade}
+var dbBootstrapEnv = []string{EnvCacheDir, EnvOffline}
 
 func clearBootstrapEnv(t *testing.T) {
 	t.Helper()
@@ -43,67 +44,111 @@ func newFakeRelease(t *testing.T, tag, content string) fakeRelease {
 	return fakeRelease{tag: tag, dbBody: body, dbHash: hex.EncodeToString(sum[:])}
 }
 
-// fixtureServer wires together the API endpoint and the asset endpoints
+// fixtureServer wires together the API endpoints and asset endpoints
 // behind a single httptest server so the fake "browser_download_url"
-// values can point back at the same host. requests counts every hit so
-// tests can assert "zero asset downloads" precisely.
+// values can point back at the same host.
+//
+// releases maps tag → fakeRelease so a single fixture can serve both
+// /releases/tags/<t> and the synthetic "latest" pick. The tags slice
+// preserves insertion order — latestTag returns the last-added tag so
+// tests that simulate "newer release dropped" can append to it
+// mid-test.
 type fixtureServer struct {
 	srv         *httptest.Server
-	rel         fakeRelease
+	releases    map[string]fakeRelease
+	tagOrder    []string
 	apiCalls    atomic.Int32
 	dbCalls     atomic.Int32
 	sha256Calls atomic.Int32
-	failAPI     atomic.Bool // when true, /repos/.../latest returns 500
-	corruptDB   atomic.Bool // when true, dbBody comes back with a single byte flipped
+	failAPI     atomic.Bool // when true, API endpoints return 500
 	corruptSHA  atomic.Bool // when true, sha256 comes back as zeroes (mismatch)
 	missingDB   atomic.Bool // when true, the JSON omits the deadzone.db asset
 }
 
-func newFixtureServer(t *testing.T, rel fakeRelease) *fixtureServer {
+func (f *fixtureServer) latestTag() string {
+	if len(f.tagOrder) == 0 {
+		return ""
+	}
+	return f.tagOrder[len(f.tagOrder)-1]
+}
+
+func newFixtureServer(t *testing.T, releases ...fakeRelease) *fixtureServer {
 	t.Helper()
-	fs := &fixtureServer{rel: rel}
+	fs := &fixtureServer{releases: map[string]fakeRelease{}}
+	for _, r := range releases {
+		fs.releases[r.tag] = r
+		fs.tagOrder = append(fs.tagOrder, r.tag)
+	}
 	mux := http.NewServeMux()
+	serveRelease := func(w http.ResponseWriter, rel fakeRelease) {
+		assets := []map[string]string{
+			{"name": sha256AssetName, "browser_download_url": fs.srv.URL + "/dl/" + rel.tag + "/" + sha256AssetName},
+		}
+		if !fs.missingDB.Load() {
+			assets = append(assets, map[string]string{
+				"name":                 dbAssetName,
+				"browser_download_url": fs.srv.URL + "/dl/" + rel.tag + "/" + dbAssetName,
+			})
+		}
+		body := map[string]any{"tag_name": rel.tag, "assets": assets}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}
 	mux.HandleFunc("/repos/laradji/deadzone/releases/latest", func(w http.ResponseWriter, r *http.Request) {
 		fs.apiCalls.Add(1)
 		if fs.failAPI.Load() {
 			http.Error(w, "boom", http.StatusInternalServerError)
 			return
 		}
-		assets := []map[string]string{
-			{"name": sha256AssetName, "browser_download_url": fs.srv.URL + "/dl/" + sha256AssetName},
-		}
-		if !fs.missingDB.Load() {
-			assets = append(assets, map[string]string{
-				"name":                 dbAssetName,
-				"browser_download_url": fs.srv.URL + "/dl/" + dbAssetName,
-			})
-		}
-		body := map[string]any{
-			"tag_name": fs.rel.tag,
-			"assets":   assets,
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(body)
-	})
-	mux.HandleFunc("/dl/"+dbAssetName, func(w http.ResponseWriter, r *http.Request) {
-		fs.dbCalls.Add(1)
-		if fs.corruptDB.Load() {
-			b := append([]byte(nil), fs.rel.dbBody...)
-			if len(b) > 0 {
-				b[0] ^= 0xff
-			}
-			_, _ = w.Write(b)
+		tag := fs.latestTag()
+		rel, ok := fs.releases[tag]
+		if !ok {
+			http.Error(w, "no releases", http.StatusNotFound)
 			return
 		}
-		_, _ = w.Write(fs.rel.dbBody)
+		serveRelease(w, rel)
 	})
-	mux.HandleFunc("/dl/"+sha256AssetName, func(w http.ResponseWriter, r *http.Request) {
-		fs.sha256Calls.Add(1)
-		hash := fs.rel.dbHash
-		if fs.corruptSHA.Load() {
-			hash = strings.Repeat("0", 64)
+	mux.HandleFunc("/repos/laradji/deadzone/releases/tags/", func(w http.ResponseWriter, r *http.Request) {
+		fs.apiCalls.Add(1)
+		if fs.failAPI.Load() {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
 		}
-		fmt.Fprintf(w, "%s  %s\n", hash, dbAssetName)
+		tag := strings.TrimPrefix(r.URL.Path, "/repos/laradji/deadzone/releases/tags/")
+		rel, ok := fs.releases[tag]
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		serveRelease(w, rel)
+	})
+	mux.HandleFunc("/dl/", func(w http.ResponseWriter, r *http.Request) {
+		// Path format: /dl/<tag>/<asset>
+		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/dl/"), "/")
+		if len(parts) != 2 {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		tag, asset := parts[0], parts[1]
+		rel, ok := fs.releases[tag]
+		if !ok {
+			http.Error(w, "unknown tag", http.StatusNotFound)
+			return
+		}
+		switch asset {
+		case dbAssetName:
+			fs.dbCalls.Add(1)
+			_, _ = w.Write(rel.dbBody)
+		case sha256AssetName:
+			fs.sha256Calls.Add(1)
+			hash := rel.dbHash
+			if fs.corruptSHA.Load() {
+				hash = strings.Repeat("0", 64)
+			}
+			fmt.Fprintf(w, "%s  %s\n", hash, dbAssetName)
+		default:
+			http.Error(w, "unknown asset", http.StatusNotFound)
+		}
 	})
 	fs.srv = httptest.NewServer(mux)
 	t.Cleanup(fs.srv.Close)
@@ -111,7 +156,7 @@ func newFixtureServer(t *testing.T, rel fakeRelease) *fixtureServer {
 }
 
 // withAPIBase swaps the package-level releasesAPIBase for the duration
-// of the test. The defer restores the production value so a failing
+// of the test. The cleanup restores the production value so a failing
 // test can't poison sibling tests in the same binary.
 func withAPIBase(t *testing.T, base string) {
 	t.Helper()
@@ -120,18 +165,35 @@ func withAPIBase(t *testing.T, base string) {
 	t.Cleanup(func() { releasesAPIBase = orig })
 }
 
-// TestBootstrap_FreshCache covers the first-fetch happy path: empty
-// cache + reachable network → DB lands in cache, sha256 verifies, tag
-// sidecar is written with the release tag, upgraded=false because no
-// previous file existed.
-func TestBootstrap_FreshCache(t *testing.T) {
+// seedCache writes dbBody + tag sidecar into dir so the tag-match
+// short-circuit tests can assert what happens on a populated cache.
+func seedCache(t *testing.T, dir, dbBody, tag string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, dbAssetName), []byte(dbBody), 0o644); err != nil {
+		t.Fatalf("seed cache db: %v", err)
+	}
+	if tag != "" {
+		if err := os.WriteFile(filepath.Join(dir, tagSidecarName), []byte(tag+"\n"), 0o644); err != nil {
+			t.Fatalf("seed cache tag: %v", err)
+		}
+	}
+}
+
+// TestBootstrap_FirstFetch covers the first-run happy path: empty
+// cache, binary's AppVersion maps to a real release → DB lands in
+// cache, sha256 verifies, tag sidecar records AppVersion, upgraded is
+// false because no previous file existed.
+func TestBootstrap_FirstFetch(t *testing.T) {
 	clearBootstrapEnv(t)
 	rel := newFakeRelease(t, "v1.0.0", "fake-db-content-v1")
 	fix := newFixtureServer(t, rel)
 	withAPIBase(t, fix.srv.URL)
 
 	cacheDir := t.TempDir()
-	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.0.0",
+	})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
@@ -160,73 +222,24 @@ func TestBootstrap_FreshCache(t *testing.T) {
 	}
 }
 
-// TestBootstrap_OfflineNoCache covers DEADZONE_DB_OFFLINE=1 with
-// nothing cached: must error and must not leave a partial file. The
-// error message must mention the env var so an offline operator knows
-// the escape hatch they tripped.
-func TestBootstrap_OfflineNoCache(t *testing.T) {
-	clearBootstrapEnv(t)
-	t.Setenv(EnvOffline, "1")
-
-	cacheDir := t.TempDir()
-	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
-	if err == nil {
-		t.Fatalf("Bootstrap returned no error; got path=%q upgraded=%v", path, upgraded)
-	}
-	if !strings.Contains(err.Error(), EnvOffline) {
-		t.Errorf("error %q does not mention %s", err, EnvOffline)
-	}
-	if _, statErr := os.Stat(filepath.Join(cacheDir, dbAssetName)); !os.IsNotExist(statErr) {
-		t.Errorf("expected no db file, stat err = %v", statErr)
-	}
-}
-
-// TestBootstrap_SHAMismatch covers the corrupted-mirror case: API +
-// asset reachable, but the sha256 of the downloaded bytes doesn't
-// match the sidecar. Must error AND must leave no partial file in the
-// cache (tempfile cleanup).
-func TestBootstrap_SHAMismatch(t *testing.T) {
-	clearBootstrapEnv(t)
-	rel := newFakeRelease(t, "v1.0.0", "fake-db-content")
-	fix := newFixtureServer(t, rel)
-	fix.corruptSHA.Store(true)
-	withAPIBase(t, fix.srv.URL)
-
-	cacheDir := t.TempDir()
-	if _, _, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir}); err == nil {
-		t.Fatalf("Bootstrap returned no error on sha256 mismatch")
-	}
-	if _, statErr := os.Stat(filepath.Join(cacheDir, dbAssetName)); !os.IsNotExist(statErr) {
-		t.Errorf("partial file left in cache after sha mismatch: stat err = %v", statErr)
-	}
-	// Tempfile pattern is dbAssetName+".tmp-*"; make sure none lingered.
-	entries, _ := os.ReadDir(cacheDir)
-	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), dbAssetName+".tmp-") {
-			t.Errorf("tempfile %q not cleaned up", e.Name())
-		}
-	}
-}
-
-// TestBootstrap_TagMatchSkipsAssetDownload covers the warm-cache path:
-// the cached tag matches the latest release, so Bootstrap must skip the
-// asset download entirely. The API call still happens (that's how we
-// learn the tag matches) — assertion is that dbCalls == 0.
-func TestBootstrap_TagMatchSkipsAssetDownload(t *testing.T) {
+// TestBootstrap_TagMatchZeroAPICalls is the headline zero-network
+// path for steady-state startup: cache exists, its sidecar tag equals
+// the binary's AppVersion → Bootstrap returns the cached path without
+// any HTTP traffic at all (PR #110 review item 1: must assert zero
+// API calls, not just zero asset downloads).
+func TestBootstrap_TagMatchZeroAPICalls(t *testing.T) {
 	clearBootstrapEnv(t)
 	rel := newFakeRelease(t, "v1.0.0", "fake-db-content")
 	fix := newFixtureServer(t, rel)
 	withAPIBase(t, fix.srv.URL)
 
 	cacheDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(cacheDir, dbAssetName), []byte("cached-bytes"), 0o644); err != nil {
-		t.Fatalf("seed cache: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cacheDir, tagSidecarName), []byte(rel.tag+"\n"), 0o644); err != nil {
-		t.Fatalf("seed tag: %v", err)
-	}
+	seedCache(t, cacheDir, "cached-bytes", "v1.0.0")
 
-	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.0.0",
+	})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
@@ -235,6 +248,9 @@ func TestBootstrap_TagMatchSkipsAssetDownload(t *testing.T) {
 	}
 	if path != filepath.Join(cacheDir, dbAssetName) {
 		t.Errorf("path = %q, want cached path", path)
+	}
+	if n := fix.apiCalls.Load(); n != 0 {
+		t.Errorf("API hit %d times on tag match, want 0 (fast-path must be zero-network)", n)
 	}
 	if n := fix.dbCalls.Load(); n != 0 {
 		t.Errorf("db asset hit %d times on tag match, want 0", n)
@@ -245,44 +261,47 @@ func TestBootstrap_TagMatchSkipsAssetDownload(t *testing.T) {
 	}
 }
 
-// TestBootstrap_StaleUpgrade covers path 3: cached tag != latest →
-// fetch new, atomic swap, upgraded=true, tag sidecar updated.
-func TestBootstrap_StaleUpgrade(t *testing.T) {
+// TestBootstrap_BinaryUpgradeSwapsDB is the version-bump path: the
+// binary was upgraded (AppVersion changed) so the cached sidecar
+// tag no longer matches. Bootstrap must fetch the new tag's release
+// and atomic-swap the DB, returning upgraded=true.
+func TestBootstrap_BinaryUpgradeSwapsDB(t *testing.T) {
 	clearBootstrapEnv(t)
-	rel := newFakeRelease(t, "v1.1.0", "new-content")
-	fix := newFixtureServer(t, rel)
+	relOld := newFakeRelease(t, "v1.0.0", "old-content")
+	relNew := newFakeRelease(t, "v1.1.0", "new-content")
+	fix := newFixtureServer(t, relOld, relNew)
 	withAPIBase(t, fix.srv.URL)
 
 	cacheDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(cacheDir, dbAssetName), []byte("old-bytes"), 0o644); err != nil {
-		t.Fatalf("seed cache: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cacheDir, tagSidecarName), []byte("v1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("seed tag: %v", err)
-	}
+	seedCache(t, cacheDir, "old-bytes", "v1.0.0")
 
-	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.1.0",
+	})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
 	if !upgraded {
-		t.Errorf("upgraded=false on stale upgrade, want true")
+		t.Errorf("upgraded=false on binary upgrade, want true")
 	}
 	got, _ := os.ReadFile(path)
-	if string(got) != string(rel.dbBody) {
-		t.Errorf("after upgrade body = %q, want %q", got, rel.dbBody)
+	if string(got) != string(relNew.dbBody) {
+		t.Errorf("after upgrade body = %q, want %q", got, relNew.dbBody)
 	}
 	tag, _ := os.ReadFile(filepath.Join(cacheDir, tagSidecarName))
-	if strings.TrimSpace(string(tag)) != rel.tag {
-		t.Errorf("tag sidecar = %q, want %q", tag, rel.tag)
+	if strings.TrimSpace(string(tag)) != relNew.tag {
+		t.Errorf("tag sidecar = %q, want %q", tag, relNew.tag)
 	}
 }
 
-// TestBootstrap_StaleNetworkErrorServesCache covers the failure-mode
-// row: stale cache + the API call fails → serve the stale cache, log a
-// WARN, return upgraded=false with no error so server startup doesn't
-// abort on a transient network blip.
-func TestBootstrap_StaleNetworkErrorServesCache(t *testing.T) {
+// TestBootstrap_VersionMismatchNetworkErrorFailsLoud covers the
+// failure-to-degrade case: cached sidecar disagrees with AppVersion
+// AND the API call fails. Previous iteration served the stale cache;
+// PR #110 review called that out as unsafe because the on-disk
+// schema/content doesn't match what the binary expects. Must error
+// out with hints at the three recovery paths.
+func TestBootstrap_VersionMismatchNetworkErrorFailsLoud(t *testing.T) {
 	clearBootstrapEnv(t)
 	rel := newFakeRelease(t, "v1.1.0", "new-content")
 	fix := newFixtureServer(t, rel)
@@ -290,66 +309,107 @@ func TestBootstrap_StaleNetworkErrorServesCache(t *testing.T) {
 	withAPIBase(t, fix.srv.URL)
 
 	cacheDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(cacheDir, dbAssetName), []byte("old-bytes"), 0o644); err != nil {
-		t.Fatalf("seed cache: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cacheDir, tagSidecarName), []byte("v1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("seed tag: %v", err)
-	}
+	seedCache(t, cacheDir, "old-bytes", "v1.0.0")
 
-	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
-	if err != nil {
-		t.Fatalf("Bootstrap returned err=%v on stale-cache+network-error, want nil (graceful degrade)", err)
+	_, _, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.1.0",
+	})
+	if err == nil {
+		t.Fatalf("Bootstrap returned nil err on version mismatch + network error, want loud failure")
 	}
-	if upgraded {
-		t.Errorf("upgraded=true on network error, want false")
-	}
-	got, _ := os.ReadFile(path)
-	if string(got) != "old-bytes" {
-		t.Errorf("cache was overwritten on network error: %q", got)
+	// Error message must surface the three recovery hints the PR
+	// review called for.
+	msg := err.Error()
+	for _, want := range []string{`"v1.0.0"`, `"v1.1.0"`, "-db", EnvOffline} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing hint %q", msg, want)
+		}
 	}
 }
 
-// TestBootstrap_NoAutoUpgradeSkipsNetwork covers the env-var escape
-// hatch: DEADZONE_DB_NO_AUTO_UPGRADE=1 with a cached file → skip the
-// API call entirely and serve the cache.
-func TestBootstrap_NoAutoUpgradeSkipsNetwork(t *testing.T) {
+// TestBootstrap_OfflineNoCache covers DEADZONE_DB_OFFLINE=1 with
+// nothing cached: must error, mention the env var, leave no partial.
+func TestBootstrap_OfflineNoCache(t *testing.T) {
 	clearBootstrapEnv(t)
-	t.Setenv(EnvNoAutoUpgrade, "1")
-	rel := newFakeRelease(t, "v1.1.0", "new-content")
+	t.Setenv(EnvOffline, "1")
+
+	cacheDir := t.TempDir()
+	_, _, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.0.0",
+	})
+	if err == nil {
+		t.Fatal("Bootstrap returned no error on offline + no cache")
+	}
+	if !strings.Contains(err.Error(), EnvOffline) {
+		t.Errorf("error %q does not mention %s", err, EnvOffline)
+	}
+	if _, statErr := os.Stat(filepath.Join(cacheDir, dbAssetName)); !os.IsNotExist(statErr) {
+		t.Errorf("expected no db file, stat err = %v", statErr)
+	}
+}
+
+// TestBootstrap_OfflineMismatchedCacheFails covers the "offline +
+// cached DB is wrong version for this binary" path: even though the
+// DB exists, we can't verify it matches the binary's AppVersion and
+// we're forbidden from asking the network, so we must fail. The
+// cache's version is already known to differ (otherwise we'd have
+// hit the zero-network fast path before the offline check).
+func TestBootstrap_OfflineMismatchedCacheFails(t *testing.T) {
+	clearBootstrapEnv(t)
+	t.Setenv(EnvOffline, "1")
+
+	cacheDir := t.TempDir()
+	seedCache(t, cacheDir, "old-bytes", "v1.0.0")
+
+	_, _, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.1.0",
+	})
+	if err == nil {
+		t.Fatal("Bootstrap returned nil err on offline + mismatched cache")
+	}
+	msg := err.Error()
+	for _, want := range []string{EnvOffline, "v1.0.0", "v1.1.0"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing hint %q", msg, want)
+		}
+	}
+}
+
+// TestBootstrap_SHAMismatch covers the corrupted-mirror case: API +
+// asset reachable, but the sha256 of the downloaded bytes doesn't
+// match the sidecar. Must error AND must leave no partial file.
+func TestBootstrap_SHAMismatch(t *testing.T) {
+	clearBootstrapEnv(t)
+	rel := newFakeRelease(t, "v1.0.0", "fake-db-content")
 	fix := newFixtureServer(t, rel)
+	fix.corruptSHA.Store(true)
 	withAPIBase(t, fix.srv.URL)
 
 	cacheDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(cacheDir, dbAssetName), []byte("cached-bytes"), 0o644); err != nil {
-		t.Fatalf("seed cache: %v", err)
+	if _, _, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.0.0",
+	}); err == nil {
+		t.Fatalf("Bootstrap returned no error on sha256 mismatch")
 	}
-	if err := os.WriteFile(filepath.Join(cacheDir, tagSidecarName), []byte("v0.1.0\n"), 0o644); err != nil {
-		t.Fatalf("seed tag: %v", err)
+	if _, statErr := os.Stat(filepath.Join(cacheDir, dbAssetName)); !os.IsNotExist(statErr) {
+		t.Errorf("partial file left in cache after sha mismatch: stat err = %v", statErr)
 	}
-
-	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	if upgraded {
-		t.Errorf("upgraded=true with NO_AUTO_UPGRADE, want false")
-	}
-	if n := fix.apiCalls.Load(); n != 0 {
-		t.Errorf("API hit %d times with NO_AUTO_UPGRADE, want 0", n)
-	}
-	if n := fix.dbCalls.Load(); n != 0 {
-		t.Errorf("db asset hit %d times with NO_AUTO_UPGRADE, want 0", n)
-	}
-	got, _ := os.ReadFile(path)
-	if string(got) != "cached-bytes" {
-		t.Errorf("cache body was modified: %q", got)
+	entries, _ := os.ReadDir(cacheDir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), dbAssetName+".tmp-") {
+			t.Errorf("tempfile %q not cleaned up", e.Name())
+		}
 	}
 }
 
 // TestBootstrap_ForceRefetches covers fetch-db --force: cached tag
-// matches latest, but Force=true must re-download anyway. The asset
-// counter goes from 0 (the tag-match short-circuit) to 1.
+// matches AppVersion, but Force=true must re-download anyway to
+// recover from local corruption. upgraded=true because the cache
+// existed and was replaced.
 func TestBootstrap_ForceRefetches(t *testing.T) {
 	clearBootstrapEnv(t)
 	rel := newFakeRelease(t, "v1.0.0", "fresh-content")
@@ -357,22 +417,18 @@ func TestBootstrap_ForceRefetches(t *testing.T) {
 	withAPIBase(t, fix.srv.URL)
 
 	cacheDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(cacheDir, dbAssetName), []byte("cached-bytes"), 0o644); err != nil {
-		t.Fatalf("seed cache: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cacheDir, tagSidecarName), []byte(rel.tag+"\n"), 0o644); err != nil {
-		t.Fatalf("seed tag: %v", err)
-	}
+	seedCache(t, cacheDir, "cached-bytes", "v1.0.0")
 
 	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
-		CacheDir: cacheDir,
-		Force:    true,
+		CacheDir:   cacheDir,
+		AppVersion: "v1.0.0",
+		Force:      true,
 	})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
 	if !upgraded {
-		t.Errorf("upgraded=false with Force, want true (cache existed and was replaced)")
+		t.Errorf("upgraded=false with Force, want true")
 	}
 	if n := fix.dbCalls.Load(); n != 1 {
 		t.Errorf("db asset hit %d times with Force, want 1", n)
@@ -383,11 +439,114 @@ func TestBootstrap_ForceRefetches(t *testing.T) {
 	}
 }
 
+// TestBootstrap_DevFallsBackToLatest covers the dev-binary path:
+// AppVersion="dev" triggers the /releases/latest fallback so local
+// iteration stays ergonomic. fetchReleaseByTag must not be called.
+func TestBootstrap_DevFallsBackToLatest(t *testing.T) {
+	clearBootstrapEnv(t)
+	rel := newFakeRelease(t, "v1.0.0", "latest-content")
+	fix := newFixtureServer(t, rel)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	path, _, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "dev",
+	})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != string(rel.dbBody) {
+		t.Errorf("dev fallback body = %q, want %q", got, rel.dbBody)
+	}
+	tag, _ := os.ReadFile(filepath.Join(cacheDir, tagSidecarName))
+	if strings.TrimSpace(string(tag)) != rel.tag {
+		t.Errorf("tag sidecar = %q, want %q", tag, rel.tag)
+	}
+}
+
+// TestBootstrap_UnknownTagGives404Error covers the tag-404 path: the
+// binary was built for a version that doesn't have a published DB
+// yet. Error must wrap ErrNoReleaseForVersion and contain the
+// actionable hint about -db / downgrading.
+func TestBootstrap_UnknownTagGives404Error(t *testing.T) {
+	clearBootstrapEnv(t)
+	rel := newFakeRelease(t, "v1.0.0", "content")
+	fix := newFixtureServer(t, rel)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	_, _, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v99.0.0",
+	})
+	if err == nil {
+		t.Fatal("Bootstrap returned no error on unknown tag")
+	}
+	if !errors.Is(err, ErrNoReleaseForVersion) {
+		t.Errorf("error %q does not wrap ErrNoReleaseForVersion", err)
+	}
+	if !strings.Contains(err.Error(), "-db") {
+		t.Errorf("error %q missing -db hint", err)
+	}
+}
+
+// TestBootstrap_MissingDBAsset covers a release that exists but was
+// published without the deadzone.db asset. The error must name the
+// missing asset so a publisher-side bug is obvious on first fetch
+// instead of silently serving nothing.
+func TestBootstrap_MissingDBAsset(t *testing.T) {
+	clearBootstrapEnv(t)
+	rel := newFakeRelease(t, "v1.0.0", "unused")
+	fix := newFixtureServer(t, rel)
+	fix.missingDB.Store(true)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	_, _, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.0.0",
+	})
+	if err == nil {
+		t.Fatal("Bootstrap returned no error with missing deadzone.db asset")
+	}
+	if !strings.Contains(err.Error(), dbAssetName) {
+		t.Errorf("error %q does not name the missing %s asset", err, dbAssetName)
+	}
+}
+
+// TestIsDevVersion pins the dev-detection heuristic. The production
+// behavior hinges on this: a false negative (tagged build classified
+// as dev) is harmless (/latest fallback still works); a false
+// positive (released build classified as dev) silently drifts DB
+// choice away from the pinned version.
+func TestIsDevVersion(t *testing.T) {
+	tests := []struct {
+		v    string
+		want bool
+	}{
+		{"", true},
+		{"dev", true},
+		{"v0.1.0", false},
+		{"v1.0.0", false},
+		{"v0.1.0-rc1", false}, // legitimate pre-release tag
+		{"v0.1.0-dirty", true},
+		{"v0.1.0-2-g1234567", true},
+		{"v0.1.0-2-g1234567-dirty", true},
+		{"v0.1.0-12-gabcdef0", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.v, func(t *testing.T) {
+			if got := isDevVersion(tc.v); got != tc.want {
+				t.Errorf("isDevVersion(%q) = %v, want %v", tc.v, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestDefaultCacheDir_HonorsEnv pins the env-var override at the head
-// of the resolution chain. Platform-specific defaults are deliberately
-// left untested at the unit level; covering them well requires
-// per-OS test fixtures and the production behavior is exercised by
-// integration runs.
+// of the resolution chain.
 func TestDefaultCacheDir_HonorsEnv(t *testing.T) {
 	t.Setenv(EnvCacheDir, "/tmp/deadzone-test-cache")
 	if got := DefaultCacheDir(); got != "/tmp/deadzone-test-cache" {

--- a/internal/db/bootstrap_test.go
+++ b/internal/db/bootstrap_test.go
@@ -1,0 +1,396 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// dbBootstrapEnv lists the env vars Bootstrap reads. Every test
+// neutralizes them via t.Setenv so a developer's local
+// DEADZONE_DB_CACHE / DEADZONE_DB_OFFLINE doesn't bleed in.
+var dbBootstrapEnv = []string{EnvCacheDir, EnvOffline, EnvNoAutoUpgrade}
+
+func clearBootstrapEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range dbBootstrapEnv {
+		t.Setenv(k, "")
+	}
+}
+
+// fakeRelease bundles the bytes a httptest fixture needs to serve a
+// single fake release: the DB asset payload, its sha256 hex, and the
+// tag string the API endpoint reports.
+type fakeRelease struct {
+	tag    string
+	dbBody []byte
+	dbHash string
+}
+
+func newFakeRelease(t *testing.T, tag, content string) fakeRelease {
+	t.Helper()
+	body := []byte(content)
+	sum := sha256.Sum256(body)
+	return fakeRelease{tag: tag, dbBody: body, dbHash: hex.EncodeToString(sum[:])}
+}
+
+// fixtureServer wires together the API endpoint and the asset endpoints
+// behind a single httptest server so the fake "browser_download_url"
+// values can point back at the same host. requests counts every hit so
+// tests can assert "zero asset downloads" precisely.
+type fixtureServer struct {
+	srv         *httptest.Server
+	rel         fakeRelease
+	apiCalls    atomic.Int32
+	dbCalls     atomic.Int32
+	sha256Calls atomic.Int32
+	failAPI     atomic.Bool // when true, /repos/.../latest returns 500
+	corruptDB   atomic.Bool // when true, dbBody comes back with a single byte flipped
+	corruptSHA  atomic.Bool // when true, sha256 comes back as zeroes (mismatch)
+	missingDB   atomic.Bool // when true, the JSON omits the deadzone.db asset
+}
+
+func newFixtureServer(t *testing.T, rel fakeRelease) *fixtureServer {
+	t.Helper()
+	fs := &fixtureServer{rel: rel}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/laradji/deadzone/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		fs.apiCalls.Add(1)
+		if fs.failAPI.Load() {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		assets := []map[string]string{
+			{"name": sha256AssetName, "browser_download_url": fs.srv.URL + "/dl/" + sha256AssetName},
+		}
+		if !fs.missingDB.Load() {
+			assets = append(assets, map[string]string{
+				"name":                 dbAssetName,
+				"browser_download_url": fs.srv.URL + "/dl/" + dbAssetName,
+			})
+		}
+		body := map[string]any{
+			"tag_name": fs.rel.tag,
+			"assets":   assets,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	})
+	mux.HandleFunc("/dl/"+dbAssetName, func(w http.ResponseWriter, r *http.Request) {
+		fs.dbCalls.Add(1)
+		if fs.corruptDB.Load() {
+			b := append([]byte(nil), fs.rel.dbBody...)
+			if len(b) > 0 {
+				b[0] ^= 0xff
+			}
+			_, _ = w.Write(b)
+			return
+		}
+		_, _ = w.Write(fs.rel.dbBody)
+	})
+	mux.HandleFunc("/dl/"+sha256AssetName, func(w http.ResponseWriter, r *http.Request) {
+		fs.sha256Calls.Add(1)
+		hash := fs.rel.dbHash
+		if fs.corruptSHA.Load() {
+			hash = strings.Repeat("0", 64)
+		}
+		fmt.Fprintf(w, "%s  %s\n", hash, dbAssetName)
+	})
+	fs.srv = httptest.NewServer(mux)
+	t.Cleanup(fs.srv.Close)
+	return fs
+}
+
+// withAPIBase swaps the package-level releasesAPIBase for the duration
+// of the test. The defer restores the production value so a failing
+// test can't poison sibling tests in the same binary.
+func withAPIBase(t *testing.T, base string) {
+	t.Helper()
+	orig := releasesAPIBase
+	releasesAPIBase = base
+	t.Cleanup(func() { releasesAPIBase = orig })
+}
+
+// TestBootstrap_FreshCache covers the first-fetch happy path: empty
+// cache + reachable network → DB lands in cache, sha256 verifies, tag
+// sidecar is written with the release tag, upgraded=false because no
+// previous file existed.
+func TestBootstrap_FreshCache(t *testing.T) {
+	clearBootstrapEnv(t)
+	rel := newFakeRelease(t, "v1.0.0", "fake-db-content-v1")
+	fix := newFixtureServer(t, rel)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if upgraded {
+		t.Errorf("upgraded=true on first fetch, want false")
+	}
+	if path != filepath.Join(cacheDir, dbAssetName) {
+		t.Errorf("path = %q, want %q", path, filepath.Join(cacheDir, dbAssetName))
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read installed db: %v", err)
+	}
+	if string(got) != string(rel.dbBody) {
+		t.Errorf("installed body = %q, want %q", got, rel.dbBody)
+	}
+	tag, err := os.ReadFile(filepath.Join(cacheDir, tagSidecarName))
+	if err != nil {
+		t.Fatalf("read tag sidecar: %v", err)
+	}
+	if strings.TrimSpace(string(tag)) != rel.tag {
+		t.Errorf("tag sidecar = %q, want %q", tag, rel.tag)
+	}
+	if n := fix.dbCalls.Load(); n != 1 {
+		t.Errorf("db asset hit %d times, want 1", n)
+	}
+}
+
+// TestBootstrap_OfflineNoCache covers DEADZONE_DB_OFFLINE=1 with
+// nothing cached: must error and must not leave a partial file. The
+// error message must mention the env var so an offline operator knows
+// the escape hatch they tripped.
+func TestBootstrap_OfflineNoCache(t *testing.T) {
+	clearBootstrapEnv(t)
+	t.Setenv(EnvOffline, "1")
+
+	cacheDir := t.TempDir()
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
+	if err == nil {
+		t.Fatalf("Bootstrap returned no error; got path=%q upgraded=%v", path, upgraded)
+	}
+	if !strings.Contains(err.Error(), EnvOffline) {
+		t.Errorf("error %q does not mention %s", err, EnvOffline)
+	}
+	if _, statErr := os.Stat(filepath.Join(cacheDir, dbAssetName)); !os.IsNotExist(statErr) {
+		t.Errorf("expected no db file, stat err = %v", statErr)
+	}
+}
+
+// TestBootstrap_SHAMismatch covers the corrupted-mirror case: API +
+// asset reachable, but the sha256 of the downloaded bytes doesn't
+// match the sidecar. Must error AND must leave no partial file in the
+// cache (tempfile cleanup).
+func TestBootstrap_SHAMismatch(t *testing.T) {
+	clearBootstrapEnv(t)
+	rel := newFakeRelease(t, "v1.0.0", "fake-db-content")
+	fix := newFixtureServer(t, rel)
+	fix.corruptSHA.Store(true)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	if _, _, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir}); err == nil {
+		t.Fatalf("Bootstrap returned no error on sha256 mismatch")
+	}
+	if _, statErr := os.Stat(filepath.Join(cacheDir, dbAssetName)); !os.IsNotExist(statErr) {
+		t.Errorf("partial file left in cache after sha mismatch: stat err = %v", statErr)
+	}
+	// Tempfile pattern is dbAssetName+".tmp-*"; make sure none lingered.
+	entries, _ := os.ReadDir(cacheDir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), dbAssetName+".tmp-") {
+			t.Errorf("tempfile %q not cleaned up", e.Name())
+		}
+	}
+}
+
+// TestBootstrap_TagMatchSkipsAssetDownload covers the warm-cache path:
+// the cached tag matches the latest release, so Bootstrap must skip the
+// asset download entirely. The API call still happens (that's how we
+// learn the tag matches) — assertion is that dbCalls == 0.
+func TestBootstrap_TagMatchSkipsAssetDownload(t *testing.T) {
+	clearBootstrapEnv(t)
+	rel := newFakeRelease(t, "v1.0.0", "fake-db-content")
+	fix := newFixtureServer(t, rel)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cacheDir, dbAssetName), []byte("cached-bytes"), 0o644); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, tagSidecarName), []byte(rel.tag+"\n"), 0o644); err != nil {
+		t.Fatalf("seed tag: %v", err)
+	}
+
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if upgraded {
+		t.Errorf("upgraded=true on tag match, want false")
+	}
+	if path != filepath.Join(cacheDir, dbAssetName) {
+		t.Errorf("path = %q, want cached path", path)
+	}
+	if n := fix.dbCalls.Load(); n != 0 {
+		t.Errorf("db asset hit %d times on tag match, want 0", n)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "cached-bytes" {
+		t.Errorf("cached body was overwritten on tag match: %q", got)
+	}
+}
+
+// TestBootstrap_StaleUpgrade covers path 3: cached tag != latest →
+// fetch new, atomic swap, upgraded=true, tag sidecar updated.
+func TestBootstrap_StaleUpgrade(t *testing.T) {
+	clearBootstrapEnv(t)
+	rel := newFakeRelease(t, "v1.1.0", "new-content")
+	fix := newFixtureServer(t, rel)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cacheDir, dbAssetName), []byte("old-bytes"), 0o644); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, tagSidecarName), []byte("v1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("seed tag: %v", err)
+	}
+
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if !upgraded {
+		t.Errorf("upgraded=false on stale upgrade, want true")
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != string(rel.dbBody) {
+		t.Errorf("after upgrade body = %q, want %q", got, rel.dbBody)
+	}
+	tag, _ := os.ReadFile(filepath.Join(cacheDir, tagSidecarName))
+	if strings.TrimSpace(string(tag)) != rel.tag {
+		t.Errorf("tag sidecar = %q, want %q", tag, rel.tag)
+	}
+}
+
+// TestBootstrap_StaleNetworkErrorServesCache covers the failure-mode
+// row: stale cache + the API call fails → serve the stale cache, log a
+// WARN, return upgraded=false with no error so server startup doesn't
+// abort on a transient network blip.
+func TestBootstrap_StaleNetworkErrorServesCache(t *testing.T) {
+	clearBootstrapEnv(t)
+	rel := newFakeRelease(t, "v1.1.0", "new-content")
+	fix := newFixtureServer(t, rel)
+	fix.failAPI.Store(true)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cacheDir, dbAssetName), []byte("old-bytes"), 0o644); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, tagSidecarName), []byte("v1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("seed tag: %v", err)
+	}
+
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
+	if err != nil {
+		t.Fatalf("Bootstrap returned err=%v on stale-cache+network-error, want nil (graceful degrade)", err)
+	}
+	if upgraded {
+		t.Errorf("upgraded=true on network error, want false")
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "old-bytes" {
+		t.Errorf("cache was overwritten on network error: %q", got)
+	}
+}
+
+// TestBootstrap_NoAutoUpgradeSkipsNetwork covers the env-var escape
+// hatch: DEADZONE_DB_NO_AUTO_UPGRADE=1 with a cached file → skip the
+// API call entirely and serve the cache.
+func TestBootstrap_NoAutoUpgradeSkipsNetwork(t *testing.T) {
+	clearBootstrapEnv(t)
+	t.Setenv(EnvNoAutoUpgrade, "1")
+	rel := newFakeRelease(t, "v1.1.0", "new-content")
+	fix := newFixtureServer(t, rel)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cacheDir, dbAssetName), []byte("cached-bytes"), 0o644); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, tagSidecarName), []byte("v0.1.0\n"), 0o644); err != nil {
+		t.Fatalf("seed tag: %v", err)
+	}
+
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{CacheDir: cacheDir})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if upgraded {
+		t.Errorf("upgraded=true with NO_AUTO_UPGRADE, want false")
+	}
+	if n := fix.apiCalls.Load(); n != 0 {
+		t.Errorf("API hit %d times with NO_AUTO_UPGRADE, want 0", n)
+	}
+	if n := fix.dbCalls.Load(); n != 0 {
+		t.Errorf("db asset hit %d times with NO_AUTO_UPGRADE, want 0", n)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "cached-bytes" {
+		t.Errorf("cache body was modified: %q", got)
+	}
+}
+
+// TestBootstrap_ForceRefetches covers fetch-db --force: cached tag
+// matches latest, but Force=true must re-download anyway. The asset
+// counter goes from 0 (the tag-match short-circuit) to 1.
+func TestBootstrap_ForceRefetches(t *testing.T) {
+	clearBootstrapEnv(t)
+	rel := newFakeRelease(t, "v1.0.0", "fresh-content")
+	fix := newFixtureServer(t, rel)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cacheDir, dbAssetName), []byte("cached-bytes"), 0o644); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, tagSidecarName), []byte(rel.tag+"\n"), 0o644); err != nil {
+		t.Fatalf("seed tag: %v", err)
+	}
+
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir: cacheDir,
+		Force:    true,
+	})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if !upgraded {
+		t.Errorf("upgraded=false with Force, want true (cache existed and was replaced)")
+	}
+	if n := fix.dbCalls.Load(); n != 1 {
+		t.Errorf("db asset hit %d times with Force, want 1", n)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != string(rel.dbBody) {
+		t.Errorf("after force body = %q, want %q", got, rel.dbBody)
+	}
+}
+
+// TestDefaultCacheDir_HonorsEnv pins the env-var override at the head
+// of the resolution chain. Platform-specific defaults are deliberately
+// left untested at the unit level; covering them well requires
+// per-OS test fixtures and the production behavior is exercised by
+// integration runs.
+func TestDefaultCacheDir_HonorsEnv(t *testing.T) {
+	t.Setenv(EnvCacheDir, "/tmp/deadzone-test-cache")
+	if got := DefaultCacheDir(); got != "/tmp/deadzone-test-cache" {
+		t.Errorf("DefaultCacheDir = %q, want /tmp/deadzone-test-cache", got)
+	}
+}

--- a/justfile
+++ b/justfile
@@ -131,6 +131,12 @@ dbrelease tag:
     CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
         mise exec -- go run -tags ORT ./cmd/deadzone dbrelease -db deadzone.db -tag {{tag}}
 
+# Download / refresh the cached deadzone.db from the latest GH Release (#108).
+# Set force=true to re-fetch even when the cached tag matches the latest release.
+fetch-db force="":
+    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+        mise exec -- go run -tags ORT ./cmd/deadzone fetch-db {{ if force != "" { "-force" } else { "" } }}
+
 # Remove the built binary, per-lib artifact folders, and the local DB files (preserves artifacts/manifest.yaml)
 clean:
     rm -f deadzone


### PR DESCRIPTION
## Summary

- Add `db.Bootstrap` flow that auto-fetches `deadzone.db` from the latest GitHub Release on first run, caches it in the platform data dir (`~/Library/Application Support/deadzone`, `$XDG_DATA_HOME/deadzone`, `%LOCALAPPDATA%\deadzone`), and auto-upgrades it on subsequent launches when a newer release tag is detected
- `deadzone server` now defaults to auto-fetch mode when `-db` is unset; explicit `-db <path>` bypasses the fetch entirely
- New `deadzone fetch-db` subcommand for explicit cache-warmup, force-refresh, or scripted/CI setups
- SHA256 verification of downloaded assets with atomic temp-file swap
- Env-var escape hatches: `DEADZONE_DB_CACHE`, `DEADZONE_DB_OFFLINE=1`, `DEADZONE_DB_NO_AUTO_UPGRADE=1`
- Comprehensive test suite covering all matrix states (cached/uncached × offline/online × force/no-force, sha256 mismatch, network degradation)

## Motivation

Previously, users had to manually download `deadzone.db` from the GitHub Release page and pass `-db` to the server. This made first-run setup a multi-step process and left users on stale data unless they manually re-fetched. Now `deadzone server` just works out of the box.

## Test plan

- [ ] `go test ./internal/db/...` — bootstrap test suite (httptest server, all matrix states)
- [ ] `deadzone server` with no `-db` flag — verify first-run fetch and cache placement
- [ ] `deadzone server` again — verify tag-match short-circuit (no re-download)
- [ ] `deadzone fetch-db -force` — verify force re-fetch
- [ ] `DEADZONE_DB_OFFLINE=1 deadzone server` with cached DB — verify no network call
- [ ] `DEADZONE_DB_OFFLINE=1 deadzone server` with no cache — verify loud failure

<!-- emdash-issue-footer:start -->
Fixes #108
<!-- emdash-issue-footer:end -->