### PR TITLE
feat(scraper): support per-version URL overrides in library config

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,23 @@ libraries:
       v1.13: { ref: v1.13.5 }
     urls:
       - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/intro/index.mdx
+
+  # Per-version `urls:` override — when two versions of the same lib
+  # diverge structurally (a file added / renamed / removed), the version
+  # that differs replaces the baseline URL list wholesale. Versions that
+  # omit `urls:` keep inheriting the top-level list. See #115.
+  - lib_id: /modelcontextprotocol/go-sdk
+    kind: github-md
+    urls:
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/README.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/server.md
+    versions:
+      v1.4.1: {}                          # inherits baseline (2 URLs)
+      v1.5.0:                             # full override (3 URLs)
+        urls:
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/README.md
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/server.md
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/quick_start.md
 ```
 
 | Field | Required | Purpose |
@@ -317,8 +334,9 @@ libraries:
 | `lib_id` | yes | canonical `/org/project` identifier (matches `db.docs.lib_id`) |
 | `kind` | yes | source kind discriminator — `github-md` for raw markdown, `github-rst` for raw reStructuredText (cpython, Django, NumPy, …), `scrape-via-agent` for HTML/text via an LLM (see [Scraping non-trivial doc sources](#scraping-non-trivial-doc-sources-scrape-via-agent)) |
 | `urls` | yes | list of doc URLs (with optional `{version}` and/or `{ref}` placeholders) |
-| `versions` | no | list `[v1, v2]` or map `{v1: {ref: tag1}, …}` of version tags; expands `{version}` in `urls` and produces one effective `lib_id` per version. The map form pins each version to its own git ref. |
+| `versions` | no | list `[v1, v2]` or map `{v1: {ref: tag1, urls: [...]}, …}` of version tags; expands `{version}` in `urls` and produces one effective `lib_id` per version. The map form accepts per-version `ref:` and per-version `urls:` overrides. |
 | `ref` | no | git tag or commit SHA substituted into `{ref}` in `urls` (#103). For multi-version libs, a per-version ref in the `versions:` map overrides this top-level ref. URLs that don't contain `{ref}` are left untouched, so a lib can opt into pinning incrementally. |
+| `versions[v].urls` | no | per-version URL list (#115). When set, replaces the top-level `urls:` for this version wholesale — use it when two versions of the same lib diverge structurally (a file added, renamed, or removed between versions). Omit the field to inherit the baseline; an explicit empty list is rejected. |
 
 Adding a new library means adding a YAML entry — no Go editing, no recompile.
 

--- a/internal/scraper/config.go
+++ b/internal/scraper/config.go
@@ -62,9 +62,16 @@ type Config struct {
 // `versions: {v1: {ref: tag1}, v2: {ref: tag2}}` produces entries with
 // per-version Ref set, which overrides the top-level Ref for that
 // version. Declaration order is preserved so scrapes are deterministic.
+//
+// URLs (map shape only, see #115) is a per-version override of the
+// parent LibrarySource.URLs. When non-nil, Expand uses it verbatim for
+// this version; when nil, the version inherits the top-level URLs. An
+// explicit empty list is rejected at parse time — inheritance is
+// expressed by omitting the field.
 type VersionEntry struct {
 	Name string
 	Ref  string
+	URLs []string
 }
 
 // LibrarySource is a single entry in libraries_sources.yaml.
@@ -157,12 +164,29 @@ func (l *LibrarySource) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("versions map key: %w", err)
 			}
 			var entry struct {
-				Ref string `yaml:"ref"`
+				Ref  string    `yaml:"ref"`
+				URLs yaml.Node `yaml:"urls"`
 			}
 			if err := valNode.Decode(&entry); err != nil {
 				return fmt.Errorf("versions[%q]: %w", name, err)
 			}
-			l.Versions = append(l.Versions, VersionEntry{Name: name, Ref: entry.Ref})
+			v := VersionEntry{Name: name, Ref: entry.Ref}
+			// Distinguish omitted urls (inherit baseline) from explicit
+			// `urls: []` (rejected as ambiguous — see #115).
+			if entry.URLs.Kind != 0 {
+				if entry.URLs.Kind != yaml.SequenceNode {
+					return fmt.Errorf("versions[%q].urls must be a list", name)
+				}
+				if len(entry.URLs.Content) == 0 {
+					return fmt.Errorf("versions[%q].urls is an empty list (omit the field to inherit the top-level urls)", name)
+				}
+				var urls []string
+				if err := entry.URLs.Decode(&urls); err != nil {
+					return fmt.Errorf("versions[%q].urls: %w", name, err)
+				}
+				v.URLs = urls
+			}
+			l.Versions = append(l.Versions, v)
 		}
 	default:
 		return fmt.Errorf("versions must be a list or a mapping, got yaml kind %d", raw.Versions.Kind)
@@ -196,11 +220,15 @@ func LoadConfig(path string) (*Config, error) {
 // validate enforces the v1 schema rules:
 //   - lib_id non-empty, starts with "/", does not end with "/"
 //   - kind in the known set
-//   - urls non-empty, no empty/whitespace entries
+//   - top-level urls: no empty/whitespace entries. Non-empty when versions
+//     is unset; may be empty when versions is set only if every version
+//     supplies its own urls (see #115)
 //   - ref (when set) has no whitespace and no placeholder tokens
 //   - if versions is set: every version has a non-empty name without
 //     whitespace, "/", or "{version}"; per-version refs (map shape) have
-//     no whitespace; every URL contains "{version}"
+//     no whitespace; every effective URL (baseline OR per-version
+//     override) contains "{version}"; per-version urls (when set) are a
+//     non-empty list with no whitespace-only entries
 //   - if versions is unset: no URL contains "{version}"
 //   - if any URL contains "{ref}": for the single-version entry the
 //     top-level ref must be set; for a multi-version entry every version
@@ -221,9 +249,6 @@ func (l LibrarySource) validate() error {
 	if !validKinds[l.Kind] {
 		return fmt.Errorf("unknown kind %q (valid: %s, %s, %s)", l.Kind, KindGithubMD, KindGithubRST, KindScrapeViaAgent)
 	}
-	if len(l.URLs) == 0 {
-		return fmt.Errorf("urls must be non-empty")
-	}
 	for _, u := range l.URLs {
 		if strings.TrimSpace(u) == "" {
 			return fmt.Errorf("urls contains an empty entry")
@@ -233,31 +258,45 @@ func (l LibrarySource) validate() error {
 		return fmt.Errorf("ref: %w", err)
 	}
 
-	urlHasRef := false
-	for _, u := range l.URLs {
-		if strings.Contains(u, refPlaceholder) {
-			urlHasRef = true
-			break
-		}
-	}
-
 	if len(l.Versions) == 0 {
-		// No versions: no URL may contain {version} — it would be an
-		// unresolved placeholder at runtime.
+		// No versions: top-level urls must be non-empty, no URL may
+		// contain {version} (unresolved placeholder at runtime), and
+		// any {ref} requires a top-level ref.
+		if len(l.URLs) == 0 {
+			return fmt.Errorf("urls must be non-empty")
+		}
 		for _, u := range l.URLs {
 			if strings.Contains(u, versionPlaceholder) {
 				return fmt.Errorf("url %q contains %s but no versions are listed", u, versionPlaceholder)
 			}
 		}
-		if urlHasRef && l.Ref == "" {
-			return fmt.Errorf("a url contains %s but ref is not set", refPlaceholder)
+		for _, u := range l.URLs {
+			if strings.Contains(u, refPlaceholder) && l.Ref == "" {
+				return fmt.Errorf("a url contains %s but ref is not set", refPlaceholder)
+			}
 		}
 		return nil
 	}
 
-	// Versions present: every version string must be a clean tag, and
-	// every URL must reference {version} (otherwise the expansion would
-	// produce N identical rows).
+	// Versions present.
+	//
+	// Baseline urls, when set, are the fallback for any version that
+	// doesn't override — so they must contain {version}. When baseline
+	// is empty, every version must supply its own urls.
+	if len(l.URLs) == 0 {
+		for _, v := range l.Versions {
+			if len(v.URLs) == 0 {
+				return fmt.Errorf("urls must be non-empty (or every version must provide its own urls); versions[%q] has no urls and the top-level urls is empty", v.Name)
+			}
+		}
+	} else {
+		for _, u := range l.URLs {
+			if !strings.Contains(u, versionPlaceholder) {
+				return fmt.Errorf("url %q is missing the %s placeholder (required when versions is set)", u, versionPlaceholder)
+			}
+		}
+	}
+
 	for _, v := range l.Versions {
 		if v.Name == "" {
 			return fmt.Errorf("versions contains an empty entry")
@@ -274,13 +313,30 @@ func (l LibrarySource) validate() error {
 		if err := validateRef(v.Ref); err != nil {
 			return fmt.Errorf("versions[%q].ref: %w", v.Name, err)
 		}
+		for _, u := range v.URLs {
+			if strings.TrimSpace(u) == "" {
+				return fmt.Errorf("versions[%q].urls contains an empty entry", v.Name)
+			}
+			if !strings.Contains(u, versionPlaceholder) {
+				return fmt.Errorf("versions[%q] url %q is missing the %s placeholder (required when versions is set)", v.Name, u, versionPlaceholder)
+			}
+		}
+
+		// {ref} check runs on the effective URL list for this version
+		// (per-version override, else baseline).
+		effective := v.URLs
+		if len(effective) == 0 {
+			effective = l.URLs
+		}
+		urlHasRef := false
+		for _, u := range effective {
+			if strings.Contains(u, refPlaceholder) {
+				urlHasRef = true
+				break
+			}
+		}
 		if urlHasRef && v.Ref == "" && l.Ref == "" {
 			return fmt.Errorf("a url contains %s but neither versions[%q].ref nor the top-level ref is set", refPlaceholder, v.Name)
-		}
-	}
-	for _, u := range l.URLs {
-		if !strings.Contains(u, versionPlaceholder) {
-			return fmt.Errorf("url %q is missing the %s placeholder (required when versions is set)", u, versionPlaceholder)
 		}
 	}
 	return nil
@@ -340,8 +396,14 @@ func (l LibrarySource) Expand() []ResolvedSource {
 		if ref == "" {
 			ref = l.Ref
 		}
-		urls := make([]string, len(l.URLs))
-		for i, u := range l.URLs {
+		// Per-version URLs replace the baseline wholesale when set;
+		// nil/empty means inherit the top-level urls (#115).
+		src := v.URLs
+		if len(src) == 0 {
+			src = l.URLs
+		}
+		urls := make([]string, len(src))
+		for i, u := range src {
 			u = strings.ReplaceAll(u, versionPlaceholder, v.Name)
 			urls[i] = substituteRef(u, ref)
 		}

--- a/internal/scraper/config_test.go
+++ b/internal/scraper/config_test.go
@@ -717,6 +717,205 @@ libraries:
 	}
 }
 
+// --- per-version URL overrides (#115) ---
+
+func TestExpand_PerVersionURLsOverrideBaseline(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /modelcontextprotocol/go-sdk
+    kind: github-md
+    urls:
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/README.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/server.md
+    versions:
+      v1.4.1: {}
+      v1.5.0:
+        urls:
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/README.md
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/server.md
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/quick_start.md
+`)
+	got := cfg.Resolve("", "")
+	if len(got) != 2 {
+		t.Fatalf("Resolve returned %d, want 2", len(got))
+	}
+	if got[0].Version != "v1.4.1" {
+		t.Fatalf("[0].Version = %q, want v1.4.1", got[0].Version)
+	}
+	if len(got[0].URLs) != 2 {
+		t.Errorf("v1.4.1 should inherit baseline (2 URLs), got %d", len(got[0].URLs))
+	}
+	for _, u := range got[0].URLs {
+		if !strings.Contains(u, "/v1.4.1/") {
+			t.Errorf("v1.4.1 URL not substituted: %q", u)
+		}
+	}
+	if got[1].Version != "v1.5.0" {
+		t.Fatalf("[1].Version = %q, want v1.5.0", got[1].Version)
+	}
+	if len(got[1].URLs) != 3 {
+		t.Errorf("v1.5.0 should use override (3 URLs), got %d", len(got[1].URLs))
+	}
+	if !strings.HasSuffix(got[1].URLs[2], "/docs/quick_start.md") {
+		t.Errorf("v1.5.0 URL[2] = %q, want …/docs/quick_start.md", got[1].URLs[2])
+	}
+}
+
+func TestExpand_NoBaselineAllVersionsOverride(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    ref: fallback-ref
+    versions:
+      v1:
+        ref: r1
+        urls:
+          - https://example.com/{version}/{ref}/a.md
+      v2:
+        urls:
+          - https://example.com/{version}/{ref}/a.md
+          - https://example.com/{version}/{ref}/b.md
+`)
+	got := cfg.Resolve("", "")
+	if len(got) != 2 {
+		t.Fatalf("Resolve returned %d, want 2", len(got))
+	}
+	if got[0].URLs[0] != "https://example.com/v1/r1/a.md" {
+		t.Errorf("v1 URL = %q", got[0].URLs[0])
+	}
+	if len(got[1].URLs) != 2 {
+		t.Fatalf("v2 URLs len = %d, want 2", len(got[1].URLs))
+	}
+	if got[1].URLs[0] != "https://example.com/v2/fallback-ref/a.md" {
+		t.Errorf("v2 URLs[0] = %q", got[1].URLs[0])
+	}
+	if got[1].URLs[1] != "https://example.com/v2/fallback-ref/b.md" {
+		t.Errorf("v2 URLs[1] = %q", got[1].URLs[1])
+	}
+}
+
+func TestLoadConfig_PerVersionURLsRules(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "per-version urls is an explicit empty list",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    urls:
+      - https://example.com/{version}/a.md
+    versions:
+      v1: { urls: [] }
+`,
+			want: "empty list",
+		},
+		{
+			name: "per-version url missing {version} placeholder",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    urls:
+      - https://example.com/{version}/a.md
+    versions:
+      v1:
+        urls:
+          - https://example.com/fixed/a.md
+`,
+			want: "missing the {version} placeholder",
+		},
+		{
+			name: "inheriting version with empty baseline",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    versions:
+      v1:
+        urls:
+          - https://example.com/{version}/a.md
+      v2: {}
+`,
+			want: `versions["v2"] has no urls and the top-level urls is empty`,
+		},
+		{
+			name: "per-version urls not a list",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    urls:
+      - https://example.com/{version}/a.md
+    versions:
+      v1:
+        urls: "https://example.com/{version}/a.md"
+`,
+			want: "must be a list",
+		},
+		{
+			name: "per-version url with whitespace entry",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    urls:
+      - https://example.com/{version}/a.md
+    versions:
+      v1:
+        urls:
+          - "   "
+`,
+			want: "contains an empty entry",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeConfig(t, tc.yaml)
+			_, err := scraper.LoadConfig(path)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_PerVersionURLsAcceptMixedInheritAndOverride(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    urls:
+      - https://example.com/{version}/a.md
+    versions:
+      v1: {}
+      v2:
+        urls:
+          - https://example.com/{version}/a.md
+          - https://example.com/{version}/b.md
+`)
+	got := cfg.Resolve("", "")
+	if len(got) != 2 {
+		t.Fatalf("Resolve returned %d, want 2", len(got))
+	}
+	if len(got[0].URLs) != 1 || got[0].URLs[0] != "https://example.com/v1/a.md" {
+		t.Errorf("v1 URLs = %v, want [https://example.com/v1/a.md]", got[0].URLs)
+	}
+	if len(got[1].URLs) != 2 {
+		t.Fatalf("v2 URLs len = %d, want 2", len(got[1].URLs))
+	}
+	if got[1].URLs[1] != "https://example.com/v2/b.md" {
+		t.Errorf("v2 URLs[1] = %q", got[1].URLs[1])
+	}
+}
+
 func TestLoadConfig_VersionsMapShape_PerVersionRefOverridesTopLevel(t *testing.T) {
 	cfg := mustLoadInline(t, `
 libraries:

--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -21,6 +21,17 @@
 #             the literal "{version}" placeholder; one effective entry is
 #             produced per version with lib_id "<lib_id>/<version>".
 #
+#             Map shape (`versions: {v1: {...}, v2: {...}}`) accepts
+#             per-version overrides:
+#               - `ref:`  pins this version's {ref} substitution (see
+#                         #103)
+#               - `urls:` replaces the top-level `urls:` for this version
+#                         wholesale (#115). Omit the field to inherit
+#                         the baseline; an explicit `urls: []` is
+#                         rejected. Use this when two versions of the
+#                         same lib diverge structurally (a file added,
+#                         renamed, or removed between versions).
+#
 # Override this path with `deadzone-scraper -config <path>`. Restrict a run
 # to one library with `-lib /org/project` (matches all versions of that
 # base) or `-lib /org/project/v18` (matches one expanded version).


### PR DESCRIPTION
## Summary

- Add per-version `urls:` field to the `versions` map shape, allowing individual versions to replace the top-level URL list wholesale when doc structure diverges between versions (e.g., a file added or renamed)
- Versions that omit `urls:` inherit the baseline; explicit empty lists are rejected at parse time
- Validate per-version URLs: require `{version}` placeholder, reject whitespace-only entries, check `{ref}` consistency against the effective URL list

## Changes

- `internal/scraper/config.go` — extend `VersionEntry` with `URLs` field, update YAML unmarshalling to distinguish omitted vs explicit-empty, revise `validate()` and `Expand()` to handle per-version URL inheritance/override
- `internal/scraper/config_test.go` — add tests for override, inheritance, mixed mode, no-baseline-all-override, and validation error cases
- `libraries_sources.yaml` — document per-version `urls:` in the header comment block
- `README.md` — document the feature with an example and update the field reference table

## Test plan

- `go test ./internal/scraper/...` passes all new and existing tests
- New tests cover: baseline inheritance, per-version override, no-baseline with all overrides, empty-list rejection, missing-placeholder rejection, whitespace rejection, non-list rejection, mixed inherit-and-override

<!-- emdash-issue-footer:start -->
Fixes #115
<!-- emdash-issue-footer:end -->