### PR TITLE
feat(scraper): add {ref} pinning for reproducible library scrapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,14 @@ libraries:
       - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/main/README.md
       - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/main/docs/quick_start.md
 
+  # Single-version lib pinned to a git tag for reproducible scrapes —
+  # `{ref}` in any URL is substituted with the lib's `ref:` value.
+  - lib_id: /python/cpython
+    kind: github-rst
+    ref: v3.13.1
+    urls:
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/os.rst
+
   # Multi-version lib — `versions` expands `{version}` in each URL,
   # producing one effective lib_id per version (`/facebook/react/v18`,
   # `/facebook/react/v19`, …) — matches Context7's `/org/project/version`
@@ -292,14 +300,25 @@ libraries:
     urls:
       - https://raw.githubusercontent.com/facebook/react/{version}/README.md
       - https://raw.githubusercontent.com/facebook/react/{version}/docs/getting-started.md
+
+  # Multi-version lib with a per-version git pin (map shorthand) — each
+  # version gets its own `ref:` substituted into URLs alongside `{version}`.
+  - lib_id: /hashicorp/terraform
+    kind: github-md
+    versions:
+      v1.14: { ref: v1.14.6 }
+      v1.13: { ref: v1.13.5 }
+    urls:
+      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/intro/index.mdx
 ```
 
 | Field | Required | Purpose |
 |---|---|---|
 | `lib_id` | yes | canonical `/org/project` identifier (matches `db.docs.lib_id`) |
 | `kind` | yes | source kind discriminator — `github-md` for raw markdown, `github-rst` for raw reStructuredText (cpython, Django, NumPy, …), `scrape-via-agent` for HTML/text via an LLM (see [Scraping non-trivial doc sources](#scraping-non-trivial-doc-sources-scrape-via-agent)) |
-| `urls` | yes | list of doc URLs (with optional `{version}` placeholder) |
-| `versions` | no | list of version tags; expands `{version}` in `urls` and produces one effective `lib_id` per version |
+| `urls` | yes | list of doc URLs (with optional `{version}` and/or `{ref}` placeholders) |
+| `versions` | no | list `[v1, v2]` or map `{v1: {ref: tag1}, …}` of version tags; expands `{version}` in `urls` and produces one effective `lib_id` per version. The map form pins each version to its own git ref. |
+| `ref` | no | git tag or commit SHA substituted into `{ref}` in `urls` (#103). For multi-version libs, a per-version ref in the `versions:` map overrides this top-level ref. URLs that don't contain `{ref}` are left untouched, so a lib can opt into pinning incrementally. |
 
 Adding a new library means adding a YAML entry — no Go editing, no recompile.
 

--- a/cmd/deadzone/scrape.go
+++ b/cmd/deadzone/scrape.go
@@ -349,6 +349,7 @@ func scrapeLibToArtifact(
 		"base_lib_id", src.BaseLibID,
 		"version", src.Version,
 		"kind", src.Kind,
+		"ref", src.Ref,
 		"url_count", len(src.URLs),
 		"artifact_path", artifactPath,
 	)
@@ -528,6 +529,7 @@ func scrapeLibToArtifact(
 			Model: e.ModelVersion(),
 			Dim:   e.Dim(),
 		},
+		Ref:       src.Ref,
 		CreatedAt: now,
 		UpdatedAt: now,
 		URLCount:  len(src.URLs),
@@ -542,6 +544,7 @@ func scrapeLibToArtifact(
 
 	slog.Info("scraper.lib_done",
 		"lib_id", src.LibID,
+		"ref", src.Ref,
 		"docs_total", docsTotal,
 		"duration_ms", time.Since(libStart).Milliseconds(),
 		"artifact_path", artifactPath,

--- a/docs/research/ingestion-architecture.md
+++ b/docs/research/ingestion-architecture.md
@@ -228,9 +228,14 @@ No metadata. No lifecycle. No sharing model. **Just enough to lift Deadzone out 
 - **Migration cost is bounded** at the current corpus size. The minute the corpus grows, the cost of switching schemas grows with it — but at 1-10 libs, conversion is a script.
 - **Composable with the other decisions**: the 4-field schema is exactly what `deadzone scrape -lib X` and `deadzone scrape -config Y` need to do per-lib filtering and per-lib artifact production.
 
+### Reproducibility hook (#103)
+
+The schema gained a fifth optional field, `ref:`, in #103: a git tag or commit SHA that gets substituted into the literal `{ref}` placeholder in URLs at config-resolve time. Without it, every URL points at an unpinned `main`/`master` branch and the resulting `deadzone.db` drifts silently between rebuilds even when the registry and code haven't changed. With it, two operators on the same registry pin produce byte-identical artifacts. Per-version refs (map shorthand for `versions:`) keep multi-version libs reproducible too. The field is opt-in per lib so the schema stays minimal — URLs without `{ref}` are passed through unchanged. The resolved ref is recorded in each artifact's `state.yaml` sidecar so an operator can see what was actually scraped.
+
 ### Trace
 
 - Designed in #51, merged in #54
+- Reproducibility pin added in #103
 - The long-term registry research lives in #52 (open, post-mvp)
 
 ### Holds at scale

--- a/internal/packs/state.go
+++ b/internal/packs/state.go
@@ -43,10 +43,15 @@ type StateFile struct {
 	LibID         string        `yaml:"lib_id"`
 	SchemaVersion int           `yaml:"schema_version"`
 	Embedder      EmbedderState `yaml:"embedder"`
-	CreatedAt     time.Time     `yaml:"created_at"`
-	UpdatedAt     time.Time     `yaml:"updated_at"`
-	URLCount      int           `yaml:"url_count"`
-	DocCount      int           `yaml:"doc_count"`
+	// Ref is the resolved upstream git tag or commit SHA the URLs were
+	// pinned to via the registry's `ref:` field (#103). Empty for libs
+	// that have not opted into pinning yet — back-compat with pre-#103
+	// state files.
+	Ref       string    `yaml:"ref,omitempty"`
+	CreatedAt time.Time `yaml:"created_at"`
+	UpdatedAt time.Time `yaml:"updated_at"`
+	URLCount  int       `yaml:"url_count"`
+	DocCount  int       `yaml:"doc_count"`
 }
 
 // EmbedderState mirrors the embedder identity triple the scraper also

--- a/internal/packs/state_test.go
+++ b/internal/packs/state_test.go
@@ -28,6 +28,7 @@ func TestStateFile_RoundTrip(t *testing.T) {
 			Model: "nomic-ai/nomic-embed-text-v1.5",
 			Dim:   768,
 		},
+		Ref:       "v1.2.3",
 		CreatedAt: created,
 		UpdatedAt: updated,
 		URLCount:  6,
@@ -61,6 +62,9 @@ func TestStateFile_RoundTrip(t *testing.T) {
 	}
 	if got.DocCount != want.DocCount {
 		t.Errorf("DocCount = %d, want %d", got.DocCount, want.DocCount)
+	}
+	if got.Ref != want.Ref {
+		t.Errorf("Ref = %q, want %q", got.Ref, want.Ref)
 	}
 }
 

--- a/internal/scraper/config.go
+++ b/internal/scraper/config.go
@@ -14,6 +14,12 @@ import (
 // (single-version entries, version strings themselves).
 const versionPlaceholder = "{version}"
 
+// refPlaceholder is the literal token substituted with the effective git
+// ref (top-level Source.Ref or per-version VersionEntry.Ref) at expand
+// time. URLs that do not contain the token are left untouched, so a lib
+// can opt into ref pinning incrementally. See #103.
+const refPlaceholder = "{ref}"
+
 // Kind discriminators for LibrarySource.Kind. All branches feed the
 // same downstream pipeline (parse → embed → store); they only differ
 // in how the source markup is obtained and which parser turns it into
@@ -49,30 +55,110 @@ type Config struct {
 	Libraries []LibrarySource `yaml:"libraries"`
 }
 
+// VersionEntry is one element of LibrarySource.Versions after parsing.
+//
+// The list shorthand `versions: [v1, v2]` produces entries with Ref
+// empty (the lib's top-level Ref applies, if any). The map shorthand
+// `versions: {v1: {ref: tag1}, v2: {ref: tag2}}` produces entries with
+// per-version Ref set, which overrides the top-level Ref for that
+// version. Declaration order is preserved so scrapes are deterministic.
+type VersionEntry struct {
+	Name string
+	Ref  string
+}
+
 // LibrarySource is a single entry in libraries_sources.yaml.
 //
 // A LibrarySource with no Versions describes one library directly. A
 // LibrarySource with Versions is a YAML-level shorthand: at Expand() time
 // it produces one ResolvedSource per version, each with its URLs templated
 // and an effective lib_id of "<LibID>/<version>".
+//
+// Ref pins URLs to a single upstream git tag or commit SHA when URLs
+// contain the literal "{ref}" token. See #103.
 type LibrarySource struct {
-	LibID    string   `yaml:"lib_id"`
-	Kind     string   `yaml:"kind"`
-	URLs     []string `yaml:"urls"`
-	Versions []string `yaml:"versions,omitempty"`
+	LibID    string
+	Kind     string
+	URLs     []string
+	Ref      string
+	Versions []VersionEntry
 }
 
 // ResolvedSource is one library, post-version-expansion, ready to scrape.
 //
 // For single-version entries, LibID == BaseLibID and Version is empty.
 // For multi-version entries, LibID is "<BaseLibID>/<Version>" and the URLs
-// have the {version} placeholder substituted.
+// have the {version} placeholder substituted. Ref is the effective git
+// ref applied to the URLs (per-version Ref if set, else the top-level
+// LibrarySource.Ref).
 type ResolvedSource struct {
 	LibID     string
 	BaseLibID string
 	Version   string
 	Kind      string
+	Ref       string
 	URLs      []string
+}
+
+// UnmarshalYAML accepts both shapes for `versions:`:
+//
+//	versions: [v1, v2]                                 # list shorthand
+//	versions: {v1: {ref: tag1}, v2: {ref: tag2}}       # map shorthand (per-version ref)
+//
+// All other fields parse via the standard reflection path. Declaration
+// order is preserved for the map shape so the scrape loop hits versions
+// in a deterministic order.
+func (l *LibrarySource) UnmarshalYAML(node *yaml.Node) error {
+	var raw struct {
+		LibID    string    `yaml:"lib_id"`
+		Kind     string    `yaml:"kind"`
+		URLs     []string  `yaml:"urls"`
+		Ref      string    `yaml:"ref"`
+		Versions yaml.Node `yaml:"versions"`
+	}
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	l.LibID = raw.LibID
+	l.Kind = raw.Kind
+	l.URLs = raw.URLs
+	l.Ref = raw.Ref
+	l.Versions = nil
+
+	if raw.Versions.Kind == 0 {
+		return nil
+	}
+	switch raw.Versions.Kind {
+	case yaml.SequenceNode:
+		for _, item := range raw.Versions.Content {
+			var name string
+			if err := item.Decode(&name); err != nil {
+				return fmt.Errorf("versions list entry: %w", err)
+			}
+			l.Versions = append(l.Versions, VersionEntry{Name: name})
+		}
+	case yaml.MappingNode:
+		// Content alternates key, value, key, value, ... — iterate by
+		// declaration order.
+		for i := 0; i+1 < len(raw.Versions.Content); i += 2 {
+			keyNode := raw.Versions.Content[i]
+			valNode := raw.Versions.Content[i+1]
+			var name string
+			if err := keyNode.Decode(&name); err != nil {
+				return fmt.Errorf("versions map key: %w", err)
+			}
+			var entry struct {
+				Ref string `yaml:"ref"`
+			}
+			if err := valNode.Decode(&entry); err != nil {
+				return fmt.Errorf("versions[%q]: %w", name, err)
+			}
+			l.Versions = append(l.Versions, VersionEntry{Name: name, Ref: entry.Ref})
+		}
+	default:
+		return fmt.Errorf("versions must be a list or a mapping, got yaml kind %d", raw.Versions.Kind)
+	}
+	return nil
 }
 
 // LoadConfig reads, parses, and validates a libraries_sources.yaml file.
@@ -102,9 +188,14 @@ func LoadConfig(path string) (*Config, error) {
 //   - lib_id non-empty, starts with "/", does not end with "/"
 //   - kind in the known set
 //   - urls non-empty, no empty/whitespace entries
-//   - if versions is set: every version is non-empty with no whitespace,
-//     no "/", and no literal "{version}"; every URL contains "{version}"
+//   - ref (when set) has no whitespace and no placeholder tokens
+//   - if versions is set: every version has a non-empty name without
+//     whitespace, "/", or "{version}"; per-version refs (map shape) have
+//     no whitespace; every URL contains "{version}"
 //   - if versions is unset: no URL contains "{version}"
+//   - if any URL contains "{ref}": for the single-version entry the
+//     top-level ref must be set; for a multi-version entry every version
+//     must resolve to a non-empty ref (per-version ref or top-level ref).
 func (l LibrarySource) validate() error {
 	if l.LibID == "" {
 		return fmt.Errorf("lib_id is required")
@@ -129,6 +220,17 @@ func (l LibrarySource) validate() error {
 			return fmt.Errorf("urls contains an empty entry")
 		}
 	}
+	if err := validateRef(l.Ref); err != nil {
+		return fmt.Errorf("ref: %w", err)
+	}
+
+	urlHasRef := false
+	for _, u := range l.URLs {
+		if strings.Contains(u, refPlaceholder) {
+			urlHasRef = true
+			break
+		}
+	}
 
 	if len(l.Versions) == 0 {
 		// No versions: no URL may contain {version} — it would be an
@@ -138,6 +240,9 @@ func (l LibrarySource) validate() error {
 				return fmt.Errorf("url %q contains %s but no versions are listed", u, versionPlaceholder)
 			}
 		}
+		if urlHasRef && l.Ref == "" {
+			return fmt.Errorf("a url contains %s but ref is not set", refPlaceholder)
+		}
 		return nil
 	}
 
@@ -145,17 +250,23 @@ func (l LibrarySource) validate() error {
 	// every URL must reference {version} (otherwise the expansion would
 	// produce N identical rows).
 	for _, v := range l.Versions {
-		if v == "" {
+		if v.Name == "" {
 			return fmt.Errorf("versions contains an empty entry")
 		}
-		if strings.ContainsAny(v, " \t\n\r") {
-			return fmt.Errorf("version %q contains whitespace", v)
+		if strings.ContainsAny(v.Name, " \t\n\r") {
+			return fmt.Errorf("version %q contains whitespace", v.Name)
 		}
-		if strings.Contains(v, "/") {
-			return fmt.Errorf("version %q must not contain %q", v, "/")
+		if strings.Contains(v.Name, "/") {
+			return fmt.Errorf("version %q must not contain %q", v.Name, "/")
 		}
-		if strings.Contains(v, versionPlaceholder) {
-			return fmt.Errorf("version %q must not contain literal %q", v, versionPlaceholder)
+		if strings.Contains(v.Name, versionPlaceholder) {
+			return fmt.Errorf("version %q must not contain literal %q", v.Name, versionPlaceholder)
+		}
+		if err := validateRef(v.Ref); err != nil {
+			return fmt.Errorf("versions[%q].ref: %w", v.Name, err)
+		}
+		if urlHasRef && v.Ref == "" && l.Ref == "" {
+			return fmt.Errorf("a url contains %s but neither versions[%q].ref nor the top-level ref is set", refPlaceholder, v.Name)
 		}
 	}
 	for _, u := range l.URLs {
@@ -166,38 +277,82 @@ func (l LibrarySource) validate() error {
 	return nil
 }
 
+// validateRef enforces the format rules common to top-level and
+// per-version refs: empty is allowed (caller decides whether that's a
+// problem), but a non-empty ref must not contain whitespace or either
+// of the substitution placeholders.
+func validateRef(ref string) error {
+	if ref == "" {
+		return nil
+	}
+	if strings.ContainsAny(ref, " \t\n\r") {
+		return fmt.Errorf("ref %q contains whitespace", ref)
+	}
+	if strings.Contains(ref, refPlaceholder) {
+		return fmt.Errorf("ref %q must not contain literal %q", ref, refPlaceholder)
+	}
+	if strings.Contains(ref, versionPlaceholder) {
+		return fmt.Errorf("ref %q must not contain literal %q", ref, versionPlaceholder)
+	}
+	return nil
+}
+
 // Expand turns one LibrarySource into one or more ResolvedSources.
 //
 // Single-version entries pass through unchanged: LibID == BaseLibID,
-// Version is empty, URLs are copied as-is.
+// Version is empty, URLs are copied with {ref} substituted from the
+// top-level Ref (if present).
 //
 // Multi-version entries produce one ResolvedSource per version, with the
-// effective lib_id formed as "<base>/<version>" and the {version}
-// placeholder substituted in each URL.
+// effective lib_id formed as "<base>/<version>", the {version}
+// placeholder substituted in each URL, and the {ref} placeholder
+// substituted from the per-version Ref if set, else from the top-level
+// Ref.
 func (l LibrarySource) Expand() []ResolvedSource {
 	if len(l.Versions) == 0 {
+		urls := make([]string, len(l.URLs))
+		for i, u := range l.URLs {
+			urls[i] = substituteRef(u, l.Ref)
+		}
 		return []ResolvedSource{{
 			LibID:     l.LibID,
 			BaseLibID: l.LibID,
 			Kind:      l.Kind,
-			URLs:      append([]string(nil), l.URLs...),
+			Ref:       l.Ref,
+			URLs:      urls,
 		}}
 	}
 	out := make([]ResolvedSource, 0, len(l.Versions))
 	for _, v := range l.Versions {
+		ref := v.Ref
+		if ref == "" {
+			ref = l.Ref
+		}
 		urls := make([]string, len(l.URLs))
 		for i, u := range l.URLs {
-			urls[i] = strings.ReplaceAll(u, versionPlaceholder, v)
+			u = strings.ReplaceAll(u, versionPlaceholder, v.Name)
+			urls[i] = substituteRef(u, ref)
 		}
 		out = append(out, ResolvedSource{
-			LibID:     l.LibID + "/" + v,
+			LibID:     l.LibID + "/" + v.Name,
 			BaseLibID: l.LibID,
-			Version:   v,
+			Version:   v.Name,
 			Kind:      l.Kind,
+			Ref:       ref,
 			URLs:      urls,
 		})
 	}
 	return out
+}
+
+// substituteRef replaces {ref} in the URL when ref is non-empty.
+// Validation guarantees we never reach Expand with a {ref} placeholder
+// and an empty effective ref.
+func substituteRef(url, ref string) string {
+	if ref == "" {
+		return url
+	}
+	return strings.ReplaceAll(url, refPlaceholder, ref)
 }
 
 // Resolve flattens every entry in the config into ResolvedSources, applying

--- a/internal/scraper/config_test.go
+++ b/internal/scraper/config_test.go
@@ -59,8 +59,8 @@ libraries:
 	if cfg.Libraries[1].LibID != "/facebook/react" {
 		t.Errorf("libraries[1].LibID = %q", cfg.Libraries[1].LibID)
 	}
-	if got := cfg.Libraries[1].Versions; len(got) != 2 || got[0] != "v18" || got[1] != "v19" {
-		t.Errorf("libraries[1].Versions = %v, want [v18 v19]", got)
+	if got := cfg.Libraries[1].Versions; len(got) != 2 || got[0].Name != "v18" || got[1].Name != "v19" {
+		t.Errorf("libraries[1].Versions = %v, want [{v18} {v19}]", got)
 	}
 }
 
@@ -340,7 +340,7 @@ func TestExpand_MultiVersionExpandsAndSubstitutes(t *testing.T) {
 	src := scraper.LibrarySource{
 		LibID:    "/facebook/react",
 		Kind:     "github-md",
-		Versions: []string{"v18", "v19"},
+		Versions: []scraper.VersionEntry{{Name: "v18"}, {Name: "v19"}},
 		URLs: []string{
 			"https://raw.githubusercontent.com/facebook/react/{version}/README.md",
 			"https://raw.githubusercontent.com/facebook/react/{version}/docs/getting-started.md",
@@ -488,4 +488,202 @@ func mustLoadInline(t *testing.T, body string) *scraper.Config {
 		t.Fatalf("LoadConfig: %v", err)
 	}
 	return cfg
+}
+
+// --- {ref} pinning (#103) ---
+
+func TestLoadConfig_RefRules(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "single-version URL has {ref} but ref is unset",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    urls:
+      - https://example.com/{ref}/a.md
+`,
+			want: "ref is not set",
+		},
+		{
+			name: "multi-version URL has {ref} but no ref anywhere",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    versions: [v1, v2]
+    urls:
+      - https://example.com/{version}/{ref}/a.md
+`,
+			want: "neither versions",
+		},
+		{
+			name: "ref contains whitespace",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    ref: "v1 0"
+    urls:
+      - https://example.com/{ref}/a.md
+`,
+			want: "whitespace",
+		},
+		{
+			name: "per-version ref contains whitespace",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    versions:
+      v1: { ref: "tag with space" }
+    urls:
+      - https://example.com/{version}/{ref}/a.md
+`,
+			want: "whitespace",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeConfig(t, tc.yaml)
+			_, err := scraper.LoadConfig(path)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_RefSetButURLHasNoPlaceholderIsAllowed(t *testing.T) {
+	// Back-compat: a lib may declare ref: for documentation/future use
+	// even if no URL substitutes it yet. The scraper does not error.
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    ref: v1.0.0
+    urls:
+      - https://example.com/main/a.md
+`)
+	got := cfg.Resolve("")
+	if len(got) != 1 {
+		t.Fatalf("Resolve returned %d, want 1", len(got))
+	}
+	if got[0].Ref != "v1.0.0" {
+		t.Errorf("ResolvedSource.Ref = %q, want v1.0.0", got[0].Ref)
+	}
+	if got[0].URLs[0] != "https://example.com/main/a.md" {
+		t.Errorf("URL was rewritten unexpectedly: %q", got[0].URLs[0])
+	}
+}
+
+func TestExpand_SingleVersionSubstitutesRef(t *testing.T) {
+	src := scraper.LibrarySource{
+		LibID: "/python/cpython",
+		Kind:  scraper.KindGithubRST,
+		Ref:   "v3.13.1",
+		URLs: []string{
+			"https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/os.rst",
+			"https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/sys.rst",
+		},
+	}
+	out := src.Expand()
+	if len(out) != 1 {
+		t.Fatalf("Expand returned %d, want 1", len(out))
+	}
+	r := out[0]
+	if r.Ref != "v3.13.1" {
+		t.Errorf("Ref = %q, want v3.13.1", r.Ref)
+	}
+	want := []string{
+		"https://raw.githubusercontent.com/python/cpython/v3.13.1/Doc/library/os.rst",
+		"https://raw.githubusercontent.com/python/cpython/v3.13.1/Doc/library/sys.rst",
+	}
+	for i, u := range want {
+		if r.URLs[i] != u {
+			t.Errorf("URLs[%d] = %q, want %q", i, r.URLs[i], u)
+		}
+	}
+}
+
+func TestLoadConfig_VersionsMapShape(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /hashicorp/terraform
+    kind: github-md
+    versions:
+      v1.14: { ref: v1.14.6 }
+      v1.13: { ref: v1.13.5 }
+    urls:
+      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/intro/index.mdx
+`)
+	got := cfg.Resolve("")
+	if len(got) != 2 {
+		t.Fatalf("Resolve returned %d, want 2", len(got))
+	}
+	// Declaration order is preserved.
+	want := []struct {
+		libID string
+		ref   string
+		url   string
+	}{
+		{
+			libID: "/hashicorp/terraform/v1.14",
+			ref:   "v1.14.6",
+			url:   "https://raw.githubusercontent.com/hashicorp/web-unified-docs/v1.14.6/content/terraform/v1.14.x/docs/intro/index.mdx",
+		},
+		{
+			libID: "/hashicorp/terraform/v1.13",
+			ref:   "v1.13.5",
+			url:   "https://raw.githubusercontent.com/hashicorp/web-unified-docs/v1.13.5/content/terraform/v1.13.x/docs/intro/index.mdx",
+		},
+	}
+	for i, w := range want {
+		if got[i].LibID != w.libID {
+			t.Errorf("[%d].LibID = %q, want %q", i, got[i].LibID, w.libID)
+		}
+		if got[i].Ref != w.ref {
+			t.Errorf("[%d].Ref = %q, want %q", i, got[i].Ref, w.ref)
+		}
+		if got[i].URLs[0] != w.url {
+			t.Errorf("[%d].URLs[0] = %q, want %q", i, got[i].URLs[0], w.url)
+		}
+	}
+}
+
+func TestLoadConfig_VersionsMapShape_PerVersionRefOverridesTopLevel(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    ref: fallback-ref
+    versions:
+      v1: { ref: per-version-ref }
+      v2: {}
+    urls:
+      - https://example.com/{version}/{ref}/a.md
+`)
+	got := cfg.Resolve("")
+	if len(got) != 2 {
+		t.Fatalf("Resolve returned %d, want 2", len(got))
+	}
+	if got[0].Ref != "per-version-ref" {
+		t.Errorf("v1 Ref = %q, want per-version-ref", got[0].Ref)
+	}
+	if got[1].Ref != "fallback-ref" {
+		t.Errorf("v2 Ref = %q, want fallback-ref (top-level fallback)", got[1].Ref)
+	}
+	if got[0].URLs[0] != "https://example.com/v1/per-version-ref/a.md" {
+		t.Errorf("v1 URL = %q", got[0].URLs[0])
+	}
+	if got[1].URLs[0] != "https://example.com/v2/fallback-ref/a.md" {
+		t.Errorf("v2 URL = %q", got[1].URLs[0])
+	}
 }


