### PR TITLE
feat: add GitHub issue templates for library submissions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question about using Deadzone
+    url: https://github.com/laradji/deadzone/discussions
+    about: Use Discussions for how-to questions, not Issues.

--- a/.github/ISSUE_TEMPLATE/library-add.yml
+++ b/.github/ISSUE_TEMPLATE/library-add.yml
@@ -1,0 +1,47 @@
+name: Add a library
+description: Request indexing a new library in Deadzone
+title: "registry: add /<org>/<project>"
+body:
+  - type: input
+    id: lib_id
+    attributes:
+      label: lib_id
+      description: Canonical /org/project form (matches the lib_id column in the DB).
+      placeholder: /fastapi/fastapi
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Source kind
+      description: See README → "Configuring which libraries to scrape" for the full contract.
+      options:
+        - github-md (raw markdown URLs on GitHub — fast path, no LLM)
+        - github-rst (raw reStructuredText URLs — fast path, no LLM)
+        - scrape-via-agent (HTML via OpenAI-compatible LLM endpoint — slow, experimental)
+    validations:
+      required: true
+  - type: textarea
+    id: urls
+    attributes:
+      label: URLs to index
+      description: One URL per line. For github-md / github-rst these should be raw.githubusercontent.com URLs. For scrape-via-agent any HTML URL works.
+      placeholder: |
+        https://raw.githubusercontent.com/fastapi/fastapi/master/docs/en/docs/tutorial/first-steps.md
+        https://raw.githubusercontent.com/fastapi/fastapi/master/docs/en/docs/tutorial/path-params.md
+      render: text
+    validations:
+      required: true
+  - type: input
+    id: ref
+    attributes:
+      label: Upstream ref (optional)
+      description: Git tag or SHA to pin URLs to (requires the {ref} placeholder in URLs — see #103). Leave blank to pin to the default branch (non-reproducible).
+      placeholder: v1.14.6
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why this library
+      description: What's the use case? Who benefits from having it indexed?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/library-refresh.yml
+++ b/.github/ISSUE_TEMPLATE/library-refresh.yml
@@ -1,0 +1,25 @@
+name: Refresh a library
+description: Ask for an existing indexed library to be re-scraped (e.g. upstream docs changed)
+title: "registry: refresh /<org>/<project>"
+body:
+  - type: input
+    id: lib_id
+    attributes:
+      label: lib_id
+      description: The existing lib_id to refresh. Must already be in libraries_sources.yaml.
+      placeholder: /hashicorp/terraform
+    validations:
+      required: true
+  - type: input
+    id: new_ref
+    attributes:
+      label: New upstream ref (optional)
+      description: If the refresh is to bump a pinned ref (see #103), give the new tag or SHA. Leave blank for a straight re-scrape of the current ref.
+      placeholder: v1.15.0
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason
+      description: What changed upstream? New docs section, bug fix in existing doc, stale content, etc.
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -439,6 +439,10 @@ Every subcommand emits structured JSON logs to **stderr** using `log/slog`. Stdo
 
 Tracked on the [GitHub issues board](https://github.com/laradji/deadzone/issues). Open issues are scoped via the `mvp`, `feature`, `research`, and `post-mvp` labels.
 
+## Contributing
+
+To request a new library or refresh an existing one, use the [New issue](https://github.com/laradji/deadzone/issues/new/choose) page and pick the matching form.
+
 ## License
 
 Deadzone is licensed under the [Apache License, Version 2.0](LICENSE). See [`NOTICE`](NOTICE) for the third-party attributions that ship with the binary.


### PR DESCRIPTION
## Summary

- Add issue template chooser config (`.github/ISSUE_TEMPLATE/config.yml`) with a link to discussions
- Add structured form template for new library addition requests (`library-add.yml`)
- Add template for requesting a library data refresh (`library-refresh.yml`)
- Update README with a link to submit new libraries via issue templates

These templates standardize how contributors request new library additions or data refreshes, making triage easier as the project grows.

<!-- emdash-issue-footer:start -->
Fixes #104
<!-- emdash-issue-footer:end -->