### PR TITLE
feat(scraper): drop versions list shape, require map-only (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,10 +293,13 @@ libraries:
   # Multi-version lib — `versions` expands `{version}` in each URL,
   # producing one effective lib_id per version (`/facebook/react/v18`,
   # `/facebook/react/v19`, …) — matches Context7's `/org/project/version`
-  # convention.
+  # convention. Entries with no per-version overrides use the `{}` empty
+  # map; add `ref:` and/or `urls:` inside the map to override per version.
   - lib_id: /facebook/react
     kind: github-md
-    versions: [v18, v19]
+    versions:
+      v18: {}
+      v19: {}
     urls:
       - https://raw.githubusercontent.com/facebook/react/{version}/README.md
       - https://raw.githubusercontent.com/facebook/react/{version}/docs/getting-started.md
@@ -334,7 +337,7 @@ libraries:
 | `lib_id` | yes | canonical `/org/project` identifier (matches `db.docs.lib_id`) |
 | `kind` | yes | source kind discriminator — `github-md` for raw markdown, `github-rst` for raw reStructuredText (cpython, Django, NumPy, …), `scrape-via-agent` for HTML/text via an LLM (see [Scraping non-trivial doc sources](#scraping-non-trivial-doc-sources-scrape-via-agent)) |
 | `urls` | yes | list of doc URLs (with optional `{version}` and/or `{ref}` placeholders) |
-| `versions` | no | list `[v1, v2]` or map `{v1: {ref: tag1, urls: [...]}, …}` of version tags; expands `{version}` in `urls` and produces one effective `lib_id` per version. The map form accepts per-version `ref:` and per-version `urls:` overrides. |
+| `versions` | no | map `{v1: {ref: tag1, urls: [...]}, v2: {}, …}` of version tags; expands `{version}` in `urls` and produces one effective `lib_id` per version. Each value accepts optional per-version `ref:` and `urls:` overrides — use `{}` when a version has neither. The legacy list form `[v1, v2]` is rejected (see #117). |
 | `ref` | no | git tag or commit SHA substituted into `{ref}` in `urls` (#103). For multi-version libs, a per-version ref in the `versions:` map overrides this top-level ref. URLs that don't contain `{ref}` are left untouched, so a lib can opt into pinning incrementally. |
 | `versions[v].urls` | no | per-version URL list (#115). When set, replaces the top-level `urls:` for this version wholesale — use it when two versions of the same lib diverge structurally (a file added, renamed, or removed between versions). Omit the field to inherit the baseline; an explicit empty list is rejected. |
 

--- a/docs/research/ingestion-architecture.md
+++ b/docs/research/ingestion-architecture.md
@@ -212,10 +212,10 @@ Before #51, the scraper hardcoded a single library and its URLs as Go constants 
   kind: github-md                          # source kind discriminator
   urls:                                    # required: list of doc URLs
     - https://...
-  versions: []                             # optional: shorthand for multi-version libs
+  versions: {}                             # optional: map of multi-version tags
 ```
 
-The `versions: []` shorthand expands `{version}` placeholders in URLs and produces one effective `lib_id` per version (matching Context7's `/org/project/version` convention). Opt-in via `-config <file>` flag, with a two-level `-lib` filter:
+The `versions:` map expands `{version}` placeholders in URLs and produces one effective `lib_id` per version (matching Context7's `/org/project/version` convention). Opt-in via `-config <file>` flag, with a two-level `-lib` filter:
 
 - `-lib /org/project` matches every expanded version
 - `-lib /org/project/v18` matches one specific expanded version

--- a/internal/scraper/config.go
+++ b/internal/scraper/config.go
@@ -57,15 +57,14 @@ type Config struct {
 
 // VersionEntry is one element of LibrarySource.Versions after parsing.
 //
-// The list shorthand `versions: [v1, v2]` produces entries with Ref
-// empty (the lib's top-level Ref applies, if any). The map shorthand
-// `versions: {v1: {ref: tag1}, v2: {ref: tag2}}` produces entries with
-// per-version Ref set, which overrides the top-level Ref for that
-// version. Declaration order is preserved so scrapes are deterministic.
+// Entries come from the map shape `versions: {v1: {ref: tag1}, v2: {ref:
+// tag2}}`. Ref, when set, overrides the top-level Ref for this version;
+// when empty the top-level Ref applies (if any). Declaration order is
+// preserved so scrapes are deterministic.
 //
-// URLs (map shape only, see #115) is a per-version override of the
-// parent LibrarySource.URLs. When non-nil, Expand uses it verbatim for
-// this version; when nil, the version inherits the top-level URLs. An
+// URLs (see #115) is a per-version override of the parent
+// LibrarySource.URLs. When non-nil, Expand uses it verbatim for this
+// version; when nil, the version inherits the top-level URLs. An
 // explicit empty list is rejected at parse time — inheritance is
 // expressed by omitting the field.
 type VersionEntry struct {
@@ -116,14 +115,17 @@ type ResolvedSource struct {
 	URLs      []string
 }
 
-// UnmarshalYAML accepts both shapes for `versions:`:
+// UnmarshalYAML parses `versions:` as a mapping:
 //
-//	versions: [v1, v2]                                 # list shorthand
-//	versions: {v1: {ref: tag1}, v2: {ref: tag2}}       # map shorthand (per-version ref)
+//	versions: {v1: {ref: tag1}, v2: {ref: tag2}}
 //
-// All other fields parse via the standard reflection path. Declaration
-// order is preserved for the map shape so the scrape loop hits versions
-// in a deterministic order.
+// Each value is an object with optional `ref:` and `urls:` per-version
+// overrides. The legacy list form (`versions: [v1, v2]`) is rejected —
+// it carried no per-version metadata and was strictly a subset of the
+// map shape, so keeping it meant two parse paths for the same semantics
+// (see #117). All other fields parse via the standard reflection path.
+// Declaration order is preserved so the scrape loop hits versions in a
+// deterministic order.
 func (l *LibrarySource) UnmarshalYAML(node *yaml.Node) error {
 	var raw struct {
 		LibID    string    `yaml:"lib_id"`
@@ -146,13 +148,7 @@ func (l *LibrarySource) UnmarshalYAML(node *yaml.Node) error {
 	}
 	switch raw.Versions.Kind {
 	case yaml.SequenceNode:
-		for _, item := range raw.Versions.Content {
-			var name string
-			if err := item.Decode(&name); err != nil {
-				return fmt.Errorf("versions list entry: %w", err)
-			}
-			l.Versions = append(l.Versions, VersionEntry{Name: name})
-		}
+		return fmt.Errorf("versions must be a mapping {v1: {ref: tag1}, v2: {ref: tag2}}; list form is no longer supported")
 	case yaml.MappingNode:
 		// Content alternates key, value, key, value, ... — iterate by
 		// declaration order.
@@ -189,7 +185,7 @@ func (l *LibrarySource) UnmarshalYAML(node *yaml.Node) error {
 			l.Versions = append(l.Versions, v)
 		}
 	default:
-		return fmt.Errorf("versions must be a list or a mapping, got yaml kind %d", raw.Versions.Kind)
+		return fmt.Errorf("versions must be a mapping, got yaml kind %d", raw.Versions.Kind)
 	}
 	return nil
 }

--- a/internal/scraper/config_test.go
+++ b/internal/scraper/config_test.go
@@ -32,7 +32,9 @@ libraries:
       - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/main/docs/quick_start.md
   - lib_id: /facebook/react
     kind: github-md
-    versions: [v18, v19]
+    versions:
+      v18: {}
+      v19: {}
     urls:
       - https://raw.githubusercontent.com/facebook/react/{version}/README.md
       - https://raw.githubusercontent.com/facebook/react/{version}/docs/getting-started.md
@@ -224,7 +226,9 @@ func TestLoadConfig_VersionsRules(t *testing.T) {
 libraries:
   - lib_id: /org/project
     kind: github-md
-    versions: [v1, v2]
+    versions:
+      v1: {}
+      v2: {}
     urls:
       - https://example.com/{version}/a.md
       - https://example.com/main/b.md
@@ -248,7 +252,8 @@ libraries:
 libraries:
   - lib_id: /org/project
     kind: github-md
-    versions: ["v1/foo"]
+    versions:
+      "v1/foo": {}
     urls:
       - https://example.com/{version}/a.md
 `,
@@ -260,7 +265,8 @@ libraries:
 libraries:
   - lib_id: /org/project
     kind: github-md
-    versions: ["v 1"]
+    versions:
+      "v 1": {}
     urls:
       - https://example.com/{version}/a.md
 `,
@@ -272,7 +278,8 @@ libraries:
 libraries:
   - lib_id: /org/project
     kind: github-md
-    versions: ["{version}"]
+    versions:
+      "{version}": {}
     urls:
       - https://example.com/{version}/a.md
 `,
@@ -284,7 +291,8 @@ libraries:
 libraries:
   - lib_id: /org/project
     kind: github-md
-    versions: [""]
+    versions:
+      "": {}
     urls:
       - https://example.com/{version}/a.md
 `,
@@ -302,6 +310,27 @@ libraries:
 				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
 			}
 		})
+	}
+}
+
+// TestLoadConfig_VersionsListShapeRejected pins #117: the legacy list
+// form `versions: [v1, v2]` is rejected at parse time with a message
+// that points at the supported map form.
+func TestLoadConfig_VersionsListShapeRejected(t *testing.T) {
+	path := writeConfig(t, `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    versions: [v1, v2]
+    urls:
+      - https://example.com/{version}/a.md
+`)
+	_, err := scraper.LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for list-shape versions, got nil")
+	}
+	if !strings.Contains(err.Error(), "list form is no longer supported") {
+		t.Errorf("error %q does not contain %q", err.Error(), "list form is no longer supported")
 	}
 }
 
@@ -405,7 +434,9 @@ libraries:
       - https://example.com/go-sdk/README.md
   - lib_id: /facebook/react
     kind: github-md
-    versions: [v18, v19]
+    versions:
+      v18: {}
+      v19: {}
     urls:
       - https://example.com/react/{version}/README.md
 `)
@@ -431,7 +462,9 @@ func TestResolve_FilterByLibAndVersion(t *testing.T) {
 libraries:
   - lib_id: /facebook/react
     kind: github-md
-    versions: [v18, v19]
+    versions:
+      v18: {}
+      v19: {}
     urls:
       - https://example.com/react/{version}/README.md
 `)
@@ -489,7 +522,9 @@ func TestResolve_VersionFilterWithoutMatchingVersion(t *testing.T) {
 libraries:
   - lib_id: /facebook/react
     kind: github-md
-    versions: [v18, v19]
+    versions:
+      v18: {}
+      v19: {}
     urls:
       - https://example.com/react/{version}/README.md
 `)
@@ -508,7 +543,9 @@ func TestResolve_MultiVersionLibIDStaysBase(t *testing.T) {
 libraries:
   - lib_id: /hashicorp/terraform
     kind: github-md
-    versions: [v1.14, v1.13]
+    versions:
+      v1.14: {}
+      v1.13: {}
     urls:
       - https://example.com/tf/{version}/README.md
 `)
@@ -567,7 +604,9 @@ libraries:
 libraries:
   - lib_id: /org/project
     kind: github-md
-    versions: [v1, v2]
+    versions:
+      v1: {}
+      v2: {}
     urls:
       - https://example.com/{version}/{ref}/a.md
 `,

--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -17,12 +17,17 @@
 #
 # Optional:
 #
-#   versions  list of version tags. When present, every URL must contain
-#             the literal "{version}" placeholder; one effective entry is
-#             produced per version with lib_id "<lib_id>/<version>".
+#   versions  mapping of version tags to per-version overrides. When
+#             present, every URL must contain the literal "{version}"
+#             placeholder; one effective entry is produced per version
+#             with lib_id "<lib_id>/<version>". Shape:
 #
-#             Map shape (`versions: {v1: {...}, v2: {...}}`) accepts
-#             per-version overrides:
+#               versions:
+#                 v1: {}                       # no overrides
+#                 v2: { ref: v2.0.1 }          # per-version git pin
+#                 v3: { urls: [...] }          # per-version url list
+#
+#             Per-version overrides:
 #               - `ref:`  pins this version's {ref} substitution (see
 #                         #103)
 #               - `urls:` replaces the top-level `urls:` for this version
@@ -31,6 +36,9 @@
 #                         rejected. Use this when two versions of the
 #                         same lib diverge structurally (a file added,
 #                         renamed, or removed between versions).
+#
+#             The legacy list shape `versions: [v1, v2]` is rejected at
+#             parse time — use `{v1: {}, v2: {}}` instead (see #117).
 #
 # Override this path with `deadzone-scraper -config <path>`. Restrict a run
 # to one library with `-lib /org/project` (matches all versions of that


### PR DESCRIPTION
## Summary

- Remove support for the legacy `versions: [v1, v2]` list shorthand in `libraries_sources.yaml`
- The `versions:` field now **only** accepts the map shape `{v1: {}, v2: {ref: ...}}`, which is a strict superset of the list form
- List-shape input is rejected at parse time with a clear error pointing at the supported syntax

## Motivation

The list shape carried no per-version metadata and was strictly a subset of the map shape. Keeping both meant two parse paths for identical semantics. Dropping the list form simplifies the parser and removes ambiguity.

## Changes

- `internal/scraper/config.go` — replace `SequenceNode` parsing with an explicit error; update comments
- `internal/scraper/config_test.go` — migrate all test fixtures from list to map shape; add `TestLoadConfig_VersionsListShapeRejected`
- `libraries_sources.yaml` — update header comments, document the map-only requirement
- `README.md` / `docs/research/ingestion-architecture.md` — update docs to reflect map-only `versions:`

## Test plan

- [ ] `go test ./internal/scraper/...` passes
- [ ] New test `TestLoadConfig_VersionsListShapeRejected` confirms list input yields the expected error
- [ ] Existing version-related tests still pass with map-shape fixtures

<!-- emdash-issue-footer:start -->
Fixes #117
<!-- emdash-issue-footer:end -->