### PR DESCRIPTION
## Summary

- Add `ref:` field to library registry config, allowing URLs to be pinned to a specific git tag or commit SHA via a `{ref}` placeholder — ensures reproducible `deadzone.db` builds across operators and runs
- Support both list shorthand (`versions: [v1, v2]`) and map shorthand (`versions: {v1: {ref: tag1}, v2: {ref: tag2}}`) for per-version ref overrides
- Record the resolved `ref` in each artifact's `state.yaml` sidecar for auditability
- Add comprehensive validation: require `ref` when URLs use `{ref}`, reject whitespace and placeholder tokens in refs, enforce per-version ref coverage for multi-version libs

## Changed files

- `internal/scraper/config.go` — new `VersionEntry` type, custom `UnmarshalYAML` for dual `versions:` shapes, `{ref}` substitution in `Expand()`, `validateRef()` helper
- `internal/scraper/config_test.go` — tests for validation rules, map/list shapes, ref substitution, per-version override fallback
- `internal/packs/state.go` — add `Ref` field to `StateFile`
- `internal/packs/state_test.go` — round-trip test for new field
- `cmd/deadzone/scrape.go` — propagate `Ref` into logging and state file
- `README.md` — document `ref:` field, add single-version and map-shorthand examples
- `docs/research/ingestion-architecture.md` — add reproducibility hook section (#103)

## Test plan

- [x] `go test ./internal/scraper/...` passes all new and existing config tests
- [x] `go test ./internal/packs/...` passes state file round-trip with `Ref`
- [ ] Manually verify `deadzone scrape -config` with a registry containing `ref:` entries produces pinned URLs in artifact state files

<!-- emdash-issue-footer:start -->
Fixes #103
<!-- emdash-issue-footer:end -->