### PR TITLE
feat: first-class multi-version support across scraper, DB, and MCP

### DIFF
--- a/cmd/deadzone/scrape.go
+++ b/cmd/deadzone/scrape.go
@@ -79,7 +79,8 @@ func runScrape(args []string) error {
 	embedderKind := fs.String("embedder", embed.KindHugot, "embedder to use (valid: hugot)")
 	verbose := fs.Bool("verbose", false, "emit per-doc Debug log lines in addition to per-URL summaries")
 	configPath := fs.String("config", "libraries_sources.yaml", "path to libraries_sources.yaml registry")
-	libFilter := fs.String("lib", "", "scrape only this lib_id (matches base or /base/version); empty = scrape all")
+	libFilter := fs.String("lib", "", "scrape only this base lib_id (e.g. /hashicorp/terraform); empty = scrape all libs in the registry")
+	versionFilter := fs.String("version", "", "scrape only this version (requires -lib); empty = all versions of the filtered lib(s)")
 	parallelGithubMD := fs.Int("parallel-github-md",
 		envIntOr(EnvParallelGithubMD, defaultParallelGithubMD),
 		"max concurrent github-* libs (github-md, github-rst — env: "+EnvParallelGithubMD+"; flag wins over env)")
@@ -96,6 +97,14 @@ func runScrape(args []string) error {
 	if *parallelScrapeViaAgent < 1 {
 		return fmt.Errorf("-parallel-scrape-via-agent must be >= 1, got %d", *parallelScrapeViaAgent)
 	}
+	// -version without -lib is ambiguous — multi-version libs share
+	// tags (two libs can both have a v1.0) so the filter has to be
+	// anchored on a base lib_id before the version tag narrows it
+	// down. Reject at parse time so the operator sees the mistake
+	// before any I/O.
+	if *versionFilter != "" && *libFilter == "" {
+		return errors.New("-version requires -lib")
+	}
 
 	// stderr-only JSON logging keeps scrape consistent with the server
 	// subcommand (which has a hard stdout-is-JSON-RPC constraint).
@@ -106,14 +115,19 @@ func runScrape(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	// Resolve flattens version shorthands and applies the -lib filter so
-	// the scrape loop doesn't need to know about either feature.
-	sources := cfg.Resolve(*libFilter)
+	// Resolve flattens version shorthands and applies the
+	// (-lib, -version) filter pair so the scrape loop doesn't need to
+	// know about either feature.
+	sources := cfg.Resolve(*libFilter, *versionFilter)
 	if len(sources) == 0 {
-		if *libFilter != "" {
+		switch {
+		case *libFilter != "" && *versionFilter != "":
+			return fmt.Errorf("no libraries match -lib %q -version %q in %s", *libFilter, *versionFilter, *configPath)
+		case *libFilter != "":
 			return fmt.Errorf("no libraries match -lib %q in %s", *libFilter, *configPath)
+		default:
+			return fmt.Errorf("no libraries to scrape in %s", *configPath)
 		}
-		return fmt.Errorf("no libraries to scrape in %s", *configPath)
 	}
 
 	// One artifacts/ dir per scrape run; created on demand so the first
@@ -157,6 +171,7 @@ func runScrape(args []string) error {
 	slog.Info("scraper.start",
 		"config_path", *configPath,
 		"lib_filter", *libFilter,
+		"version_filter", *versionFilter,
 		"lib_count", len(sources),
 		"artifacts_dir", *artifactsDir,
 		"embedder_kind", e.Kind(),
@@ -178,12 +193,17 @@ func runScrape(args []string) error {
 	var okCount, failedCount, docsTotal int
 	var failedIDs []string
 	for _, r := range results {
+		slot := r.libID
+		if r.version != "" {
+			slot = r.libID + "@" + r.version
+		}
 		if r.err != nil {
-			joined = errors.Join(joined, fmt.Errorf("%s: %w", r.libID, r.err))
+			joined = errors.Join(joined, fmt.Errorf("%s: %w", slot, r.err))
 			failedCount++
-			failedIDs = append(failedIDs, r.libID)
+			failedIDs = append(failedIDs, slot)
 			slog.Error("scraper.lib_failed",
 				"lib_id", r.libID,
+				"version", r.version,
 				"skipped_count", r.skipped,
 				"err", r.err.Error(),
 			)
@@ -205,13 +225,14 @@ func runScrape(args []string) error {
 	return joined
 }
 
-// libResult is the per-lib outcome produced by scrapeSources. docs is
-// the count of successfully indexed snippets (0 on failure); err is the
-// lib-fatal error or nil. skipped carries the per-URL soft-fail count
-// so the scraper.lib_failed log line can surface whether the lib died
-// on a ceiling trip vs a hard error.
+// libResult is the per-(lib, version) outcome produced by
+// scrapeSources. docs is the count of successfully indexed snippets
+// (0 on failure); err is the lib-fatal error or nil. skipped carries
+// the per-URL soft-fail count so the scraper.lib_failed log line can
+// surface whether the slot died on a ceiling trip vs a hard error.
 type libResult struct {
 	libID   string
+	version string
 	docs    int
 	skipped int
 	err     error
@@ -253,19 +274,19 @@ func scrapeSources(
 		group.Go(func() error {
 			sem, ok := sems[src.Kind]
 			if !ok {
-				results[i] = libResult{libID: src.LibID, err: fmt.Errorf("unknown kind %q", src.Kind)}
+				results[i] = libResult{libID: src.LibID, version: src.Version, err: fmt.Errorf("unknown kind %q", src.Kind)}
 				return nil
 			}
 			select {
 			case sem <- struct{}{}:
 			case <-gctx.Done():
-				results[i] = libResult{libID: src.LibID, err: gctx.Err()}
+				results[i] = libResult{libID: src.LibID, version: src.Version, err: gctx.Err()}
 				return nil
 			}
 			defer func() { <-sem }()
 
 			docs, skipped, err := scrapeLibToArtifact(gctx, client, agent, e, meta, artifactsDir, src)
-			results[i] = libResult{libID: src.LibID, docs: docs, skipped: skipped, err: err}
+			results[i] = libResult{libID: src.LibID, version: src.Version, docs: docs, skipped: skipped, err: err}
 			// Never propagate — aggregation happens in the caller so
 			// sibling libs are not cancelled by errgroup.
 			return nil
@@ -298,12 +319,12 @@ func scrapeLibToArtifact(
 	artifactsDir string,
 	src scraper.ResolvedSource,
 ) (int, int, error) {
-	artifactDir := packs.ArtifactDir(artifactsDir, src.LibID)
+	artifactDir := packs.ArtifactDir(artifactsDir, src.LibID, src.Version)
 	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
 		return 0, 0, fmt.Errorf("create artifact dir %s: %w", artifactDir, err)
 	}
-	artifactPath := packs.ArtifactDBPath(artifactsDir, src.LibID)
-	statePath := packs.StatePath(artifactsDir, src.LibID)
+	artifactPath := packs.ArtifactDBPath(artifactsDir, src.LibID, src.Version)
+	statePath := packs.StatePath(artifactsDir, src.LibID, src.Version)
 
 	// Read any pre-existing sidecar BEFORE the wipe loop so
 	// `created_at` survives a re-scrape. A missing file is the first-
@@ -317,6 +338,7 @@ func scrapeLibToArtifact(
 	} else if !os.IsNotExist(err) {
 		slog.Warn("scraper.state_load_failed",
 			"lib_id", src.LibID,
+			"version", src.Version,
 			"state_path", statePath,
 			"err", err.Error(),
 		)
@@ -338,7 +360,7 @@ func scrapeLibToArtifact(
 		}
 	}
 
-	d, err := db.OpenArtifact(artifactPath, meta, src.LibID)
+	d, err := db.OpenArtifact(artifactPath, meta, src.LibID, src.Version)
 	if err != nil {
 		return 0, 0, fmt.Errorf("open artifact %s: %w", artifactPath, err)
 	}
@@ -346,7 +368,6 @@ func scrapeLibToArtifact(
 
 	slog.Info("scraper.lib_start",
 		"lib_id", src.LibID,
-		"base_lib_id", src.BaseLibID,
 		"version", src.Version,
 		"kind", src.Kind,
 		"ref", src.Ref,
@@ -355,15 +376,14 @@ func scrapeLibToArtifact(
 	)
 
 	// Make sure the libs catalog row exists before we start indexing
-	// docs. UpsertLibIfNew is idempotent and skips the embed call when
-	// the row is already present, so the cost on a re-run is just one
-	// count(*); the actual doc_count is filled in at the end of this
-	// function once we know the real number. Each ResolvedSource has
-	// its own canonical lib_id (versioned libs already get distinct
-	// /org/project/version values from cfg.Resolve), so a single
-	// upsert per source is the correct grain.
-	if err := db.UpsertLibIfNew(d, src.LibID, e); err != nil {
-		return 0, 0, fmt.Errorf("upsert lib %q: %w", src.LibID, err)
+	// docs. UpsertLibIfNew is idempotent per (lib_id, version) and
+	// skips the embed call when the row is already present, so the
+	// cost on a re-run is just one count(*); the actual doc_count is
+	// filled in at the end of this function once we know the real
+	// number. Each ResolvedSource covers exactly one (lib_id, version)
+	// slot so a single upsert per source is the correct grain.
+	if err := db.UpsertLibIfNew(d, src.LibID, src.Version, e); err != nil {
+		return 0, 0, fmt.Errorf("upsert lib %q version %q: %w", src.LibID, src.Version, err)
 	}
 
 	libStart := time.Now()
@@ -408,6 +428,7 @@ func scrapeLibToArtifact(
 				skippedThisLib++
 				slog.Error("scraper.url_skipped",
 					"lib_id", src.LibID,
+					"version", src.Version,
 					"url", u,
 					"kind", fetcher,
 					"reason", reason,
@@ -425,6 +446,7 @@ func scrapeLibToArtifact(
 			}
 			slog.Error("scraper.fetch_failed",
 				"lib_id", src.LibID,
+				"version", src.Version,
 				"url", u,
 				"kind", fetcher,
 				"reason", reason,
@@ -435,6 +457,7 @@ func scrapeLibToArtifact(
 		}
 		slog.Info("scraper.fetch",
 			"lib_id", src.LibID,
+			"version", src.Version,
 			"url", u,
 			"kind", fetcher,
 			"bytes", res.Bytes,
@@ -453,6 +476,11 @@ func scrapeLibToArtifact(
 		var embedTotal, insertTotal time.Duration
 		var docsInserted, docsSkipped int
 		for _, doc := range res.Docs {
+			// The fetchers populate doc.LibID from the ResolvedSource's
+			// base lib_id but do not know about version — stamp it in
+			// here so the DB row carries the (lib_id, version) slot.
+			doc.Version = src.Version
+
 			embedStart := time.Now()
 			vec, err := e.EmbedDocument(doc.Title + "\n" + doc.Content)
 			embedTotal += time.Since(embedStart)
@@ -460,6 +488,7 @@ func scrapeLibToArtifact(
 				docsSkipped++
 				slog.Warn("scraper.embed_failed",
 					"lib_id", doc.LibID,
+					"version", doc.Version,
 					"title", doc.Title,
 					"url", u,
 					"err", err.Error(),
@@ -471,6 +500,7 @@ func scrapeLibToArtifact(
 			if err := db.Insert(d, doc, vec); err != nil {
 				slog.Error("scraper.insert_failed",
 					"lib_id", doc.LibID,
+					"version", doc.Version,
 					"title", doc.Title,
 					"url", u,
 					"err", err.Error(),
@@ -482,6 +512,7 @@ func scrapeLibToArtifact(
 
 			slog.Debug("scraper.doc_indexed",
 				"lib_id", doc.LibID,
+				"version", doc.Version,
 				"title", doc.Title,
 				"url", u,
 				"content_bytes", len(doc.Content),
@@ -490,6 +521,7 @@ func scrapeLibToArtifact(
 
 		slog.Info("scraper.indexed",
 			"lib_id", src.LibID,
+			"version", src.Version,
 			"url", u,
 			"docs_inserted", docsInserted,
 			"docs_skipped", docsSkipped,
@@ -505,13 +537,14 @@ func scrapeLibToArtifact(
 	// Each artifact is rebuilt from scratch, so docsTotal is the
 	// absolute row count for the lib in this artifact — no append-
 	// vs-replace ambiguity.
-	if err := db.UpdateLibCount(d, src.LibID, docsTotal); err != nil {
+	if err := db.UpdateLibCount(d, src.LibID, src.Version, docsTotal); err != nil {
 		slog.Error("scraper.update_lib_count_failed",
 			"lib_id", src.LibID,
+			"version", src.Version,
 			"docs_total", docsTotal,
 			"err", err.Error(),
 		)
-		return docsTotal, skippedThisLib, fmt.Errorf("update lib count %q: %w", src.LibID, err)
+		return docsTotal, skippedThisLib, fmt.Errorf("update lib count %q version %q: %w", src.LibID, src.Version, err)
 	}
 
 	// Write the `.state` sidecar AFTER the `.db` is committed and the
@@ -523,6 +556,7 @@ func scrapeLibToArtifact(
 	now := time.Now().UTC()
 	state := &packs.StateFile{
 		LibID:         src.LibID,
+		Version:       src.Version,
 		SchemaVersion: db.CurrentSchemaVersion,
 		Embedder: packs.EmbedderState{
 			Kind:  e.Kind(),
@@ -544,6 +578,7 @@ func scrapeLibToArtifact(
 
 	slog.Info("scraper.lib_done",
 		"lib_id", src.LibID,
+		"version", src.Version,
 		"ref", src.Ref,
 		"docs_total", docsTotal,
 		"duration_ms", time.Since(libStart).Milliseconds(),

--- a/cmd/deadzone/server.go
+++ b/cmd/deadzone/server.go
@@ -17,15 +17,22 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// Library IDs follow the format /org/project (e.g. /hashicorp/terraform)
+// Library IDs follow the format /org/project (e.g.
+// /hashicorp/terraform). Version is the per-release tag as recorded
+// in the registry (e.g. "v1.14"); empty version means "every version
+// of this lib". Multi-version support is first-class after #113: a
+// single /hashicorp/terraform entry can hold v1.13 and v1.14 side by
+// side, and the LLM picks between them via the Version field.
 type SearchDocsInput struct {
-	Query  string `json:"query" jsonschema:"the search query"`
-	LibID  string `json:"lib_id,omitempty" jsonschema:"library ID in /org/project format (optional)"`
-	Tokens int    `json:"tokens,omitempty" jsonschema:"max tokens to return, min 1000, default 5000 (optional)"`
+	Query   string `json:"query" jsonschema:"the search query"`
+	LibID   string `json:"lib_id,omitempty" jsonschema:"base library ID in /org/project format (optional)"`
+	Version string `json:"version,omitempty" jsonschema:"version tag to filter by (optional; requires lib_id)"`
+	Tokens  int    `json:"tokens,omitempty" jsonschema:"max tokens to return, min 1000, default 5000 (optional)"`
 }
 
 type Snippet struct {
 	LibID   string `json:"lib_id"`
+	Version string `json:"version,omitempty"`
 	Title   string `json:"title"`
 	Content string `json:"content"`
 }
@@ -45,12 +52,19 @@ func makeSearchHandler(d *db.DB, e embed.Embedder, verbose bool) func(context.Co
 	return func(ctx context.Context, req *mcp.CallToolRequest, input SearchDocsInput) (*mcp.CallToolResult, SearchDocsOutput, error) {
 		start := time.Now()
 
+		// version without lib_id is ambiguous (two libs can each have
+		// a v1.0) so reject before any work.
+		if input.Version != "" && input.LibID == "" {
+			slog.Error("search_docs failed", searchAttrs(input, verbose, "stage", "validate", "err", "version requires lib_id")...)
+			return nil, SearchDocsOutput{}, fmt.Errorf("version requires lib_id")
+		}
+
 		queryVec, err := e.EmbedQuery(input.Query)
 		if err != nil {
 			slog.Error("search_docs failed", searchAttrs(input, verbose, "stage", "embed", "err", err.Error())...)
 			return nil, SearchDocsOutput{}, fmt.Errorf("embed query: %w", err)
 		}
-		docs, err := db.SearchByEmbedding(d, queryVec, input.LibID, searchK)
+		docs, err := db.SearchByEmbedding(d, queryVec, input.LibID, input.Version, searchK)
 		if err != nil {
 			slog.Error("search_docs failed", searchAttrs(input, verbose, "stage", "search", "err", err.Error())...)
 			return nil, SearchDocsOutput{}, err
@@ -74,6 +88,7 @@ func makeSearchHandler(d *db.DB, e embed.Embedder, verbose bool) func(context.Co
 			}
 			snippets = append(snippets, Snippet{
 				LibID:   doc.LibID,
+				Version: doc.Version,
 				Title:   doc.Title,
 				Content: content,
 			})
@@ -99,8 +114,8 @@ func makeSearchHandler(d *db.DB, e embed.Embedder, verbose bool) func(context.Co
 // query text — gated because queries may contain user data routed
 // through the LLM and we don't want it in default logs.
 func searchAttrs(input SearchDocsInput, verbose bool, extra ...any) []any {
-	attrs := make([]any, 0, 4+len(extra))
-	attrs = append(attrs, "lib_id", input.LibID)
+	attrs := make([]any, 0, 6+len(extra))
+	attrs = append(attrs, "lib_id", input.LibID, "version", input.Version)
 	attrs = append(attrs, extra...)
 	if verbose {
 		attrs = append(attrs, "query", input.Query)
@@ -120,12 +135,15 @@ type SearchLibrariesInput struct {
 }
 
 // LibraryHit is one ranked candidate returned by search_libraries.
-// MatchScore is 1 - cosine_distance(query, lib_embedding) so higher is
-// closer; the empty-name path returns 1.0 for every row (no query was
-// embedded). LLM clients can use the score to decide whether to commit
-// to a single result or surface multiple candidates to the user.
+// MatchScore is 1 - cosine_distance(query, lib_embedding) so higher
+// is closer; the empty-name path returns 1.0 for every row (no query
+// was embedded). After #113 each hit is one (lib_id, version) pair —
+// two versions of the same lib come back as two separate hits with
+// the same lib_id and different version values. Clients that want an
+// aggregate "versions of terraform" view group on lib_id themselves.
 type LibraryHit struct {
 	LibID      string  `json:"lib_id"`
+	Version    string  `json:"version,omitempty"`
 	DocCount   int     `json:"doc_count"`
 	MatchScore float32 `json:"match_score"`
 }
@@ -192,6 +210,7 @@ func makeSearchLibrariesHandler(d *db.DB, e embed.Embedder, verbose bool) func(c
 		for _, lib := range libs {
 			hits = append(hits, LibraryHit{
 				LibID:      lib.LibID,
+				Version:    lib.Version,
 				DocCount:   lib.DocCount,
 				MatchScore: 1.0 - lib.Distance,
 			})
@@ -314,11 +333,11 @@ func runServer(args []string) error {
 	s := mcp.NewServer(&mcp.Implementation{Name: "deadzone", Version: version}, nil)
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "search_docs",
-		Description: "Search documentation snippets for a library. Use lib_id in /org/project format to filter by library.",
+		Description: "Search documentation snippets for a library. Filter by library via lib_id (base form like /hashicorp/terraform). Pass version alongside lib_id to pin to a specific version (e.g. v1.14); omit version to search across all indexed versions of the lib. version without lib_id is rejected.",
 	}, makeSearchHandler(d, e, *verbose))
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "search_libraries",
-		Description: "Resolve a free-text library name into a ranked list of canonical lib_id candidates that can be passed to search_docs. Pass an empty name to list the most-indexed libraries by doc_count.",
+		Description: "Resolve a free-text library name into a ranked list of (lib_id, version) candidates that can be passed to search_docs. Returns one entry per indexed (lib_id, version) pair — group by lib_id on the client to see the versions of the same library. Pass an empty name to list the most-indexed libraries by doc_count.",
 	}, makeSearchLibrariesHandler(d, e, *verbose))
 
 	if err := s.Run(context.Background(), &mcp.StdioTransport{}); err != nil {

--- a/cmd/deadzone/server_test.go
+++ b/cmd/deadzone/server_test.go
@@ -119,6 +119,76 @@ func TestHandleSearchDocs_ReturnsSnippets(t *testing.T) {
 	})
 }
 
+// TestHandleSearchDocs_VersionRequiresLibID pins the usage-error
+// guard: passing version without lib_id is rejected before any
+// embed/query work.
+func TestHandleSearchDocs_VersionRequiresLibID(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"), db.Meta{
+		EmbedderKind: testEmbedder.Kind(),
+		EmbeddingDim: testEmbedder.Dim(),
+		ModelVersion: testEmbedder.ModelVersion(),
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+	handler := makeSearchHandler(d, testEmbedder, false)
+
+	_, _, err = handler(context.Background(), &mcp.CallToolRequest{}, SearchDocsInput{
+		Query:   "anything",
+		Version: "v1.14",
+	})
+	if err == nil {
+		t.Fatal("expected error for version without lib_id, got nil")
+	}
+}
+
+// TestHandleSearchDocs_VersionFiltersAndSurfaces seeds two versions of
+// the same lib_id and asserts the filtered query returns only that
+// version's snippets AND that each snippet carries the version in the
+// Snippet.Version field the LLM sees.
+func TestHandleSearchDocs_VersionFiltersAndSurfaces(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"), db.Meta{
+		EmbedderKind: testEmbedder.Kind(),
+		EmbeddingDim: testEmbedder.Dim(),
+		ModelVersion: testEmbedder.ModelVersion(),
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	docs := []db.Doc{
+		{LibID: "/hashicorp/terraform", Version: "v1.14", Title: "tf v1.14 intro", Content: "v1.14 install instructions"},
+		{LibID: "/hashicorp/terraform", Version: "v1.13", Title: "tf v1.13 intro", Content: "v1.13 install instructions"},
+	}
+	for _, doc := range docs {
+		vec, err := testEmbedder.EmbedDocument(doc.Title + "\n" + doc.Content)
+		if err != nil {
+			t.Fatalf("Embed %q: %v", doc.Title, err)
+		}
+		if err := db.Insert(d, doc, vec); err != nil {
+			t.Fatalf("Insert: %v", err)
+		}
+	}
+
+	handler := makeSearchHandler(d, testEmbedder, false)
+	_, out, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchDocsInput{
+		Query:   "install",
+		LibID:   "/hashicorp/terraform",
+		Version: "v1.14",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if len(out.Snippets) != 1 {
+		t.Fatalf("got %d snippets, want 1", len(out.Snippets))
+	}
+	if out.Snippets[0].Version != "v1.14" {
+		t.Errorf("snippet Version = %q, want v1.14", out.Snippets[0].Version)
+	}
+}
+
 // TestHandleSearchLibraries exercises the search_libraries handler end
 // to end against a hand-seeded libs catalog. The corpus is intentionally
 // small but heterogeneous (different doc_counts, different topics) so
@@ -145,10 +215,10 @@ func TestHandleSearchLibraries(t *testing.T) {
 		{"/expressjs/express", 75},
 	}
 	for _, l := range libs {
-		if err := db.UpsertLibIfNew(d, l.id, testEmbedder); err != nil {
+		if err := db.UpsertLibIfNew(d, l.id, "", testEmbedder); err != nil {
 			t.Fatalf("UpsertLibIfNew %q: %v", l.id, err)
 		}
-		if err := db.UpdateLibCount(d, l.id, l.count); err != nil {
+		if err := db.UpdateLibCount(d, l.id, "", l.count); err != nil {
 			t.Fatalf("UpdateLibCount %q: %v", l.id, err)
 		}
 	}

--- a/internal/db/consolidate.go
+++ b/internal/db/consolidate.go
@@ -27,10 +27,12 @@ type ConsolidateResult struct {
 // Consolidate merges every per-lib artifact in artifactsDir into main.
 // Each lib lives in its own subdirectory (artifacts/<slug>/artifact.db
 // + state.yaml, see #101), so consolidation globs the nested shape
-// rather than the old flat *.db layout. It is the inverse of the
-// per-lib scrape: each artifact replaces (not appends to) the rows in
-// main that share its lib_id, in both the docs and libs tables,
-// atomically.
+// rather than the old flat *.db layout. Artifacts are keyed on
+// (lib_id, version) after #113 — two versions of the same base lib
+// live in two sibling folders and merge as two independent (lib_id,
+// version) slots without clobbering each other. Each artifact replaces
+// (not appends to) the rows in main for its (lib_id, version) slot,
+// in both the docs and libs tables, atomically.
 //
 // The operation runs in two passes:
 //
@@ -64,21 +66,22 @@ func Consolidate(main *DB, artifactsDir string) (ConsolidateResult, error) {
 	sort.Strings(matches)
 
 	type entry struct {
-		path  string
-		libID string
+		path    string
+		libID   string
+		version string
 	}
 	entries := make([]entry, 0, len(matches))
 
 	// Pass 1 — validation. Opening each artifact with libID="" both
 	// re-runs Open's meta/schema cross-check against main.Meta and
-	// reads the artifact's recorded lib_id. We close immediately so
-	// the conn pool is free for pass 2.
+	// reads the artifact's recorded (lib_id, version). We close
+	// immediately so the conn pool is free for pass 2.
 	for _, path := range matches {
-		a, err := OpenArtifact(path, main.Meta, "")
+		a, err := OpenArtifact(path, main.Meta, "", "")
 		if err != nil {
 			return result, fmt.Errorf("validate artifact %s: %w", filepath.Base(path), err)
 		}
-		entries = append(entries, entry{path: path, libID: a.ArtifactLibID})
+		entries = append(entries, entry{path: path, libID: a.ArtifactLibID, version: a.ArtifactVersion})
 		_ = a.Close()
 	}
 
@@ -103,7 +106,7 @@ func Consolidate(main *DB, artifactsDir string) (ConsolidateResult, error) {
 	}()
 
 	for _, e := range entries {
-		merged, libRow, err := mergeArtifactInto(tx, e.path, e.libID, main.Meta)
+		merged, libRow, err := mergeArtifactInto(tx, e.path, e.libID, e.version, main.Meta)
 		if err != nil {
 			return result, fmt.Errorf("merge artifact %s: %w", filepath.Base(e.path), err)
 		}
@@ -122,43 +125,50 @@ func Consolidate(main *DB, artifactsDir string) (ConsolidateResult, error) {
 }
 
 // mergeArtifactInto reopens one artifact, deletes any existing rows in
-// main for its lib_id (across both docs and libs), and streams the
-// artifact's rows in via the supplied transaction. Returns the number
-// of docs inserted and whether a libs row was inserted.
+// main for its (lib_id, version) slot (across both docs and libs), and
+// streams the artifact's rows in via the supplied transaction. Returns
+// the number of docs inserted and whether a libs row was inserted.
 //
-// The artifact is opened with libID set to the value captured during
-// pass 1; any drift between the validation pass and the merge pass
-// (e.g. an artifact file rewritten between the two) surfaces here as
+// The DELETE is keyed on (lib_id, version), not lib_id alone: a merge
+// of /foo v1.14 must not wipe out /foo v1.13's rows in main. Each
+// artifact owns exactly one (lib_id, version) slot by construction
+// (OpenArtifact enforces it via meta) so two versions of the same
+// base lib are two independent artifacts that merge cleanly as two
+// (lib_id, version) rows.
+//
+// The artifact is opened with the (lib_id, version) pair captured
+// during pass 1; any drift between validation and merge (e.g. an
+// artifact file rewritten between the two) surfaces here as
 // ErrArtifactLibIDMismatch and rolls back the whole consolidation.
-func mergeArtifactInto(tx *sql.Tx, path, libID string, meta Meta) (int, bool, error) {
-	a, err := OpenArtifact(path, meta, libID)
+func mergeArtifactInto(tx *sql.Tx, path, libID, version string, meta Meta) (int, bool, error) {
+	a, err := OpenArtifact(path, meta, libID, version)
 	if err != nil {
 		return 0, false, err
 	}
 	defer a.Close()
 
-	// docs: drop the old per-lib slice in main, then stream the
-	// artifact's rows back in. vector_extract / vector() round-trips
-	// the F32_BLOB through the same JSON-array form formatVector
-	// uses on the insert path, so we don't need to teach this
-	// function about the on-disk encoding.
-	if _, err := tx.Exec(`DELETE FROM docs WHERE lib_id = ?`, libID); err != nil {
-		return 0, false, fmt.Errorf("delete docs for %q: %w", libID, err)
+	// docs: drop the old per-(lib, version) slice in main, then
+	// stream the artifact's rows back in. vector_extract / vector()
+	// round-trips the F32_BLOB through the same JSON-array form
+	// formatVector uses on the insert path, so we don't need to
+	// teach this function about the on-disk encoding.
+	if _, err := tx.Exec(`DELETE FROM docs WHERE lib_id = ? AND version = ?`, libID, version); err != nil {
+		return 0, false, fmt.Errorf("delete docs for %q version %q: %w", libID, version, err)
 	}
-	docRows, err := a.Query(`SELECT lib_id, title, content, vector_extract(embedding) FROM docs`)
+	docRows, err := a.Query(`SELECT lib_id, version, title, content, vector_extract(embedding) FROM docs`)
 	if err != nil {
 		return 0, false, fmt.Errorf("select artifact docs: %w", err)
 	}
 	docsInserted := 0
 	for docRows.Next() {
-		var rowLibID, title, content, vecJSON string
-		if err := docRows.Scan(&rowLibID, &title, &content, &vecJSON); err != nil {
+		var rowLibID, rowVersion, title, content, vecJSON string
+		if err := docRows.Scan(&rowLibID, &rowVersion, &title, &content, &vecJSON); err != nil {
 			docRows.Close()
 			return 0, false, fmt.Errorf("scan artifact doc: %w", err)
 		}
 		if _, err := tx.Exec(
-			`INSERT INTO docs(lib_id, title, content, embedding) VALUES (?, ?, ?, vector(?))`,
-			rowLibID, title, content, vecJSON,
+			`INSERT INTO docs(lib_id, version, title, content, embedding) VALUES (?, ?, ?, ?, vector(?))`,
+			rowLibID, rowVersion, title, content, vecJSON,
 		); err != nil {
 			docRows.Close()
 			return 0, false, fmt.Errorf("insert doc into main: %w", err)
@@ -171,27 +181,28 @@ func mergeArtifactInto(tx *sql.Tx, path, libID string, meta Meta) (int, bool, er
 	}
 	docRows.Close()
 
-	// libs: same dance. Most artifacts hold exactly one libs row
-	// (the lib_id they advertise via meta), but the loop is generic
-	// in case a future scraper writes additional bookkeeping rows.
-	if _, err := tx.Exec(`DELETE FROM libs WHERE lib_id = ?`, libID); err != nil {
-		return 0, false, fmt.Errorf("delete libs for %q: %w", libID, err)
+	// libs: same dance, keyed on (lib_id, version). Most artifacts
+	// hold exactly one libs row (the pair they advertise via meta),
+	// but the loop is generic in case a future scraper writes
+	// additional bookkeeping rows.
+	if _, err := tx.Exec(`DELETE FROM libs WHERE lib_id = ? AND version = ?`, libID, version); err != nil {
+		return 0, false, fmt.Errorf("delete libs for %q version %q: %w", libID, version, err)
 	}
-	libRows, err := a.Query(`SELECT lib_id, doc_count, vector_extract(embedding) FROM libs`)
+	libRows, err := a.Query(`SELECT lib_id, version, doc_count, vector_extract(embedding) FROM libs`)
 	if err != nil {
 		return 0, false, fmt.Errorf("select artifact libs: %w", err)
 	}
 	libRowInserted := false
 	for libRows.Next() {
-		var rowLibID, vecJSON string
+		var rowLibID, rowVersion, vecJSON string
 		var docCount int
-		if err := libRows.Scan(&rowLibID, &docCount, &vecJSON); err != nil {
+		if err := libRows.Scan(&rowLibID, &rowVersion, &docCount, &vecJSON); err != nil {
 			libRows.Close()
 			return 0, false, fmt.Errorf("scan artifact lib: %w", err)
 		}
 		if _, err := tx.Exec(
-			`INSERT INTO libs(lib_id, doc_count, embedding) VALUES (?, ?, vector(?))`,
-			rowLibID, docCount, vecJSON,
+			`INSERT INTO libs(lib_id, version, doc_count, embedding) VALUES (?, ?, ?, vector(?))`,
+			rowLibID, rowVersion, docCount, vecJSON,
 		); err != nil {
 			libRows.Close()
 			return 0, false, fmt.Errorf("insert lib into main: %w", err)

--- a/internal/db/consolidate_test.go
+++ b/internal/db/consolidate_test.go
@@ -14,48 +14,51 @@ import (
 
 // makeArtifact builds a fresh artifact file at
 // <dir>/<slug>/artifact.db containing one libs row and the supplied
-// docs. The slug matches the scraper's naming rule (leading "/" stripped,
-// remaining "/" → "_"), so the test fixtures double as a regression
-// check on the folder-per-lib layout introduced by #101. Returns the
-// artifact's on-disk path.
-func makeArtifact(t *testing.T, dir, libID string, docs []db.Doc) string {
+// docs. The slug matches the scraper's naming rule (leading "/"
+// stripped, remaining "/" → "_", plus "_<version>" when version !=
+// ""), so the test fixtures double as a regression check on the
+// folder-per-(lib, version) layout introduced by #113. Returns the
+// artifact's on-disk path. version is "" for single-version libs —
+// the canonical form.
+func makeArtifact(t *testing.T, dir, libID, version string, docs []db.Doc) string {
 	t.Helper()
-	libDir := filepath.Join(dir, artifactBasename(libID))
+	libDir := filepath.Join(dir, artifactBasename(libID, version))
 	if err := os.MkdirAll(libDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll %s: %v", libDir, err)
 	}
 	path := filepath.Join(libDir, "artifact.db")
 
-	a, err := db.OpenArtifact(path, metaFor(testEmbedder), libID)
+	a, err := db.OpenArtifact(path, metaFor(testEmbedder), libID, version)
 	if err != nil {
-		t.Fatalf("OpenArtifact %q: %v", libID, err)
+		t.Fatalf("OpenArtifact %q version %q: %v", libID, version, err)
 	}
-	if err := db.UpsertLibIfNew(a, libID, testEmbedder); err != nil {
+	if err := db.UpsertLibIfNew(a, libID, version, testEmbedder); err != nil {
 		a.Close()
-		t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
+		t.Fatalf("UpsertLibIfNew %q version %q: %v", libID, version, err)
 	}
 	for _, doc := range docs {
+		doc.Version = version
 		if err := db.Insert(a, doc, embedText(t, testEmbedder, doc)); err != nil {
 			a.Close()
-			t.Fatalf("Insert into artifact %q: %v", libID, err)
+			t.Fatalf("Insert into artifact %q version %q: %v", libID, version, err)
 		}
 	}
-	if err := db.UpdateLibCount(a, libID, len(docs)); err != nil {
+	if err := db.UpdateLibCount(a, libID, version, len(docs)); err != nil {
 		a.Close()
-		t.Fatalf("UpdateLibCount %q: %v", libID, err)
+		t.Fatalf("UpdateLibCount %q version %q: %v", libID, version, err)
 	}
 	if err := a.Close(); err != nil {
-		t.Fatalf("Close artifact %q: %v", libID, err)
+		t.Fatalf("Close artifact %q version %q: %v", libID, version, err)
 	}
 	return path
 }
 
-// artifactBasename mirrors the scraper's filename derivation. Kept
-// here in the test package (rather than imported) so the test catches
-// drift if the scraper's rule changes — when both sides break together
-// it's a deliberate refactor; when only one side breaks the diff is a
-// red flag.
-func artifactBasename(libID string) string {
+// artifactBasename mirrors the scraper's slug derivation (see
+// packs.Slug). Kept here in the test package (rather than imported)
+// so the test catches drift if the packs rule changes — when both
+// sides break together it's a deliberate refactor; when only one
+// side breaks the diff is a red flag.
+func artifactBasename(libID, version string) string {
 	out := libID
 	if len(out) > 0 && out[0] == '/' {
 		out = out[1:]
@@ -66,22 +69,29 @@ func artifactBasename(libID string) string {
 			b[i] = '_'
 		}
 	}
-	return string(b)
+	slug := string(b)
+	if version == "" {
+		return slug
+	}
+	return slug + "_" + version
 }
 
 func TestOpenArtifact_FreshWritesLibID(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "fresh.db")
-	a, err := db.OpenArtifact(path, metaFor(testEmbedder), "/foo/bar")
+	a, err := db.OpenArtifact(path, metaFor(testEmbedder), "/foo/bar", "")
 	if err != nil {
 		t.Fatalf("OpenArtifact: %v", err)
 	}
 	if a.ArtifactLibID != "/foo/bar" {
 		t.Errorf("ArtifactLibID = %q, want %q", a.ArtifactLibID, "/foo/bar")
 	}
+	if a.ArtifactVersion != "" {
+		t.Errorf("ArtifactVersion = %q, want empty", a.ArtifactVersion)
+	}
 	a.Close()
 
-	// Reopen with the same lib_id should succeed.
-	reopened, err := db.OpenArtifact(path, metaFor(testEmbedder), "/foo/bar")
+	// Reopen with the same (lib_id, version) should succeed.
+	reopened, err := db.OpenArtifact(path, metaFor(testEmbedder), "/foo/bar", "")
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -92,7 +102,7 @@ func TestOpenArtifact_FreshWritesLibID(t *testing.T) {
 
 	// Reopen with libID="" should also succeed and surface the
 	// stored value — this is the consolidate code path.
-	discovered, err := db.OpenArtifact(path, metaFor(testEmbedder), "")
+	discovered, err := db.OpenArtifact(path, metaFor(testEmbedder), "", "")
 	if err != nil {
 		t.Fatalf("discover: %v", err)
 	}
@@ -102,17 +112,63 @@ func TestOpenArtifact_FreshWritesLibID(t *testing.T) {
 	discovered.Close()
 }
 
+// TestOpenArtifact_FreshWritesLibIDAndVersion pins the multi-version
+// arm of the meta round-trip: both lib_id and version are persisted
+// on first write, and the consolidate-mode reopen (libID == "")
+// recovers both.
+func TestOpenArtifact_FreshWritesLibIDAndVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fresh_v.db")
+	a, err := db.OpenArtifact(path, metaFor(testEmbedder), "/hashicorp/terraform", "v1.14")
+	if err != nil {
+		t.Fatalf("OpenArtifact: %v", err)
+	}
+	if a.ArtifactLibID != "/hashicorp/terraform" || a.ArtifactVersion != "v1.14" {
+		t.Errorf("got (%q, %q), want (%q, %q)", a.ArtifactLibID, a.ArtifactVersion, "/hashicorp/terraform", "v1.14")
+	}
+	a.Close()
+
+	discovered, err := db.OpenArtifact(path, metaFor(testEmbedder), "", "")
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if discovered.ArtifactLibID != "/hashicorp/terraform" || discovered.ArtifactVersion != "v1.14" {
+		t.Errorf("discover got (%q, %q), want (%q, %q)", discovered.ArtifactLibID, discovered.ArtifactVersion, "/hashicorp/terraform", "v1.14")
+	}
+	discovered.Close()
+}
+
 func TestOpenArtifact_RejectsLibIDMismatch(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "tampered.db")
-	a, err := db.OpenArtifact(path, metaFor(testEmbedder), "/real/lib")
+	a, err := db.OpenArtifact(path, metaFor(testEmbedder), "/real/lib", "")
 	if err != nil {
 		t.Fatalf("OpenArtifact: %v", err)
 	}
 	a.Close()
 
-	_, err = db.OpenArtifact(path, metaFor(testEmbedder), "/wrong/lib")
+	_, err = db.OpenArtifact(path, metaFor(testEmbedder), "/wrong/lib", "")
 	if err == nil {
 		t.Fatal("expected ErrArtifactLibIDMismatch, got nil")
+	}
+	if !errors.Is(err, db.ErrArtifactLibIDMismatch) {
+		t.Errorf("expected ErrArtifactLibIDMismatch, got %v", err)
+	}
+}
+
+// TestOpenArtifact_RejectsVersionMismatch catches the failure mode
+// where a (lib_id, v1.14) artifact gets misaddressed as (lib_id,
+// v1.13) by a buggy caller — without this check the two versions
+// would quietly collide in main.
+func TestOpenArtifact_RejectsVersionMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tampered_v.db")
+	a, err := db.OpenArtifact(path, metaFor(testEmbedder), "/hashicorp/terraform", "v1.14")
+	if err != nil {
+		t.Fatalf("OpenArtifact: %v", err)
+	}
+	a.Close()
+
+	_, err = db.OpenArtifact(path, metaFor(testEmbedder), "/hashicorp/terraform", "v1.13")
+	if err == nil {
+		t.Fatal("expected ErrArtifactLibIDMismatch (on version drift), got nil")
 	}
 	if !errors.Is(err, db.ErrArtifactLibIDMismatch) {
 		t.Errorf("expected ErrArtifactLibIDMismatch, got %v", err)
@@ -122,7 +178,7 @@ func TestOpenArtifact_RejectsLibIDMismatch(t *testing.T) {
 func TestOpenArtifact_DiscoverModeRequiresExistingFile(t *testing.T) {
 	// libID="" against a non-existent file must NOT create a stub.
 	path := filepath.Join(t.TempDir(), "ghost.db")
-	_, err := db.OpenArtifact(path, metaFor(testEmbedder), "")
+	_, err := db.OpenArtifact(path, metaFor(testEmbedder), "", "")
 	if err == nil {
 		t.Fatal("expected error opening missing artifact in discover mode, got nil")
 	}
@@ -144,7 +200,7 @@ func TestOpenArtifact_DiscoverModeOnMainDBFails(t *testing.T) {
 	}
 	d.Close()
 
-	_, err = db.OpenArtifact(path, metaFor(testEmbedder), "")
+	_, err = db.OpenArtifact(path, metaFor(testEmbedder), "", "")
 	if err == nil {
 		t.Fatal("expected ErrArtifactLibIDMissing, got nil")
 	}
@@ -189,10 +245,10 @@ func TestConsolidate_MergesMultipleArtifacts(t *testing.T) {
 	// Two artifacts, one doc each, distinct lib_ids. Each artifact
 	// is its own .db file, isolated from the others — exactly what
 	// the per-lib refactor promises.
-	makeArtifact(t, artifactsDir, "/a/one", []db.Doc{
+	makeArtifact(t, artifactsDir, "/a/one", "", []db.Doc{
 		{LibID: "/a/one", Title: "alpha", Content: "doc a"},
 	})
-	makeArtifact(t, artifactsDir, "/b/two", []db.Doc{
+	makeArtifact(t, artifactsDir, "/b/two", "", []db.Doc{
 		{LibID: "/b/two", Title: "beta", Content: "doc b"},
 	})
 
@@ -228,7 +284,7 @@ func TestConsolidate_ReplacesExistingLibInMain(t *testing.T) {
 	artifactsDir := filepath.Join(tmp, "artifacts")
 
 	// First scrape: artifact with two docs.
-	v1Path := makeArtifact(t, artifactsDir, "/x/y", []db.Doc{
+	v1Path := makeArtifact(t, artifactsDir, "/x/y", "", []db.Doc{
 		{LibID: "/x/y", Title: "v1 first", Content: "older content"},
 		{LibID: "/x/y", Title: "v1 second", Content: "older content"},
 	})
@@ -250,7 +306,7 @@ func TestConsolidate_ReplacesExistingLibInMain(t *testing.T) {
 	if err := os.Remove(v1Path); err != nil {
 		t.Fatalf("remove v1 artifact: %v", err)
 	}
-	makeArtifact(t, artifactsDir, "/x/y", []db.Doc{
+	makeArtifact(t, artifactsDir, "/x/y", "", []db.Doc{
 		{LibID: "/x/y", Title: "v2 only", Content: "newer content"},
 	})
 
@@ -284,10 +340,10 @@ func TestConsolidate_EmbedderMismatchLeavesMainUnchanged(t *testing.T) {
 	// later so it would otherwise be merged second; if the merge
 	// loop were not transactional, the first iteration would commit
 	// before the second one detected the mismatch.
-	makeArtifact(t, artifactsDir, "/aaa/healthy", []db.Doc{
+	makeArtifact(t, artifactsDir, "/aaa/healthy", "", []db.Doc{
 		{LibID: "/aaa/healthy", Title: "ok", Content: "fine"},
 	})
-	tampered := makeArtifact(t, artifactsDir, "/zzz/bad", []db.Doc{
+	tampered := makeArtifact(t, artifactsDir, "/zzz/bad", "", []db.Doc{
 		{LibID: "/zzz/bad", Title: "bad", Content: "doomed"},
 	})
 	// Sneak through the driver to corrupt only the embedder_kind
@@ -308,7 +364,7 @@ func TestConsolidate_EmbedderMismatchLeavesMainUnchanged(t *testing.T) {
 	if err := db.Insert(main, seed, embedText(t, testEmbedder, seed)); err != nil {
 		t.Fatalf("Insert seed: %v", err)
 	}
-	if err := db.UpsertLibIfNew(main, "/seed/lib", testEmbedder); err != nil {
+	if err := db.UpsertLibIfNew(main, "/seed/lib", "", testEmbedder); err != nil {
 		t.Fatalf("UpsertLibIfNew seed: %v", err)
 	}
 
@@ -344,7 +400,7 @@ func TestConsolidate_SchemaMismatchLeavesMainUnchanged(t *testing.T) {
 	// Build a real artifact then drop the schema_version row to
 	// fake a pre-libs (v0) artifact. Open() reads the missing key
 	// as 0, which never matches CurrentSchemaVersion.
-	path := makeArtifact(t, artifactsDir, "/old/lib", []db.Doc{
+	path := makeArtifact(t, artifactsDir, "/old/lib", "", []db.Doc{
 		{LibID: "/old/lib", Title: "x", Content: "x"},
 	})
 	dropSchemaVersion(t, path)
@@ -370,6 +426,76 @@ func TestConsolidate_SchemaMismatchLeavesMainUnchanged(t *testing.T) {
 	}
 	if docCount != 0 {
 		t.Errorf("docs = %d, want 0 (main should be untouched)", docCount)
+	}
+}
+
+// TestConsolidate_MergesMultipleVersionsOfSameLib is the load-bearing
+// assertion behind #113's "artifacts keyed on (lib_id, version)"
+// promise: two artifacts advertising the same lib_id but different
+// versions must merge cleanly as two distinct (lib_id, version) rows
+// in main, without either DELETE clobbering the other's data.
+func TestConsolidate_MergesMultipleVersionsOfSameLib(t *testing.T) {
+	tmp := t.TempDir()
+	artifactsDir := filepath.Join(tmp, "artifacts")
+
+	makeArtifact(t, artifactsDir, "/hashicorp/terraform", "v1.14", []db.Doc{
+		{LibID: "/hashicorp/terraform", Title: "tf v1.14 intro", Content: "new stuff"},
+	})
+	makeArtifact(t, artifactsDir, "/hashicorp/terraform", "v1.13", []db.Doc{
+		{LibID: "/hashicorp/terraform", Title: "tf v1.13 intro", Content: "older stuff"},
+	})
+
+	mainPath := filepath.Join(tmp, "main.db")
+	main, err := db.Open(mainPath, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("Open main: %v", err)
+	}
+	defer main.Close()
+
+	result, err := db.Consolidate(main, artifactsDir)
+	if err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	if result.Artifacts != 2 || result.DocsMerged != 2 || result.LibsMerged != 2 {
+		t.Errorf("got %+v, want {2,2,2}", result)
+	}
+
+	// Both libs rows present, same lib_id, different versions.
+	rows, err := main.Query(`SELECT lib_id, version FROM libs ORDER BY version DESC`)
+	if err != nil {
+		t.Fatalf("select libs: %v", err)
+	}
+	defer rows.Close()
+	type pair struct{ lib, ver string }
+	var got []pair
+	for rows.Next() {
+		var p pair
+		if err := rows.Scan(&p.lib, &p.ver); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, p)
+	}
+	want := []pair{
+		{"/hashicorp/terraform", "v1.14"},
+		{"/hashicorp/terraform", "v1.13"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d libs rows, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("row %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	// And both docs are preserved, not collapsed: the DELETE keyed on
+	// (lib_id, version) must not have wiped the sibling version's doc.
+	var docCount int
+	if err := main.QueryRow(`SELECT count(*) FROM docs WHERE lib_id = ?`, "/hashicorp/terraform").Scan(&docCount); err != nil {
+		t.Fatalf("count docs: %v", err)
+	}
+	if docCount != 2 {
+		t.Errorf("doc count for terraform (both versions) = %d, want 2", docCount)
 	}
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -56,7 +56,7 @@ var ErrArtifactLibIDMismatch = errors.New("artifact lib_id mismatch")
 // compatible way (e.g. a new required table like libs). Stored in the
 // meta table at first Open and cross-checked on every subsequent open
 // against this constant; a mismatch surfaces as ErrSchemaMismatch.
-const CurrentSchemaVersion = 3
+const CurrentSchemaVersion = 4
 
 // Meta describes the embedder a database was created with. It is written
 // to the meta table the first time a fresh DB is opened and cross-checked
@@ -76,19 +76,29 @@ type Meta struct {
 // re-reading the meta table on every call. *sql.DB is embedded so callers
 // can still use QueryRow, Exec, Close, etc. directly on a *DB.
 //
-// ArtifactLibID is populated only when the database was opened via
-// OpenArtifact. It is the canonical lib_id this artifact carries (read
-// from the meta table at open time). The main consolidated database
-// always leaves it empty — the libs table is the source of truth there.
+// ArtifactLibID / ArtifactVersion are populated only when the database
+// was opened via OpenArtifact. Together they form the canonical
+// (lib_id, version) slot this artifact carries (read from the meta
+// table at open time). ArtifactVersion is "" for single-version libs,
+// matching the on-wire canonical form. The main consolidated database
+// always leaves both empty — the libs table is the source of truth
+// there.
 type DB struct {
 	*sql.DB
-	Meta          Meta
-	ArtifactLibID string
+	Meta            Meta
+	ArtifactLibID   string
+	ArtifactVersion string
 }
 
 // Doc represents a documentation snippet stored in the docs table.
+//
+// Version is the canonical form for single-version libs: empty string,
+// not NULL. Multi-version libs pass the version tag as recorded in the
+// registry (e.g. "v1.14"). LibID always carries the base lib_id — the
+// "/base/version" concat that earlier builds emitted is gone.
 type Doc struct {
 	LibID   string
+	Version string
 	Title   string
 	Content string
 }
@@ -166,6 +176,7 @@ func Open(path string, meta Meta) (*DB, error) {
 	docsSchema := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS docs (
 		id INTEGER PRIMARY KEY,
 		lib_id TEXT NOT NULL,
+		version TEXT NOT NULL DEFAULT '',
 		title TEXT NOT NULL,
 		content TEXT NOT NULL,
 		embedding F32_BLOB(%d) NOT NULL
@@ -185,9 +196,11 @@ func Open(path string, meta Meta) (*DB, error) {
 	// docs table for the same reason — both columns have to be openable
 	// by the same Embedder, which the meta cross-check above guarantees.
 	libsSchema := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS libs (
-		lib_id    TEXT PRIMARY KEY,
+		lib_id    TEXT NOT NULL,
+		version   TEXT NOT NULL DEFAULT '',
 		doc_count INTEGER NOT NULL DEFAULT 0,
-		embedding F32_BLOB(%d) NOT NULL
+		embedding F32_BLOB(%d) NOT NULL,
+		PRIMARY KEY (lib_id, version)
 	)`, meta.EmbeddingDim)
 	if _, err := raw.Exec(libsSchema); err != nil {
 		raw.Close()
@@ -201,28 +214,33 @@ func Open(path string, meta Meta) (*DB, error) {
 	return &DB{DB: raw, Meta: meta}, nil
 }
 
-// OpenArtifact opens (or creates) a per-lib artifact database. An
-// artifact carries a single lib_id recorded in its meta table; the
-// recorded value is the source of truth for which library the
-// artifact's docs and libs rows belong to.
+// OpenArtifact opens (or creates) a per-(lib_id, version) artifact
+// database. An artifact carries a single (lib_id, version) pair
+// recorded in its meta table; the recorded values are the source of
+// truth for which library slot the artifact's docs and libs rows
+// belong to.
 //
-// libID semantics:
+// (libID, version) semantics:
 //
-//   - libID != "" — the caller knows which lib this artifact represents
-//     (e.g. the scraper). On a fresh file the lib_id is written. On an
-//     existing file the stored lib_id must match libID, otherwise
-//     ErrArtifactLibIDMismatch is returned.
+//   - libID != "" — the caller knows which (lib_id, version) slot this
+//     artifact represents (e.g. the scraper). On a fresh file the pair
+//     is written. On an existing file both values must match the
+//     stored ones, otherwise ErrArtifactLibIDMismatch is returned.
+//     Version may be "" for single-version libs — that is the
+//     canonical form.
 //
 //   - libID == "" — the caller is reading an existing artifact and
-//     wants to discover its lib_id (e.g. consolidate). The file must
-//     already exist; if it doesn't, an os.ErrNotExist-wrapped error
-//     is returned without creating a stub. If the file exists but has
-//     no lib_id stored, ErrArtifactLibIDMissing is returned.
+//     wants to discover its (lib_id, version) (e.g. consolidate).
+//     Version must also be "" in this mode; it is populated from the
+//     stored meta. The file must already exist; if it doesn't, an
+//     os.ErrNotExist-wrapped error is returned without creating a
+//     stub. If the file exists but has no lib_id stored,
+//     ErrArtifactLibIDMissing is returned.
 //
 // Embedder meta and schema version validation are inherited from Open
 // — an artifact built with a different embedder than the caller's
 // surfaces as ErrEmbedderMismatch, exactly like the main DB.
-func OpenArtifact(path string, meta Meta, libID string) (*DB, error) {
+func OpenArtifact(path string, meta Meta, libID, version string) (*DB, error) {
 	// Refuse to fabricate a stub file when the caller is in
 	// "read existing artifact" mode. Lets the consolidate path
 	// distinguish "no such file" from "file exists but is malformed"
@@ -243,26 +261,42 @@ func OpenArtifact(path string, meta Meta, libID string) (*DB, error) {
 		d.Close()
 		return nil, fmt.Errorf("open artifact %s: read lib_id: %w", path, err)
 	}
+	storedVersion, _, err := readArtifactVersion(d.DB)
+	if err != nil {
+		d.Close()
+		return nil, fmt.Errorf("open artifact %s: read version: %w", path, err)
+	}
 
 	switch {
 	case libID != "" && hasStored:
 		if stored != libID {
 			d.Close()
-			return nil, fmt.Errorf("%w: stored=%q requested=%q (file=%s)",
+			return nil, fmt.Errorf("%w: stored lib_id=%q requested=%q (file=%s)",
 				ErrArtifactLibIDMismatch, stored, libID, path)
+		}
+		if storedVersion != version {
+			d.Close()
+			return nil, fmt.Errorf("%w: stored version=%q requested=%q (file=%s, lib_id=%s)",
+				ErrArtifactLibIDMismatch, storedVersion, version, path, libID)
 		}
 	case libID != "" && !hasStored:
 		if err := writeArtifactLibID(d.DB, libID); err != nil {
 			d.Close()
 			return nil, fmt.Errorf("open artifact %s: write lib_id: %w", path, err)
 		}
+		if err := writeArtifactVersion(d.DB, version); err != nil {
+			d.Close()
+			return nil, fmt.Errorf("open artifact %s: write version: %w", path, err)
+		}
 		stored = libID
+		storedVersion = version
 	case libID == "" && !hasStored:
 		d.Close()
 		return nil, fmt.Errorf("%w: %s", ErrArtifactLibIDMissing, path)
 	}
 
 	d.ArtifactLibID = stored
+	d.ArtifactVersion = storedVersion
 	return d, nil
 }
 
@@ -292,6 +326,32 @@ func writeArtifactLibID(raw *sql.DB, libID string) error {
 	return err
 }
 
+// readArtifactVersion returns the version meta value if present. A
+// missing row returns ("", false, nil) — older artifacts that
+// predate #113 never wrote this key and we want them to surface as
+// ErrSchemaMismatch at Open, not here.
+func readArtifactVersion(raw *sql.DB) (string, bool, error) {
+	var v string
+	err := raw.QueryRow(`SELECT value FROM meta WHERE key = ?`, metaKeyVersion).Scan(&v)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return v, true, nil
+}
+
+// writeArtifactVersion inserts the version meta row. Like
+// writeArtifactLibID, the caller guarantees the row does not already
+// exist. Empty string is the canonical single-version form and is
+// written verbatim so round-tripping the value preserves the
+// distinction between "single-version lib" and "never wrote version".
+func writeArtifactVersion(raw *sql.DB, version string) error {
+	_, err := raw.Exec(`INSERT INTO meta(key, value) VALUES (?, ?)`, metaKeyVersion, version)
+	return err
+}
+
 // Insert stores a Doc along with its precomputed embedding. The embedding
 // must have exactly db.Meta.EmbeddingDim components — the dimension travels
 // with the *DB rather than being a package-level constant so a single
@@ -301,8 +361,8 @@ func Insert(db *DB, doc Doc, embedding []float32) error {
 		return fmt.Errorf("insert doc: embedding length %d, want %d", len(embedding), db.Meta.EmbeddingDim)
 	}
 	_, err := db.Exec(
-		`INSERT INTO docs(lib_id, title, content, embedding) VALUES (?, ?, ?, vector(?))`,
-		doc.LibID, doc.Title, doc.Content, formatVector(embedding),
+		`INSERT INTO docs(lib_id, version, title, content, embedding) VALUES (?, ?, ?, ?, vector(?))`,
+		doc.LibID, doc.Version, doc.Title, doc.Content, formatVector(embedding),
 	)
 	if err != nil {
 		return fmt.Errorf("insert doc: %w", err)
@@ -311,10 +371,21 @@ func Insert(db *DB, doc Doc, embedding []float32) error {
 }
 
 // SearchByEmbedding returns the top-k Docs ranked by cosine distance to
-// queryVec (lower = more similar). If libID is non-empty, results are
-// filtered to that library. k defaults to 10 if <= 0. The query vector
-// must have db.Meta.EmbeddingDim components.
-func SearchByEmbedding(db *DB, queryVec []float32, libID string, k int) ([]Doc, error) {
+// queryVec (lower = more similar). k defaults to 10 if <= 0. The query
+// vector must have db.Meta.EmbeddingDim components.
+//
+// The (libID, version) filter is three-valued:
+//
+//   - libID == ""                        — no filter (version is ignored).
+//   - libID != "" and version == ""      — match every indexed version of
+//     the lib (WHERE lib_id = ?). The single-version case is the same query
+//     since those rows carry version = "".
+//   - libID != "" and version != ""      — pin to a specific version
+//     (WHERE lib_id = ? AND version = ?).
+//
+// Passing version without libID is a usage error at the MCP tool layer;
+// this function does not enforce it so unit tests stay small.
+func SearchByEmbedding(db *DB, queryVec []float32, libID, version string, k int) ([]Doc, error) {
 	if len(queryVec) != db.Meta.EmbeddingDim {
 		return nil, fmt.Errorf("search: query vector length %d, want %d", len(queryVec), db.Meta.EmbeddingDim)
 	}
@@ -328,22 +399,32 @@ func SearchByEmbedding(db *DB, queryVec []float32, libID string, k int) ([]Doc, 
 		rows *sql.Rows
 		err  error
 	)
-	if libID != "" {
+	switch {
+	case libID == "":
 		rows, err = db.Query(
-			`SELECT lib_id, title, content
+			`SELECT lib_id, version, title, content
+			 FROM docs
+			 ORDER BY vector_distance_cos(embedding, vector(?)) ASC
+			 LIMIT ?`,
+			q, k,
+		)
+	case version == "":
+		rows, err = db.Query(
+			`SELECT lib_id, version, title, content
 			 FROM docs
 			 WHERE lib_id = ?
 			 ORDER BY vector_distance_cos(embedding, vector(?)) ASC
 			 LIMIT ?`,
 			libID, q, k,
 		)
-	} else {
+	default:
 		rows, err = db.Query(
-			`SELECT lib_id, title, content
+			`SELECT lib_id, version, title, content
 			 FROM docs
+			 WHERE lib_id = ? AND version = ?
 			 ORDER BY vector_distance_cos(embedding, vector(?)) ASC
 			 LIMIT ?`,
-			q, k,
+			libID, version, q, k,
 		)
 	}
 	if err != nil {
@@ -354,7 +435,7 @@ func SearchByEmbedding(db *DB, queryVec []float32, libID string, k int) ([]Doc, 
 	var results []Doc
 	for rows.Next() {
 		var d Doc
-		if err := rows.Scan(&d.LibID, &d.Title, &d.Content); err != nil {
+		if err := rows.Scan(&d.LibID, &d.Version, &d.Title, &d.Content); err != nil {
 			return nil, fmt.Errorf("scan: %w", err)
 		}
 		results = append(results, d)
@@ -386,63 +467,74 @@ type LibEmbedder interface {
 // fills it in from vector_distance_cos.
 type LibInfo struct {
 	LibID    string
+	Version  string
 	DocCount int
 	Distance float32
 }
 
-// UpsertLibIfNew inserts a row into the libs table for libID iff one
-// doesn't already exist. The embedding is computed from the lib_id text
-// itself with "/" and "-" turned into spaces so the encoder sees something
-// resembling natural language ("/hashicorp/terraform-provider-aws" →
-// "hashicorp terraform provider aws"). The lib_id is the primary key
-// and the embedding is immutable for the lifetime of the database, so
-// re-running this function for an existing lib is a fast no-op that
-// does NOT call EmbedDocument — the issue's "at most one Embed call per
-// lib per database" guarantee is enforced here, and verified by tests
-// that count the call against a wrapping LibEmbedder.
-func UpsertLibIfNew(d *DB, libID string, e LibEmbedder) error {
+// UpsertLibIfNew inserts a row into the libs table for (libID, version)
+// iff one doesn't already exist. The embedding is computed from the
+// lib_id text alone with "/" and "-" turned into spaces so the encoder
+// sees something resembling natural language
+// ("/hashicorp/terraform-provider-aws" → "hashicorp terraform provider
+// aws"). Version is intentionally NOT mixed into the embed text:
+// multiple versions of the same lib should rank identically against a
+// free-text library-name query, so the embedding stays keyed on the
+// base identity while the row's (lib_id, version) primary key keeps
+// the versions distinct on disk.
+//
+// Re-running this function for an existing (lib_id, version) pair is a
+// fast no-op that does NOT call EmbedDocument — the issue's "at most
+// one Embed call per (lib, version) per database" guarantee is
+// enforced here and verified by tests that count the call against a
+// wrapping LibEmbedder.
+//
+// Version is the canonical empty string for single-version libs; the
+// primary key is on (lib_id, version) so the same base lib with two
+// versions cleanly produces two rows.
+func UpsertLibIfNew(d *DB, libID, version string, e LibEmbedder) error {
 	if libID == "" {
 		return errors.New("upsert lib: libID must not be empty")
 	}
 	var existing int
-	if err := d.QueryRow(`SELECT count(*) FROM libs WHERE lib_id = ?`, libID).Scan(&existing); err != nil {
-		return fmt.Errorf("upsert lib %q: check exists: %w", libID, err)
+	if err := d.QueryRow(`SELECT count(*) FROM libs WHERE lib_id = ? AND version = ?`, libID, version).Scan(&existing); err != nil {
+		return fmt.Errorf("upsert lib %q version %q: check exists: %w", libID, version, err)
 	}
 	if existing > 0 {
 		return nil
 	}
 	vec, err := e.EmbedDocument(normalizeLibIDText(libID))
 	if err != nil {
-		return fmt.Errorf("upsert lib %q: embed: %w", libID, err)
+		return fmt.Errorf("upsert lib %q version %q: embed: %w", libID, version, err)
 	}
 	if len(vec) != d.Meta.EmbeddingDim {
-		return fmt.Errorf("upsert lib %q: embedding length %d, want %d", libID, len(vec), d.Meta.EmbeddingDim)
+		return fmt.Errorf("upsert lib %q version %q: embedding length %d, want %d", libID, version, len(vec), d.Meta.EmbeddingDim)
 	}
 	if _, err := d.Exec(
-		`INSERT INTO libs (lib_id, doc_count, embedding) VALUES (?, 0, vector(?))`,
-		libID, formatVector(vec),
+		`INSERT INTO libs (lib_id, version, doc_count, embedding) VALUES (?, ?, 0, vector(?))`,
+		libID, version, formatVector(vec),
 	); err != nil {
-		return fmt.Errorf("upsert lib %q: insert: %w", libID, err)
+		return fmt.Errorf("upsert lib %q version %q: insert: %w", libID, version, err)
 	}
 	return nil
 }
 
-// UpdateLibCount sets the doc_count for an existing libs row. The
-// scraper calls this once per lib at the end of a run with the actual
-// number of docs that were inserted, so search_libraries can surface
-// "how well-indexed is this lib" without recounting on every query.
-// Updating a row that does not exist is silently a no-op (zero rows
-// affected) — the scraper is responsible for calling UpsertLibIfNew
-// first.
-func UpdateLibCount(d *DB, libID string, count int) error {
+// UpdateLibCount sets the doc_count for an existing libs row keyed on
+// (libID, version). The scraper calls this once per lib at the end of
+// a run with the actual number of docs that were inserted, so
+// search_libraries can surface "how well-indexed is this lib" without
+// recounting on every query. Updating a row that does not exist is
+// silently a no-op (zero rows affected) — the scraper is responsible
+// for calling UpsertLibIfNew first.
+func UpdateLibCount(d *DB, libID, version string, count int) error {
 	if libID == "" {
 		return errors.New("update lib count: libID must not be empty")
 	}
 	if count < 0 {
 		return fmt.Errorf("update lib count: count must be >= 0, got %d", count)
 	}
-	if _, err := d.Exec(`UPDATE libs SET doc_count = ? WHERE lib_id = ?`, count, libID); err != nil {
-		return fmt.Errorf("update lib count %q: %w", libID, err)
+	if _, err := d.Exec(`UPDATE libs SET doc_count = ? WHERE lib_id = ? AND version = ?`, count, libID, version); err != nil {
+		return fmt.Errorf("update lib count %q version %q: %w", libID, version, err)
 	}
 	return nil
 }
@@ -461,10 +553,13 @@ func SearchLibsByEmbedding(d *DB, queryVec []float32, limit int) ([]LibInfo, err
 	if limit <= 0 {
 		limit = 10
 	}
+	// Tie-break on lib_id then version so the same base lib's versions
+	// return in a deterministic order when they score identically
+	// (which they always do — the embedding doesn't include version).
 	rows, err := d.Query(
-		`SELECT lib_id, doc_count, vector_distance_cos(embedding, vector(?)) AS dist
+		`SELECT lib_id, version, doc_count, vector_distance_cos(embedding, vector(?)) AS dist
 		 FROM libs
-		 ORDER BY dist ASC, doc_count DESC
+		 ORDER BY dist ASC, doc_count DESC, lib_id ASC, version ASC
 		 LIMIT ?`,
 		formatVector(queryVec), limit,
 	)
@@ -482,7 +577,7 @@ func SearchLibsByEmbedding(d *DB, queryVec []float32, limit int) ([]LibInfo, err
 			// (database/sql's Scan doesn't bind directly to *float32).
 			dist float64
 		)
-		if err := rows.Scan(&info.LibID, &info.DocCount, &dist); err != nil {
+		if err := rows.Scan(&info.LibID, &info.Version, &info.DocCount, &dist); err != nil {
 			return nil, fmt.Errorf("search libs: scan: %w", err)
 		}
 		info.Distance = float32(dist)
@@ -502,7 +597,10 @@ func TopLibsByDocCount(d *DB, limit int) ([]LibInfo, error) {
 		limit = 10
 	}
 	rows, err := d.Query(
-		`SELECT lib_id, doc_count FROM libs ORDER BY doc_count DESC LIMIT ?`,
+		`SELECT lib_id, version, doc_count
+		 FROM libs
+		 ORDER BY doc_count DESC, lib_id ASC, version ASC
+		 LIMIT ?`,
 		limit,
 	)
 	if err != nil {
@@ -513,7 +611,7 @@ func TopLibsByDocCount(d *DB, limit int) ([]LibInfo, error) {
 	results := make([]LibInfo, 0, limit)
 	for rows.Next() {
 		var info LibInfo
-		if err := rows.Scan(&info.LibID, &info.DocCount); err != nil {
+		if err := rows.Scan(&info.LibID, &info.Version, &info.DocCount); err != nil {
 			return nil, fmt.Errorf("top libs: scan: %w", err)
 		}
 		results = append(results, info)
@@ -546,6 +644,11 @@ const (
 	// ignores any meta keys it does not recognize, so adding this key
 	// is backwards-compatible with the existing schema version.
 	metaKeyLibID = "lib_id"
+	// metaKeyVersion is the per-artifact version tag. Same lifecycle
+	// as metaKeyLibID: written once at OpenArtifact time, absent from
+	// the main consolidated DB. Empty string is the canonical
+	// single-version form and is persisted as such.
+	metaKeyVersion = "version"
 )
 
 func validateMeta(m Meta) error {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -140,7 +140,7 @@ func TestSearchByEmbedding_RanksRelevantFirst(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Embed query: %v", err)
 	}
-	results, err := db.SearchByEmbedding(d, qv, "", 10)
+	results, err := db.SearchByEmbedding(d, qv, "", "", 10)
 	if err != nil {
 		t.Fatalf("SearchByEmbedding: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestSearchByEmbedding_FiltersByLib(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Embed query: %v", err)
 	}
-	results, err := db.SearchByEmbedding(d, qv, "go-sdk", 10)
+	results, err := db.SearchByEmbedding(d, qv, "go-sdk", "", 10)
 	if err != nil {
 		t.Fatalf("SearchByEmbedding: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestSearchByEmbedding_Acceptance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Embed query: %v", err)
 	}
-	results, err := db.SearchByEmbedding(d, qv, "", 10)
+	results, err := db.SearchByEmbedding(d, qv, "", "", 10)
 	if err != nil {
 		t.Fatalf("SearchByEmbedding: %v", err)
 	}
@@ -220,6 +220,78 @@ func TestSearchByEmbedding_Acceptance(t *testing.T) {
 		for i, r := range results {
 			t.Logf("  #%d: [%s] %s", i+1, r.LibID, r.Title)
 		}
+	}
+}
+
+// TestSearchByEmbedding_FiltersByLibAllVersions seeds one lib_id
+// with two versions and asserts that the lib-scoped search
+// (version == "") surfaces both versions' rows.
+func TestSearchByEmbedding_FiltersByLibAllVersions(t *testing.T) {
+	d := openTestDB(t)
+
+	docs := []db.Doc{
+		{LibID: "/foo/tf", Version: "v1.14", Title: "tf install", Content: "install in v1.14"},
+		{LibID: "/foo/tf", Version: "v1.13", Title: "tf install", Content: "install in v1.13"},
+		{LibID: "/other/lib", Version: "", Title: "unrelated", Content: "noise"},
+	}
+	for _, doc := range docs {
+		if err := db.Insert(d, doc, embedText(t, testEmbedder, doc)); err != nil {
+			t.Fatalf("Insert: %v", err)
+		}
+	}
+
+	qv, err := testEmbedder.EmbedQuery("install")
+	if err != nil {
+		t.Fatalf("Embed query: %v", err)
+	}
+	results, err := db.SearchByEmbedding(d, qv, "/foo/tf", "", 10)
+	if err != nil {
+		t.Fatalf("SearchByEmbedding: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	seen := map[string]bool{}
+	for _, r := range results {
+		if r.LibID != "/foo/tf" {
+			t.Errorf("filter leaked: LibID = %q", r.LibID)
+		}
+		seen[r.Version] = true
+	}
+	if !seen["v1.14"] || !seen["v1.13"] {
+		t.Errorf("expected both versions, got %v", seen)
+	}
+}
+
+// TestSearchByEmbedding_FiltersByLibAndVersion pins the two-arg
+// filter path: when both lib and version are supplied, only the
+// matching (lib_id, version) rows come back.
+func TestSearchByEmbedding_FiltersByLibAndVersion(t *testing.T) {
+	d := openTestDB(t)
+
+	docs := []db.Doc{
+		{LibID: "/foo/tf", Version: "v1.14", Title: "tf install", Content: "install in v1.14"},
+		{LibID: "/foo/tf", Version: "v1.13", Title: "tf install", Content: "install in v1.13"},
+	}
+	for _, doc := range docs {
+		if err := db.Insert(d, doc, embedText(t, testEmbedder, doc)); err != nil {
+			t.Fatalf("Insert: %v", err)
+		}
+	}
+
+	qv, err := testEmbedder.EmbedQuery("install")
+	if err != nil {
+		t.Fatalf("Embed query: %v", err)
+	}
+	results, err := db.SearchByEmbedding(d, qv, "/foo/tf", "v1.14", 10)
+	if err != nil {
+		t.Fatalf("SearchByEmbedding: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1 (v1.14 only)", len(results))
+	}
+	if results[0].Version != "v1.14" {
+		t.Errorf("Version = %q, want v1.14", results[0].Version)
 	}
 }
 
@@ -331,14 +403,14 @@ func TestUpsertLibIfNew_Idempotent(t *testing.T) {
 	d := openTestDB(t)
 	c := &countingEmbedder{inner: testEmbedder}
 
-	if err := db.UpsertLibIfNew(d, "/facebook/react", c); err != nil {
+	if err := db.UpsertLibIfNew(d, "/facebook/react", "", c); err != nil {
 		t.Fatalf("first UpsertLibIfNew: %v", err)
 	}
 	if c.calls != 1 {
 		t.Fatalf("after first upsert: Embed called %d time(s), want 1", c.calls)
 	}
 
-	if err := db.UpsertLibIfNew(d, "/facebook/react", c); err != nil {
+	if err := db.UpsertLibIfNew(d, "/facebook/react", "", c); err != nil {
 		t.Fatalf("second UpsertLibIfNew: %v", err)
 	}
 	if c.calls != 1 {
@@ -348,11 +420,48 @@ func TestUpsertLibIfNew_Idempotent(t *testing.T) {
 	// And a sanity check: a *different* lib_id does trigger a fresh Embed
 	// call. This catches the failure mode where UpsertLibIfNew gets
 	// over-eager and short-circuits on any non-empty libs table.
-	if err := db.UpsertLibIfNew(d, "/vercel/next.js", c); err != nil {
+	if err := db.UpsertLibIfNew(d, "/vercel/next.js", "", c); err != nil {
 		t.Fatalf("upsert second lib: %v", err)
 	}
 	if c.calls != 2 {
 		t.Errorf("after upserting a second lib: Embed called %d time(s), want 2", c.calls)
+	}
+}
+
+// TestUpsertLibIfNew_AllowsSameLibDifferentVersion pins the #113
+// "(lib_id, version) is the primary key" promise: two rows with the
+// same lib_id and different versions must coexist, and each pair
+// gets exactly one EmbedDocument call.
+func TestUpsertLibIfNew_AllowsSameLibDifferentVersion(t *testing.T) {
+	d := openTestDB(t)
+	c := &countingEmbedder{inner: testEmbedder}
+
+	if err := db.UpsertLibIfNew(d, "/hashicorp/terraform", "v1.14", c); err != nil {
+		t.Fatalf("upsert v1.14: %v", err)
+	}
+	if err := db.UpsertLibIfNew(d, "/hashicorp/terraform", "v1.13", c); err != nil {
+		t.Fatalf("upsert v1.13: %v", err)
+	}
+	// Two distinct (lib_id, version) pairs → two embed calls.
+	if c.calls != 2 {
+		t.Errorf("Embed called %d time(s), want 2 (one per version)", c.calls)
+	}
+
+	var count int
+	if err := d.QueryRow(`SELECT count(*) FROM libs WHERE lib_id = ?`, "/hashicorp/terraform").Scan(&count); err != nil {
+		t.Fatalf("count libs: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("libs rows for /hashicorp/terraform = %d, want 2", count)
+	}
+
+	// And the re-upsert of an existing pair is still idempotent (no
+	// extra embed call).
+	if err := db.UpsertLibIfNew(d, "/hashicorp/terraform", "v1.14", c); err != nil {
+		t.Fatalf("re-upsert v1.14: %v", err)
+	}
+	if c.calls != 2 {
+		t.Errorf("after re-upsert: Embed called %d time(s), want 2", c.calls)
 	}
 }
 
@@ -364,12 +473,12 @@ func TestUpdateLibCount_UpdatesRightRow(t *testing.T) {
 	d := openTestDB(t)
 
 	for _, libID := range []string{"/a/one", "/b/two"} {
-		if err := db.UpsertLibIfNew(d, libID, testEmbedder); err != nil {
+		if err := db.UpsertLibIfNew(d, libID, "", testEmbedder); err != nil {
 			t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
 		}
 	}
 
-	if err := db.UpdateLibCount(d, "/a/one", 42); err != nil {
+	if err := db.UpdateLibCount(d, "/a/one", "", 42); err != nil {
 		t.Fatalf("UpdateLibCount: %v", err)
 	}
 
@@ -407,7 +516,7 @@ func TestSearchLibsByEmbedding_RanksRelevantFirst(t *testing.T) {
 		"/expressjs/express",
 	}
 	for _, libID := range libs {
-		if err := db.UpsertLibIfNew(d, libID, testEmbedder); err != nil {
+		if err := db.UpsertLibIfNew(d, libID, "", testEmbedder); err != nil {
 			t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
 		}
 	}
@@ -439,7 +548,7 @@ func TestSearchLibsByEmbedding_HonoursLimit(t *testing.T) {
 	d := openTestDB(t)
 
 	for _, libID := range []string{"/a/one", "/b/two", "/c/three"} {
-		if err := db.UpsertLibIfNew(d, libID, testEmbedder); err != nil {
+		if err := db.UpsertLibIfNew(d, libID, "", testEmbedder); err != nil {
 			t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
 		}
 	}
@@ -474,10 +583,10 @@ func TestTopLibsByDocCount_OrdersDescending(t *testing.T) {
 		{"/medium/lib", 25},
 	}
 	for _, l := range libs {
-		if err := db.UpsertLibIfNew(d, l.id, testEmbedder); err != nil {
+		if err := db.UpsertLibIfNew(d, l.id, "", testEmbedder); err != nil {
 			t.Fatalf("UpsertLibIfNew %q: %v", l.id, err)
 		}
-		if err := db.UpdateLibCount(d, l.id, l.count); err != nil {
+		if err := db.UpdateLibCount(d, l.id, "", l.count); err != nil {
 			t.Fatalf("UpdateLibCount %q: %v", l.id, err)
 		}
 	}

--- a/internal/packs/paths.go
+++ b/internal/packs/paths.go
@@ -25,37 +25,46 @@ import (
 	"strings"
 )
 
-// Slug derives the on-disk subdirectory name for a lib_id. The leading
-// "/" is stripped and the remaining slashes become underscores:
+// Slug derives the on-disk subdirectory name for a (lib_id, version)
+// slot. The leading "/" is stripped from lib_id, the remaining slashes
+// become underscores, and the version (when non-empty) is appended
+// after another "_":
 //
-//	/modelcontextprotocol/go-sdk → modelcontextprotocol_go-sdk
-//	/facebook/react/v18          → facebook_react_v18
+//	(/modelcontextprotocol/go-sdk, "")    → modelcontextprotocol_go-sdk
+//	(/facebook/react,              v18)   → facebook_react_v18
+//	(/hashicorp/terraform,         v1.14) → hashicorp_terraform_v1.14
 //
-// The mapping is deterministic and 1:1 with the lib_id, so an operator
-// listing artifacts/ can recover every lib by inspection. Hyphens and
-// dots are preserved.
-func Slug(libID string) string {
+// The mapping is deterministic and 1:1 with (lib_id, version), so an
+// operator listing artifacts/ can recover every slot by inspection.
+// Hyphens and dots are preserved; empty version produces the
+// single-version legacy form (no trailing underscore). See #113.
+func Slug(libID, version string) string {
 	trimmed := strings.TrimPrefix(libID, "/")
-	return strings.ReplaceAll(trimmed, "/", "_")
+	slug := strings.ReplaceAll(trimmed, "/", "_")
+	if version == "" {
+		return slug
+	}
+	return slug + "_" + version
 }
 
-// ArtifactDir returns <artifactsDir>/<slug>/ — the per-lib folder that
-// holds artifact.db (+ WAL/SHM during runs) and state.yaml.
-func ArtifactDir(artifactsDir, libID string) string {
-	return filepath.Join(artifactsDir, Slug(libID))
+// ArtifactDir returns <artifactsDir>/<slug>/ — the per-(lib, version)
+// folder that holds artifact.db (+ WAL/SHM during runs) and
+// state.yaml.
+func ArtifactDir(artifactsDir, libID, version string) string {
+	return filepath.Join(artifactsDir, Slug(libID, version))
 }
 
 // ArtifactDBPath returns <artifactsDir>/<slug>/artifact.db — the
-// canonical per-lib database path the scraper writes and the
-// consolidator reads.
-func ArtifactDBPath(artifactsDir, libID string) string {
-	return filepath.Join(ArtifactDir(artifactsDir, libID), "artifact.db")
+// canonical per-(lib, version) database path the scraper writes and
+// the consolidator reads.
+func ArtifactDBPath(artifactsDir, libID, version string) string {
+	return filepath.Join(ArtifactDir(artifactsDir, libID, version), "artifact.db")
 }
 
-// StatePath returns <artifactsDir>/<slug>/state.yaml — the per-lib
-// sidecar carrying content metadata (embedder identity, schema
-// version, scrape dates, counts). See state.go for the StateFile
-// shape and lifecycle.
-func StatePath(artifactsDir, libID string) string {
-	return filepath.Join(ArtifactDir(artifactsDir, libID), "state.yaml")
+// StatePath returns <artifactsDir>/<slug>/state.yaml — the
+// per-(lib, version) sidecar carrying content metadata (embedder
+// identity, schema version, scrape dates, counts). See state.go for
+// the StateFile shape and lifecycle.
+func StatePath(artifactsDir, libID, version string) string {
+	return filepath.Join(ArtifactDir(artifactsDir, libID, version), "state.yaml")
 }

--- a/internal/packs/paths_test.go
+++ b/internal/packs/paths_test.go
@@ -9,37 +9,40 @@ import (
 
 func TestSlug(t *testing.T) {
 	cases := []struct {
-		libID string
-		want  string
+		libID   string
+		version string
+		want    string
 	}{
-		{"/modelcontextprotocol/go-sdk", "modelcontextprotocol_go-sdk"},
-		{"/facebook/react/v18", "facebook_react_v18"},
-		{"/org/project", "org_project"},
-		{"/org/project-with.dots", "org_project-with.dots"},
+		{"/modelcontextprotocol/go-sdk", "", "modelcontextprotocol_go-sdk"},
+		{"/facebook/react", "v18", "facebook_react_v18"},
+		{"/org/project", "", "org_project"},
+		{"/org/project-with.dots", "", "org_project-with.dots"},
+		{"/hashicorp/terraform", "v1.14", "hashicorp_terraform_v1.14"},
+		{"/hashicorp/terraform", "v1.13", "hashicorp_terraform_v1.13"},
 	}
 	for _, c := range cases {
-		if got := packs.Slug(c.libID); got != c.want {
-			t.Errorf("Slug(%q) = %q, want %q", c.libID, got, c.want)
+		if got := packs.Slug(c.libID, c.version); got != c.want {
+			t.Errorf("Slug(%q, %q) = %q, want %q", c.libID, c.version, got, c.want)
 		}
 	}
 }
 
 func TestArtifactDir(t *testing.T) {
-	if got := packs.ArtifactDir("./artifacts", "/facebook/react/v18"); got != filepath.Join("artifacts", "facebook_react_v18") {
+	if got := packs.ArtifactDir("./artifacts", "/facebook/react", "v18"); got != filepath.Join("artifacts", "facebook_react_v18") {
 		t.Errorf("ArtifactDir = %q", got)
 	}
 }
 
 func TestArtifactDBPath(t *testing.T) {
 	want := filepath.Join("artifacts", "modelcontextprotocol_go-sdk", "artifact.db")
-	if got := packs.ArtifactDBPath("./artifacts", "/modelcontextprotocol/go-sdk"); got != want {
+	if got := packs.ArtifactDBPath("./artifacts", "/modelcontextprotocol/go-sdk", ""); got != want {
 		t.Errorf("ArtifactDBPath = %q, want %q", got, want)
 	}
 }
 
 func TestStatePath(t *testing.T) {
 	want := filepath.Join("artifacts", "facebook_react_v18", "state.yaml")
-	if got := packs.StatePath("./artifacts", "/facebook/react/v18"); got != want {
+	if got := packs.StatePath("./artifacts", "/facebook/react", "v18"); got != want {
 		t.Errorf("StatePath = %q, want %q", got, want)
 	}
 }

--- a/internal/packs/state.go
+++ b/internal/packs/state.go
@@ -40,7 +40,13 @@ import (
 // declaration order, so diffs in operator-visible `.state` files land
 // in a predictable shape.
 type StateFile struct {
-	LibID         string        `yaml:"lib_id"`
+	LibID string `yaml:"lib_id"`
+	// Version is the per-artifact version tag introduced by #113.
+	// Empty string is the canonical single-version form; multi-version
+	// libs carry the version as written in the registry (e.g.
+	// "v1.14"). Serialized with omitempty so single-version sidecars
+	// keep their pre-#113 shape on disk.
+	Version       string        `yaml:"version,omitempty"`
 	SchemaVersion int           `yaml:"schema_version"`
 	Embedder      EmbedderState `yaml:"embedder"`
 	// Ref is the resolved upstream git tag or commit SHA the URLs were

--- a/internal/packs/state_test.go
+++ b/internal/packs/state_test.go
@@ -3,6 +3,7 @@ package packs_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -22,7 +23,8 @@ func TestStateFile_RoundTrip(t *testing.T) {
 	updated := time.Date(2026, 4, 13, 14, 32, 0, 0, time.UTC)
 	want := &packs.StateFile{
 		LibID:         "/x/y",
-		SchemaVersion: 3,
+		Version:       "v1.14",
+		SchemaVersion: 4,
 		Embedder: packs.EmbedderState{
 			Kind:  "hugot",
 			Model: "nomic-ai/nomic-embed-text-v1.5",
@@ -45,6 +47,9 @@ func TestStateFile_RoundTrip(t *testing.T) {
 	if got.LibID != want.LibID {
 		t.Errorf("LibID = %q, want %q", got.LibID, want.LibID)
 	}
+	if got.Version != want.Version {
+		t.Errorf("Version = %q, want %q", got.Version, want.Version)
+	}
 	if got.SchemaVersion != want.SchemaVersion {
 		t.Errorf("SchemaVersion = %d, want %d", got.SchemaVersion, want.SchemaVersion)
 	}
@@ -65,6 +70,40 @@ func TestStateFile_RoundTrip(t *testing.T) {
 	}
 	if got.Ref != want.Ref {
 		t.Errorf("Ref = %q, want %q", got.Ref, want.Ref)
+	}
+}
+
+// TestStateFile_EmptyVersionOmittedOnDisk pins the on-disk shape
+// canonical single-version sidecars keep: Version is serialized with
+// omitempty so pre-#113 single-version sidecars don't grow a blank
+// `version: ""` line just because the field now exists.
+func TestStateFile_EmptyVersionOmittedOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	libDir := filepath.Join(dir, "x_y")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(libDir, "state.yaml")
+
+	s := &packs.StateFile{
+		LibID:         "/x/y",
+		SchemaVersion: 4,
+		Embedder:      packs.EmbedderState{Kind: "hugot", Model: "m", Dim: 8},
+		CreatedAt:     time.Now().UTC(),
+		UpdatedAt:     time.Now().UTC(),
+	}
+	if err := s.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	// Guard specifically against the top-level `version:` key — naive
+	// strings.Contains("version:") would false-positive on
+	// `schema_version:`.
+	if strings.Contains("\n"+string(data), "\nversion:") {
+		t.Errorf("expected no top-level version: line for single-version sidecar, got:\n%s", string(data))
 	}
 }
 

--- a/internal/scraper/config.go
+++ b/internal/scraper/config.go
@@ -72,7 +72,9 @@ type VersionEntry struct {
 // A LibrarySource with no Versions describes one library directly. A
 // LibrarySource with Versions is a YAML-level shorthand: at Expand() time
 // it produces one ResolvedSource per version, each with its URLs templated
-// and an effective lib_id of "<LibID>/<version>".
+// and the version surfaced in the dedicated Version field. The base LibID
+// is never mutated — two versions of the same lib share one LibID and
+// differ only in Version. See #113.
 //
 // Ref pins URLs to a single upstream git tag or commit SHA when URLs
 // contain the literal "{ref}" token. See #103.
@@ -86,11 +88,18 @@ type LibrarySource struct {
 
 // ResolvedSource is one library, post-version-expansion, ready to scrape.
 //
-// For single-version entries, LibID == BaseLibID and Version is empty.
-// For multi-version entries, LibID is "<BaseLibID>/<Version>" and the URLs
-// have the {version} placeholder substituted. Ref is the effective git
-// ref applied to the URLs (per-version Ref if set, else the top-level
+// LibID always equals BaseLibID — it is the base lib_id (e.g.
+// /hashicorp/terraform). Version is empty for single-version entries
+// and carries the version tag (e.g. "v1.14") for multi-version
+// entries. The "<base>/<version>" concat that earlier builds produced
+// here is gone (#113); callers that need a (lib_id, version) slot
+// pass them as two fields. Ref is the effective git ref applied to
+// the URLs (per-version Ref if set, else the top-level
 // LibrarySource.Ref).
+//
+// BaseLibID is retained as a separate field for readability at call
+// sites — it is always == LibID after #113, but the name documents
+// intent ("the unversioned identity of this lib").
 type ResolvedSource struct {
 	LibID     string
 	BaseLibID string
@@ -303,11 +312,14 @@ func validateRef(ref string) error {
 // Version is empty, URLs are copied with {ref} substituted from the
 // top-level Ref (if present).
 //
-// Multi-version entries produce one ResolvedSource per version, with the
-// effective lib_id formed as "<base>/<version>", the {version}
-// placeholder substituted in each URL, and the {ref} placeholder
-// substituted from the per-version Ref if set, else from the top-level
-// Ref.
+// Multi-version entries produce one ResolvedSource per version with
+// LibID == BaseLibID (the base, e.g. /hashicorp/terraform) and
+// Version set to the version tag. The {version} placeholder is
+// substituted in each URL, and the {ref} placeholder is substituted
+// from the per-version Ref if set, else from the top-level Ref. The
+// "<base>/<version>" concatenation that earlier builds produced here
+// is gone (#113); downstream code treats (LibID, Version) as the
+// canonical slot.
 func (l LibrarySource) Expand() []ResolvedSource {
 	if len(l.Versions) == 0 {
 		urls := make([]string, len(l.URLs))
@@ -334,7 +346,7 @@ func (l LibrarySource) Expand() []ResolvedSource {
 			urls[i] = substituteRef(u, ref)
 		}
 		out = append(out, ResolvedSource{
-			LibID:     l.LibID + "/" + v.Name,
+			LibID:     l.LibID,
 			BaseLibID: l.LibID,
 			Version:   v.Name,
 			Kind:      l.Kind,
@@ -355,20 +367,34 @@ func substituteRef(url, ref string) string {
 	return strings.ReplaceAll(url, refPlaceholder, ref)
 }
 
-// Resolve flattens every entry in the config into ResolvedSources, applying
-// the two-level lib_id filter described in #51:
+// Resolve flattens every entry in the config into ResolvedSources,
+// applying the (libFilter, versionFilter) filter pair introduced in
+// #113:
 //
-//   - filter == "" matches every resolved entry
-//   - filter == "/org/project" matches every expanded version of that base
-//     (and the base itself for single-version entries)
-//   - filter == "/org/project/version" matches exactly one expanded entry
-func (c *Config) Resolve(filter string) []ResolvedSource {
+//   - libFilter == "" matches every resolved entry (versionFilter is
+//     ignored in this case; the caller is expected to reject that
+//     combination as a usage error before calling in).
+//   - libFilter != "", versionFilter == "" matches every expanded
+//     version of that base (and the base itself for single-version
+//     entries). This is the "scrape every version of terraform" knob.
+//   - libFilter != "", versionFilter != "" matches the exactly-one
+//     expanded entry whose (BaseLibID, Version) pair equals the
+//     filter. This is the "scrape only terraform v1.14" knob.
+func (c *Config) Resolve(libFilter, versionFilter string) []ResolvedSource {
 	var out []ResolvedSource
 	for _, lib := range c.Libraries {
 		for _, r := range lib.Expand() {
-			if filter == "" || r.LibID == filter || r.BaseLibID == filter {
+			if libFilter == "" {
 				out = append(out, r)
+				continue
 			}
+			if r.BaseLibID != libFilter {
+				continue
+			}
+			if versionFilter != "" && r.Version != versionFilter {
+				continue
+			}
+			out = append(out, r)
 		}
 	}
 	return out

--- a/internal/scraper/config_test.go
+++ b/internal/scraper/config_test.go
@@ -203,7 +203,7 @@ libraries:
 	}
 
 	// Verify the kind round-trips through Resolve as well.
-	resolved := cfg.Resolve("")
+	resolved := cfg.Resolve("", "")
 	if len(resolved) != 1 {
 		t.Fatalf("Resolve returned %d, want 1", len(resolved))
 	}
@@ -351,13 +351,15 @@ func TestExpand_MultiVersionExpandsAndSubstitutes(t *testing.T) {
 		t.Fatalf("expected 2 resolved sources, got %d", len(out))
 	}
 
+	// After #113 LibID stays equal to the base for every expansion;
+	// the version lives in the dedicated Version field.
 	want := []struct {
 		libID   string
 		version string
 		urls    []string
 	}{
 		{
-			libID:   "/facebook/react/v18",
+			libID:   "/facebook/react",
 			version: "v18",
 			urls: []string{
 				"https://raw.githubusercontent.com/facebook/react/v18/README.md",
@@ -365,7 +367,7 @@ func TestExpand_MultiVersionExpandsAndSubstitutes(t *testing.T) {
 			},
 		},
 		{
-			libID:   "/facebook/react/v19",
+			libID:   "/facebook/react",
 			version: "v19",
 			urls: []string{
 				"https://raw.githubusercontent.com/facebook/react/v19/README.md",
@@ -408,14 +410,14 @@ libraries:
       - https://example.com/react/{version}/README.md
 `)
 
-	all := cfg.Resolve("")
+	all := cfg.Resolve("", "")
 	if len(all) != 3 {
-		t.Fatalf("Resolve(\"\") returned %d, want 3", len(all))
+		t.Fatalf("Resolve(\"\", \"\") returned %d, want 3", len(all))
 	}
 
-	react := cfg.Resolve("/facebook/react")
+	react := cfg.Resolve("/facebook/react", "")
 	if len(react) != 2 {
-		t.Fatalf("Resolve(/facebook/react) returned %d, want 2", len(react))
+		t.Fatalf("Resolve(/facebook/react, \"\") returned %d, want 2", len(react))
 	}
 	for _, r := range react {
 		if r.BaseLibID != "/facebook/react" {
@@ -424,7 +426,7 @@ libraries:
 	}
 }
 
-func TestResolve_FilterByVersionedLibID(t *testing.T) {
+func TestResolve_FilterByLibAndVersion(t *testing.T) {
 	cfg := mustLoadInline(t, `
 libraries:
   - lib_id: /facebook/react
@@ -434,12 +436,12 @@ libraries:
       - https://example.com/react/{version}/README.md
 `)
 
-	v18 := cfg.Resolve("/facebook/react/v18")
+	v18 := cfg.Resolve("/facebook/react", "v18")
 	if len(v18) != 1 {
-		t.Fatalf("Resolve(/facebook/react/v18) returned %d, want 1", len(v18))
+		t.Fatalf("Resolve(/facebook/react, v18) returned %d, want 1", len(v18))
 	}
-	if v18[0].LibID != "/facebook/react/v18" {
-		t.Errorf("LibID = %q, want /facebook/react/v18", v18[0].LibID)
+	if v18[0].LibID != "/facebook/react" {
+		t.Errorf("LibID = %q, want /facebook/react (base stays unversioned after #113)", v18[0].LibID)
 	}
 	if v18[0].Version != "v18" {
 		t.Errorf("Version = %q, want v18", v18[0].Version)
@@ -455,7 +457,7 @@ libraries:
       - https://example.com/go-sdk/README.md
 `)
 
-	got := cfg.Resolve("/modelcontextprotocol/go-sdk")
+	got := cfg.Resolve("/modelcontextprotocol/go-sdk", "")
 	if len(got) != 1 {
 		t.Fatalf("Resolve returned %d, want 1", len(got))
 	}
@@ -473,8 +475,58 @@ libraries:
       - https://example.com/go-sdk/README.md
 `)
 
-	if got := cfg.Resolve("/missing/lib"); len(got) != 0 {
+	if got := cfg.Resolve("/missing/lib", ""); len(got) != 0 {
 		t.Errorf("expected no matches, got %d", len(got))
+	}
+}
+
+// TestResolve_VersionFilterWithoutMatchingVersion exercises the
+// (-lib, -version) pair when the version tag doesn't exist for the
+// filtered lib: the slice comes back empty, exactly as the scrape
+// command's startup error relies on.
+func TestResolve_VersionFilterWithoutMatchingVersion(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /facebook/react
+    kind: github-md
+    versions: [v18, v19]
+    urls:
+      - https://example.com/react/{version}/README.md
+`)
+
+	if got := cfg.Resolve("/facebook/react", "v20"); len(got) != 0 {
+		t.Errorf("expected no matches for v20, got %d", len(got))
+	}
+}
+
+// TestResolve_MultiVersionLibIDStaysBase is the regression test for
+// the un-concatenation: every expansion of a multi-version lib must
+// carry the base as LibID with the version in the Version field,
+// never the old /<base>/<version> concat.
+func TestResolve_MultiVersionLibIDStaysBase(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /hashicorp/terraform
+    kind: github-md
+    versions: [v1.14, v1.13]
+    urls:
+      - https://example.com/tf/{version}/README.md
+`)
+
+	got := cfg.Resolve("", "")
+	if len(got) != 2 {
+		t.Fatalf("Resolve returned %d, want 2", len(got))
+	}
+	for i, r := range got {
+		if r.LibID != "/hashicorp/terraform" {
+			t.Errorf("[%d].LibID = %q, want /hashicorp/terraform", i, r.LibID)
+		}
+		if r.BaseLibID != "/hashicorp/terraform" {
+			t.Errorf("[%d].BaseLibID = %q, want /hashicorp/terraform", i, r.BaseLibID)
+		}
+	}
+	if got[0].Version != "v1.14" || got[1].Version != "v1.13" {
+		t.Errorf("versions = %q, %q; want v1.14, v1.13", got[0].Version, got[1].Version)
 	}
 }
 
@@ -572,7 +624,7 @@ libraries:
     urls:
       - https://example.com/main/a.md
 `)
-	got := cfg.Resolve("")
+	got := cfg.Resolve("", "")
 	if len(got) != 1 {
 		t.Fatalf("Resolve returned %d, want 1", len(got))
 	}
@@ -624,30 +676,37 @@ libraries:
     urls:
       - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/intro/index.mdx
 `)
-	got := cfg.Resolve("")
+	got := cfg.Resolve("", "")
 	if len(got) != 2 {
 		t.Fatalf("Resolve returned %d, want 2", len(got))
 	}
-	// Declaration order is preserved.
+	// Declaration order is preserved. LibID stays the base after #113;
+	// the version lives in Version.
 	want := []struct {
-		libID string
-		ref   string
-		url   string
+		libID   string
+		version string
+		ref     string
+		url     string
 	}{
 		{
-			libID: "/hashicorp/terraform/v1.14",
-			ref:   "v1.14.6",
-			url:   "https://raw.githubusercontent.com/hashicorp/web-unified-docs/v1.14.6/content/terraform/v1.14.x/docs/intro/index.mdx",
+			libID:   "/hashicorp/terraform",
+			version: "v1.14",
+			ref:     "v1.14.6",
+			url:     "https://raw.githubusercontent.com/hashicorp/web-unified-docs/v1.14.6/content/terraform/v1.14.x/docs/intro/index.mdx",
 		},
 		{
-			libID: "/hashicorp/terraform/v1.13",
-			ref:   "v1.13.5",
-			url:   "https://raw.githubusercontent.com/hashicorp/web-unified-docs/v1.13.5/content/terraform/v1.13.x/docs/intro/index.mdx",
+			libID:   "/hashicorp/terraform",
+			version: "v1.13",
+			ref:     "v1.13.5",
+			url:     "https://raw.githubusercontent.com/hashicorp/web-unified-docs/v1.13.5/content/terraform/v1.13.x/docs/intro/index.mdx",
 		},
 	}
 	for i, w := range want {
 		if got[i].LibID != w.libID {
 			t.Errorf("[%d].LibID = %q, want %q", i, got[i].LibID, w.libID)
+		}
+		if got[i].Version != w.version {
+			t.Errorf("[%d].Version = %q, want %q", i, got[i].Version, w.version)
 		}
 		if got[i].Ref != w.ref {
 			t.Errorf("[%d].Ref = %q, want %q", i, got[i].Ref, w.ref)
@@ -670,7 +729,7 @@ libraries:
     urls:
       - https://example.com/{version}/{ref}/a.md
 `)
-	got := cfg.Resolve("")
+	got := cfg.Resolve("", "")
 	if len(got) != 2 {
 		t.Fatalf("Resolve returned %d, want 2", len(got))
 	}


### PR DESCRIPTION
## Summary

- Promote `version` to a first-class column in the `docs` and `libs` tables (schema v3 → v4), making `(lib_id, version)` the composite primary key for libs instead of encoding version into the lib_id string
- Add `-version` CLI flag to `scrape` (requires `-lib`) for filtering a specific version of a multi-version library
- Thread `version` through the full pipeline: `ResolvedSource` → artifact meta → DB inserts/queries → MCP search → consolidation
- Update `SearchByEmbedding` with three-valued `(libID, version)` filtering: all libs, all versions of a lib, or a pinned version
- Update artifact paths (`ArtifactDir`, `ArtifactDBPath`, `StatePath`) to include version in the directory layout
- Extend `StateFile` with `Version` and `Ref` fields for per-version sidecar tracking
- Add deterministic tie-breaking (`lib_id ASC, version ASC`) to `SearchLibsByEmbedding`

## Key design decisions

- Version is **not** mixed into the embedding text — multiple versions of the same lib rank identically against free-text queries, keeping search behavior consistent
- Empty string is the canonical version for single-version libs (not NULL), so existing single-version workflows are unchanged
- `-version` without `-lib` is rejected at parse time to avoid ambiguity across libs sharing tags

## Test plan

- Existing and new unit tests for `internal/db`, `internal/packs`, `internal/scraper`, and `cmd/deadzone/server_test.go`
- Verify schema v4 migration creates the expected composite PK
- Verify `-version` flag requires `-lib` and filters correctly
- Verify consolidation handles versioned artifacts

<!-- emdash-issue-footer:start -->
Fixes #113
<!-- emdash-issue-footer:end -->