### PR TITLE
feat(registry): normalize version keys to major.minor, unify on {ref} placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,12 @@ VERSION=v0.1.0 COMMIT=$(git rev-parse --short HEAD) DATE=$(date -u +%FT%TZ) just
 
 ### Refreshing a single library
 
-The per-lib folder layout means one library can be re-scraped without touching the others. The flow is the same for both single-version libs and multi-version (`/facebook/react/v18`, `/facebook/react/v19`, …) entries:
+The per-lib folder layout means one library can be re-scraped without touching the others. The flow is the same for both single-version libs and multi-version (`/hashicorp/terraform/1.13`, `/hashicorp/terraform/1.14`, …) entries:
 
 ```bash
 # Re-scrape locally (rebuilds exactly the matching artifacts/<slug>/artifact.db)
-just scrape /facebook/react           # base — every versioned child
-just scrape /facebook/react/v18       # one expanded version
+just scrape /hashicorp/terraform           # base — every versioned child
+just scrape /hashicorp/terraform/1.14      # one expanded version
 
 # Then re-consolidate to pick up the change in the main DB.
 just consolidate
@@ -290,56 +290,63 @@ libraries:
     urls:
       - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/os.rst
 
-  # Multi-version lib — `versions` expands `{version}` in each URL,
-  # producing one effective lib_id per version (`/facebook/react/v18`,
-  # `/facebook/react/v19`, …) — matches Context7's `/org/project/version`
-  # convention. Entries with no per-version overrides use the `{}` empty
-  # map; add `ref:` and/or `urls:` inside the map to override per version.
-  - lib_id: /facebook/react
+  # Multi-version lib — `versions` expands per-version entries into one
+  # effective lib_id per version (`/modelcontextprotocol/go-sdk/1.4`,
+  # `/modelcontextprotocol/go-sdk/1.5`, …). The `versions:` key is the
+  # user-facing identifier (major.minor, surfaced in `search_libraries` /
+  # `search_docs`); the git tag lives in each version's `ref:` field and
+  # is substituted into `{ref}` in URLs. See #120.
+  - lib_id: /modelcontextprotocol/go-sdk
     kind: github-md
     versions:
-      v18: {}
-      v19: {}
+      "1.4": { ref: v1.4.1 }
+      "1.5": { ref: v1.5.0 }
     urls:
-      - https://raw.githubusercontent.com/facebook/react/{version}/README.md
-      - https://raw.githubusercontent.com/facebook/react/{version}/docs/getting-started.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/README.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/getting-started.md
 
-  # Multi-version lib with a per-version git pin (map shorthand) — each
-  # version gets its own `ref:` substituted into URLs alongside `{version}`.
+  # Per-version `urls:` override — when two versions share a git sha but
+  # the URL path has a literal version segment (HashiCorp's unified-docs
+  # monorepo), each version supplies its own `urls:` block with the
+  # literal hardcoded. See #115, #120.
   - lib_id: /hashicorp/terraform
     kind: github-md
+    ref: 9c479db1ab97
     versions:
-      v1.14: { ref: v1.14.6 }
-      v1.13: { ref: v1.13.5 }
-    urls:
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/intro/index.mdx
+      "1.13":
+        urls:
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/intro/index.mdx
+      "1.14":
+        urls:
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/intro/index.mdx
 
-  # Per-version `urls:` override — when two versions of the same lib
-  # diverge structurally (a file added / renamed / removed), the version
-  # that differs replaces the baseline URL list wholesale. Versions that
-  # omit `urls:` keep inheriting the top-level list. See #115.
+  # Per-version `urls:` override for structurally-diverging versions —
+  # one minor ships an extra doc page (or renames one). The version that
+  # differs replaces the baseline URL list wholesale; the version that
+  # omits `urls:` keeps inheriting the top-level list. See #115.
   - lib_id: /modelcontextprotocol/go-sdk
     kind: github-md
     urls:
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/README.md
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/server.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/README.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/server.md
     versions:
-      v1.4.1: {}                          # inherits baseline (2 URLs)
-      v1.5.0:                             # full override (3 URLs)
+      "1.4": { ref: v1.4.1 }              # inherits baseline (2 URLs)
+      "1.5":                              # full override (3 URLs)
+        ref: v1.5.0
         urls:
-          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/README.md
-          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/server.md
-          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/quick_start.md
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/README.md
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/server.md
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/quick_start.md
 ```
 
 | Field | Required | Purpose |
 |---|---|---|
 | `lib_id` | yes | canonical `/org/project` identifier (matches `db.docs.lib_id`) |
 | `kind` | yes | source kind discriminator — `github-md` for raw markdown, `github-rst` for raw reStructuredText (cpython, Django, NumPy, …), `scrape-via-agent` for HTML/text via an LLM (see [Scraping non-trivial doc sources](#scraping-non-trivial-doc-sources-scrape-via-agent)) |
-| `urls` | yes | list of doc URLs (with optional `{version}` and/or `{ref}` placeholders) |
-| `versions` | no | map `{v1: {ref: tag1, urls: [...]}, v2: {}, …}` of version tags; expands `{version}` in `urls` and produces one effective `lib_id` per version. Each value accepts optional per-version `ref:` and `urls:` overrides — use `{}` when a version has neither. The legacy list form `[v1, v2]` is rejected (see #117). |
+| `urls` | yes | list of doc URLs with an optional `{ref}` placeholder (#120 retired the former `{version}` placeholder). |
+| `versions` | no | map `{"1.4": {ref: v1.4.1, urls: [...]}, "1.5": {ref: v1.5.0}, …}` of user-facing version identifiers to per-version overrides. Keys are the identifiers surfaced to the MCP surface (`search_libraries` / `search_docs`); prefer `major.minor`. Each value accepts optional per-version `ref:` and `urls:` overrides. The legacy list form `[v1, v2]` is rejected (see #117). |
 | `ref` | no | git tag or commit SHA substituted into `{ref}` in `urls` (#103). For multi-version libs, a per-version ref in the `versions:` map overrides this top-level ref. URLs that don't contain `{ref}` are left untouched, so a lib can opt into pinning incrementally. |
-| `versions[v].urls` | no | per-version URL list (#115). When set, replaces the top-level `urls:` for this version wholesale — use it when two versions of the same lib diverge structurally (a file added, renamed, or removed between versions). Omit the field to inherit the baseline; an explicit empty list is rejected. |
+| `versions[v].urls` | no | per-version URL list (#115). When set, replaces the top-level `urls:` for this version wholesale. Use it when two versions of the same lib diverge structurally (a file added, renamed, or removed between versions), or when the URL path contains a literal version segment that can't be shared across versions (the HashiCorp Terraform case, #120). Omit the field to inherit the baseline; an explicit empty list is rejected. |
 
 Adding a new library means adding a YAML entry — no Go editing, no recompile.
 
@@ -353,13 +360,13 @@ mise exec -- go run ./cmd/deadzone scrape -artifacts ./artifacts -config /path/t
 mise exec -- go run ./cmd/deadzone scrape -artifacts /var/cache/deadzone/artifacts
 
 # Scrape every configured version of one base lib
-mise exec -- go run ./cmd/deadzone scrape -artifacts ./artifacts -lib /facebook/react
+mise exec -- go run ./cmd/deadzone scrape -artifacts ./artifacts -lib /hashicorp/terraform
 
-# Scrape only one specific versioned lib
-mise exec -- go run ./cmd/deadzone scrape -artifacts ./artifacts -lib /facebook/react/v18
+# Scrape only one specific versioned lib (pass the major.minor identifier)
+mise exec -- go run ./cmd/deadzone scrape -artifacts ./artifacts -lib /hashicorp/terraform/1.14
 ```
 
-`-lib` matches at two levels: a base `lib_id` selects every expanded version of that base; a fully versioned `lib_id` selects exactly one expanded entry. Omitting `-lib` scrapes everything in the registry. Each entry produces (or replaces) one `artifacts/<slug>/artifact.db` file (+ `state.yaml` sidecar) — the leading `/` is stripped from the `lib_id` and the remaining `/` characters become `_`, so `/facebook/react/v18` lands at `artifacts/facebook_react_v18/artifact.db`.
+`-lib` matches at two levels: a base `lib_id` selects every expanded version of that base; a fully versioned `lib_id` selects exactly one expanded entry. Omitting `-lib` scrapes everything in the registry. Each entry produces (or replaces) one `artifacts/<slug>/artifact.db` file (+ `state.yaml` sidecar) — the leading `/` is stripped from the `lib_id` and the remaining `/` characters become `_`, so `/hashicorp/terraform/1.14` lands at `artifacts/hashicorp_terraform_1.14/artifact.db`.
 
 ### Scraping non-trivial doc sources (`scrape-via-agent`)
 

--- a/docs/research/ingestion-architecture.md
+++ b/docs/research/ingestion-architecture.md
@@ -232,10 +232,19 @@ No metadata. No lifecycle. No sharing model. **Just enough to lift Deadzone out 
 
 The schema gained a fifth optional field, `ref:`, in #103: a git tag or commit SHA that gets substituted into the literal `{ref}` placeholder in URLs at config-resolve time. Without it, every URL points at an unpinned `main`/`master` branch and the resulting `deadzone.db` drifts silently between rebuilds even when the registry and code haven't changed. With it, two operators on the same registry pin produce byte-identical artifacts. Per-version refs (map shorthand for `versions:`) keep multi-version libs reproducible too. The field is opt-in per lib so the schema stays minimal — URLs without `{ref}` are passed through unchanged. The resolved ref is recorded in each artifact's `state.yaml` sidecar so an operator can see what was actually scraped.
 
+### User-facing identifier vs git-layer detail (#120)
+
+Pre-#120 the `versions:` map did double duty: each key was both the user-facing `version` surfaced to the LLM (via `search_libraries` / `search_docs`) and the git tag the scraper fetched. That coupling leaked three different tag formats across the corpus (`v1.9.0`, `0.135.3`, `v3.14.4`) and forced the LLM to guess which shape to pass — *"how do I do X in terraform 1.14"* had to be translated into `v1.14.6` or `v1.14` or `1.14` depending on the lib.
+
+#120 split the two concerns: `versions:` keys became opaque user-facing labels (`major.minor` is the house convention), and the git tag moved into each version's `ref:` field. URLs reference `{ref}` as the sole placeholder — the pre-#120 `{version}` placeholder was retired because it was never doing anything the `ref:` field doesn't do better. The one edge case where URLs need to differ per version beyond a shared `ref:` substitution (HashiCorp's unified-docs monorepo, which bakes `v1.13.x` / `v1.14.x` into the path) is handled by the per-version `urls:` override from #115: each version supplies its own `urls:` block with the literal hardcoded. One placeholder (`{ref}`), one concept, zero ambiguity about what the LLM is supposed to pass.
+
+The separation matters for cache economics too: a patch-level bump (`v1.14.5` → `v1.14.6`) is now a `ref:` edit that doesn't touch the user-facing identifier or the consolidated DB shape, so cached artifacts across minor versions stay stable through routine upstream refreshes.
+
 ### Trace
 
 - Designed in #51, merged in #54
 - Reproducibility pin added in #103
+- Version-identifier / git-tag split in #120
 - The long-term registry research lives in #52 (open, post-mvp)
 
 ### Holds at scale

--- a/internal/scraper/config.go
+++ b/internal/scraper/config.go
@@ -8,17 +8,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// versionPlaceholder is the literal token substituted with each entry in
-// LibrarySource.Versions when expanding a multi-version entry. It is also
-// the token rejected by validation in places where it must not appear
-// (single-version entries, version strings themselves).
-const versionPlaceholder = "{version}"
-
 // refPlaceholder is the literal token substituted with the effective git
 // ref (top-level Source.Ref or per-version VersionEntry.Ref) at expand
-// time. URLs that do not contain the token are left untouched, so a lib
-// can opt into ref pinning incrementally. See #103.
+// time. It is the sole URL placeholder after #120 — the former
+// {version} placeholder was dropped because version identifiers (the
+// `versions:` map keys) are now user-facing labels that no longer need
+// to appear in URLs. URLs that don't contain the token are left
+// untouched, so a lib can opt into ref pinning incrementally. See #103.
 const refPlaceholder = "{ref}"
+
+// deprecatedVersionPlaceholder is the former URL placeholder, now
+// rejected at parse time with a pointer at {ref}. Kept as a named
+// constant so the rejection message is grep-able.
+const deprecatedVersionPlaceholder = "{version}"
 
 // Kind discriminators for LibrarySource.Kind. All branches feed the
 // same downstream pipeline (parse → embed → store); they only differ
@@ -213,21 +215,21 @@ func LoadConfig(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// validate enforces the v1 schema rules:
+// validate enforces the v1 schema rules (post-#120):
 //   - lib_id non-empty, starts with "/", does not end with "/"
 //   - kind in the known set
-//   - top-level urls: no empty/whitespace entries. Non-empty when versions
-//     is unset; may be empty when versions is set only if every version
+//   - top-level urls: no empty/whitespace entries; no URL may contain the
+//     deprecated "{version}" placeholder. Non-empty when versions is
+//     unset; may be empty when versions is set only if every version
 //     supplies its own urls (see #115)
-//   - ref (when set) has no whitespace and no placeholder tokens
+//   - ref (when set) has no whitespace and no placeholder token
 //   - if versions is set: every version has a non-empty name without
-//     whitespace, "/", or "{version}"; per-version refs (map shape) have
-//     no whitespace; every effective URL (baseline OR per-version
-//     override) contains "{version}"; per-version urls (when set) are a
-//     non-empty list with no whitespace-only entries
-//   - if versions is unset: no URL contains "{version}"
-//   - if any URL contains "{ref}": for the single-version entry the
-//     top-level ref must be set; for a multi-version entry every version
+//     whitespace or "/"; per-version refs have no whitespace; every
+//     effective URL list (baseline OR per-version override) contains
+//     "{ref}"; per-version urls (when set) are a non-empty list with no
+//     whitespace-only entries and no "{version}"
+//   - if any URL contains "{ref}": for a single-version entry the top
+//     level ref must be set; for a multi-version entry every version
 //     must resolve to a non-empty ref (per-version ref or top-level ref).
 func (l LibrarySource) validate() error {
 	if l.LibID == "" {
@@ -249,22 +251,19 @@ func (l LibrarySource) validate() error {
 		if strings.TrimSpace(u) == "" {
 			return fmt.Errorf("urls contains an empty entry")
 		}
+		if err := rejectDeprecatedVersionPlaceholder(u); err != nil {
+			return err
+		}
 	}
 	if err := validateRef(l.Ref); err != nil {
 		return fmt.Errorf("ref: %w", err)
 	}
 
 	if len(l.Versions) == 0 {
-		// No versions: top-level urls must be non-empty, no URL may
-		// contain {version} (unresolved placeholder at runtime), and
-		// any {ref} requires a top-level ref.
+		// No versions: top-level urls must be non-empty and any {ref}
+		// requires a top-level ref.
 		if len(l.URLs) == 0 {
 			return fmt.Errorf("urls must be non-empty")
-		}
-		for _, u := range l.URLs {
-			if strings.Contains(u, versionPlaceholder) {
-				return fmt.Errorf("url %q contains %s but no versions are listed", u, versionPlaceholder)
-			}
 		}
 		for _, u := range l.URLs {
 			if strings.Contains(u, refPlaceholder) && l.Ref == "" {
@@ -274,21 +273,13 @@ func (l LibrarySource) validate() error {
 		return nil
 	}
 
-	// Versions present.
-	//
-	// Baseline urls, when set, are the fallback for any version that
-	// doesn't override — so they must contain {version}. When baseline
-	// is empty, every version must supply its own urls.
+	// Versions present. Baseline urls, when set, are the fallback for
+	// any version that doesn't override. When baseline is empty, every
+	// version must supply its own urls.
 	if len(l.URLs) == 0 {
 		for _, v := range l.Versions {
 			if len(v.URLs) == 0 {
 				return fmt.Errorf("urls must be non-empty (or every version must provide its own urls); versions[%q] has no urls and the top-level urls is empty", v.Name)
-			}
-		}
-	} else {
-		for _, u := range l.URLs {
-			if !strings.Contains(u, versionPlaceholder) {
-				return fmt.Errorf("url %q is missing the %s placeholder (required when versions is set)", u, versionPlaceholder)
 			}
 		}
 	}
@@ -303,9 +294,6 @@ func (l LibrarySource) validate() error {
 		if strings.Contains(v.Name, "/") {
 			return fmt.Errorf("version %q must not contain %q", v.Name, "/")
 		}
-		if strings.Contains(v.Name, versionPlaceholder) {
-			return fmt.Errorf("version %q must not contain literal %q", v.Name, versionPlaceholder)
-		}
 		if err := validateRef(v.Ref); err != nil {
 			return fmt.Errorf("versions[%q].ref: %w", v.Name, err)
 		}
@@ -313,13 +301,14 @@ func (l LibrarySource) validate() error {
 			if strings.TrimSpace(u) == "" {
 				return fmt.Errorf("versions[%q].urls contains an empty entry", v.Name)
 			}
-			if !strings.Contains(u, versionPlaceholder) {
-				return fmt.Errorf("versions[%q] url %q is missing the %s placeholder (required when versions is set)", v.Name, u, versionPlaceholder)
+			if err := rejectDeprecatedVersionPlaceholder(u); err != nil {
+				return fmt.Errorf("versions[%q].urls: %w", v.Name, err)
 			}
 		}
 
-		// {ref} check runs on the effective URL list for this version
-		// (per-version override, else baseline).
+		// Every effective URL list must contain {ref} (baseline or
+		// per-version override) — that is the "differentiates per
+		// version" invariant that used to be spelled via {version}.
 		effective := v.URLs
 		if len(effective) == 0 {
 			effective = l.URLs
@@ -331,17 +320,31 @@ func (l LibrarySource) validate() error {
 				break
 			}
 		}
-		if urlHasRef && v.Ref == "" && l.Ref == "" {
+		if !urlHasRef {
+			return fmt.Errorf("versions[%q]: no effective url contains %s (required when versions is set)", v.Name, refPlaceholder)
+		}
+		if v.Ref == "" && l.Ref == "" {
 			return fmt.Errorf("a url contains %s but neither versions[%q].ref nor the top-level ref is set", refPlaceholder, v.Name)
 		}
 	}
 	return nil
 }
 
+// rejectDeprecatedVersionPlaceholder returns an error when a URL still
+// carries the pre-#120 "{version}" placeholder. The message names {ref}
+// as the replacement so operators porting an old registry get a direct
+// pointer at the new placeholder vocabulary.
+func rejectDeprecatedVersionPlaceholder(u string) error {
+	if strings.Contains(u, deprecatedVersionPlaceholder) {
+		return fmt.Errorf("url %q contains deprecated %s placeholder — use %s instead (see #120)", u, deprecatedVersionPlaceholder, refPlaceholder)
+	}
+	return nil
+}
+
 // validateRef enforces the format rules common to top-level and
 // per-version refs: empty is allowed (caller decides whether that's a
-// problem), but a non-empty ref must not contain whitespace or either
-// of the substitution placeholders.
+// problem), but a non-empty ref must not contain whitespace or the
+// {ref} placeholder token itself.
 func validateRef(ref string) error {
 	if ref == "" {
 		return nil
@@ -351,9 +354,6 @@ func validateRef(ref string) error {
 	}
 	if strings.Contains(ref, refPlaceholder) {
 		return fmt.Errorf("ref %q must not contain literal %q", ref, refPlaceholder)
-	}
-	if strings.Contains(ref, versionPlaceholder) {
-		return fmt.Errorf("ref %q must not contain literal %q", ref, versionPlaceholder)
 	}
 	return nil
 }
@@ -365,13 +365,15 @@ func validateRef(ref string) error {
 // top-level Ref (if present).
 //
 // Multi-version entries produce one ResolvedSource per version with
-// LibID == BaseLibID (the base, e.g. /hashicorp/terraform) and
-// Version set to the version tag. The {version} placeholder is
-// substituted in each URL, and the {ref} placeholder is substituted
-// from the per-version Ref if set, else from the top-level Ref. The
-// "<base>/<version>" concatenation that earlier builds produced here
-// is gone (#113); downstream code treats (LibID, Version) as the
-// canonical slot.
+// LibID == BaseLibID (the base, e.g. /hashicorp/terraform) and Version
+// set to the version identifier from the `versions:` map. The {ref}
+// placeholder is substituted from the per-version Ref if set, else
+// from the top-level Ref. Post-#120 there is no {version} substitution:
+// the version identifier is a user-facing label only, and per-version
+// URL divergence is expressed either through {ref} (10 libs) or
+// per-version `urls:` overrides (terraform). The "<base>/<version>"
+// concatenation that earlier builds produced here is gone (#113);
+// downstream code treats (LibID, Version) as the canonical slot.
 func (l LibrarySource) Expand() []ResolvedSource {
 	if len(l.Versions) == 0 {
 		urls := make([]string, len(l.URLs))
@@ -400,7 +402,6 @@ func (l LibrarySource) Expand() []ResolvedSource {
 		}
 		urls := make([]string, len(src))
 		for i, u := range src {
-			u = strings.ReplaceAll(u, versionPlaceholder, v.Name)
 			urls[i] = substituteRef(u, ref)
 		}
 		out = append(out, ResolvedSource{

--- a/internal/scraper/config_test.go
+++ b/internal/scraper/config_test.go
@@ -33,11 +33,11 @@ libraries:
   - lib_id: /facebook/react
     kind: github-md
     versions:
-      v18: {}
-      v19: {}
+      "18": { ref: v18.2.0 }
+      "19": { ref: v19.0.0 }
     urls:
-      - https://raw.githubusercontent.com/facebook/react/{version}/README.md
-      - https://raw.githubusercontent.com/facebook/react/{version}/docs/getting-started.md
+      - https://raw.githubusercontent.com/facebook/react/{ref}/README.md
+      - https://raw.githubusercontent.com/facebook/react/{ref}/docs/getting-started.md
 `)
 
 	cfg, err := scraper.LoadConfig(path)
@@ -61,8 +61,8 @@ libraries:
 	if cfg.Libraries[1].LibID != "/facebook/react" {
 		t.Errorf("libraries[1].LibID = %q", cfg.Libraries[1].LibID)
 	}
-	if got := cfg.Libraries[1].Versions; len(got) != 2 || got[0].Name != "v18" || got[1].Name != "v19" {
-		t.Errorf("libraries[1].Versions = %v, want [{v18} {v19}]", got)
+	if got := cfg.Libraries[1].Versions; len(got) != 2 || got[0].Name != "18" || got[1].Name != "19" {
+		t.Errorf("libraries[1].Versions = %v, want [{18} {19}]", got)
 	}
 }
 
@@ -221,30 +221,18 @@ func TestLoadConfig_VersionsRules(t *testing.T) {
 		want string
 	}{
 		{
-			name: "versions present but URL lacks placeholder",
+			name: "versions present but no URL contains {ref}",
 			yaml: `
 libraries:
   - lib_id: /org/project
     kind: github-md
     versions:
-      v1: {}
-      v2: {}
+      "1.0": { ref: v1.0.0 }
+      "2.0": { ref: v2.0.0 }
     urls:
-      - https://example.com/{version}/a.md
-      - https://example.com/main/b.md
+      - https://example.com/main/a.md
 `,
-			want: "missing the {version} placeholder",
-		},
-		{
-			name: "URL contains placeholder but no versions",
-			yaml: `
-libraries:
-  - lib_id: /org/project
-    kind: github-md
-    urls:
-      - https://example.com/{version}/a.md
-`,
-			want: "no versions are listed",
+			want: "no effective url contains {ref}",
 		},
 		{
 			name: "version contains slash",
@@ -253,9 +241,9 @@ libraries:
   - lib_id: /org/project
     kind: github-md
     versions:
-      "v1/foo": {}
+      "v1/foo": { ref: v1.0.0 }
     urls:
-      - https://example.com/{version}/a.md
+      - https://example.com/{ref}/a.md
 `,
 			want: `must not contain "/"`,
 		},
@@ -266,24 +254,11 @@ libraries:
   - lib_id: /org/project
     kind: github-md
     versions:
-      "v 1": {}
+      "v 1": { ref: v1.0.0 }
     urls:
-      - https://example.com/{version}/a.md
+      - https://example.com/{ref}/a.md
 `,
 			want: "contains whitespace",
-		},
-		{
-			name: "version literally is {version}",
-			yaml: `
-libraries:
-  - lib_id: /org/project
-    kind: github-md
-    versions:
-      "{version}": {}
-    urls:
-      - https://example.com/{version}/a.md
-`,
-			want: `must not contain literal "{version}"`,
 		},
 		{
 			name: "empty version string",
@@ -292,9 +267,9 @@ libraries:
   - lib_id: /org/project
     kind: github-md
     versions:
-      "": {}
+      "": { ref: v1.0.0 }
     urls:
-      - https://example.com/{version}/a.md
+      - https://example.com/{ref}/a.md
 `,
 			want: "empty entry",
 		},
@@ -313,6 +288,67 @@ libraries:
 	}
 }
 
+// TestLoadConfig_VersionPlaceholderRejected pins #120: URLs containing
+// the retired "{version}" placeholder are rejected at parse time. The
+// error message points at "{ref}" as the replacement so operators
+// porting a pre-#120 registry can fix it mechanically.
+func TestLoadConfig_VersionPlaceholderRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "top-level url still uses {version}",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    versions:
+      "1.0": { ref: v1.0.0 }
+    urls:
+      - https://example.com/{version}/a.md
+`,
+		},
+		{
+			name: "per-version url still uses {version}",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    versions:
+      "1.0":
+        ref: v1.0.0
+        urls:
+          - https://example.com/{version}/a.md
+`,
+		},
+		{
+			name: "single-version url still uses {version}",
+			yaml: `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    urls:
+      - https://example.com/{version}/a.md
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := scraper.LoadConfig(writeConfig(t, tc.yaml))
+			if err == nil {
+				t.Fatal("expected rejection of deprecated {version} placeholder, got nil")
+			}
+			if !strings.Contains(err.Error(), "deprecated {version}") {
+				t.Errorf("error %q should mention deprecated {version}", err.Error())
+			}
+			if !strings.Contains(err.Error(), "use {ref} instead") {
+				t.Errorf("error %q should steer the operator toward {ref}", err.Error())
+			}
+		})
+	}
+}
+
 // TestLoadConfig_VersionsListShapeRejected pins #117: the legacy list
 // form `versions: [v1, v2]` is rejected at parse time with a message
 // that points at the supported map form.
@@ -323,7 +359,7 @@ libraries:
     kind: github-md
     versions: [v1, v2]
     urls:
-      - https://example.com/{version}/a.md
+      - https://example.com/{ref}/a.md
 `)
 	_, err := scraper.LoadConfig(path)
 	if err == nil {
@@ -367,12 +403,15 @@ func TestExpand_SingleVersionIsIdentity(t *testing.T) {
 
 func TestExpand_MultiVersionExpandsAndSubstitutes(t *testing.T) {
 	src := scraper.LibrarySource{
-		LibID:    "/facebook/react",
-		Kind:     "github-md",
-		Versions: []scraper.VersionEntry{{Name: "v18"}, {Name: "v19"}},
+		LibID: "/facebook/react",
+		Kind:  "github-md",
+		Versions: []scraper.VersionEntry{
+			{Name: "18", Ref: "v18.2.0"},
+			{Name: "19", Ref: "v19.0.0"},
+		},
 		URLs: []string{
-			"https://raw.githubusercontent.com/facebook/react/{version}/README.md",
-			"https://raw.githubusercontent.com/facebook/react/{version}/docs/getting-started.md",
+			"https://raw.githubusercontent.com/facebook/react/{ref}/README.md",
+			"https://raw.githubusercontent.com/facebook/react/{ref}/docs/getting-started.md",
 		},
 	}
 	out := src.Expand()
@@ -381,7 +420,8 @@ func TestExpand_MultiVersionExpandsAndSubstitutes(t *testing.T) {
 	}
 
 	// After #113 LibID stays equal to the base for every expansion;
-	// the version lives in the dedicated Version field.
+	// the version lives in the dedicated Version field. Post-#120 the
+	// per-version differentiator in URLs is {ref}, not {version}.
 	want := []struct {
 		libID   string
 		version string
@@ -389,18 +429,18 @@ func TestExpand_MultiVersionExpandsAndSubstitutes(t *testing.T) {
 	}{
 		{
 			libID:   "/facebook/react",
-			version: "v18",
+			version: "18",
 			urls: []string{
-				"https://raw.githubusercontent.com/facebook/react/v18/README.md",
-				"https://raw.githubusercontent.com/facebook/react/v18/docs/getting-started.md",
+				"https://raw.githubusercontent.com/facebook/react/v18.2.0/README.md",
+				"https://raw.githubusercontent.com/facebook/react/v18.2.0/docs/getting-started.md",
 			},
 		},
 		{
 			libID:   "/facebook/react",
-			version: "v19",
+			version: "19",
 			urls: []string{
-				"https://raw.githubusercontent.com/facebook/react/v19/README.md",
-				"https://raw.githubusercontent.com/facebook/react/v19/docs/getting-started.md",
+				"https://raw.githubusercontent.com/facebook/react/v19.0.0/README.md",
+				"https://raw.githubusercontent.com/facebook/react/v19.0.0/docs/getting-started.md",
 			},
 		},
 	}
@@ -435,10 +475,10 @@ libraries:
   - lib_id: /facebook/react
     kind: github-md
     versions:
-      v18: {}
-      v19: {}
+      "18": { ref: v18.2.0 }
+      "19": { ref: v19.0.0 }
     urls:
-      - https://example.com/react/{version}/README.md
+      - https://example.com/react/{ref}/README.md
 `)
 
 	all := cfg.Resolve("", "")
@@ -463,21 +503,21 @@ libraries:
   - lib_id: /facebook/react
     kind: github-md
     versions:
-      v18: {}
-      v19: {}
+      "18": { ref: v18.2.0 }
+      "19": { ref: v19.0.0 }
     urls:
-      - https://example.com/react/{version}/README.md
+      - https://example.com/react/{ref}/README.md
 `)
 
-	v18 := cfg.Resolve("/facebook/react", "v18")
+	v18 := cfg.Resolve("/facebook/react", "18")
 	if len(v18) != 1 {
-		t.Fatalf("Resolve(/facebook/react, v18) returned %d, want 1", len(v18))
+		t.Fatalf("Resolve(/facebook/react, 18) returned %d, want 1", len(v18))
 	}
 	if v18[0].LibID != "/facebook/react" {
 		t.Errorf("LibID = %q, want /facebook/react (base stays unversioned after #113)", v18[0].LibID)
 	}
-	if v18[0].Version != "v18" {
-		t.Errorf("Version = %q, want v18", v18[0].Version)
+	if v18[0].Version != "18" {
+		t.Errorf("Version = %q, want 18", v18[0].Version)
 	}
 }
 
@@ -523,14 +563,14 @@ libraries:
   - lib_id: /facebook/react
     kind: github-md
     versions:
-      v18: {}
-      v19: {}
+      "18": { ref: v18.2.0 }
+      "19": { ref: v19.0.0 }
     urls:
-      - https://example.com/react/{version}/README.md
+      - https://example.com/react/{ref}/README.md
 `)
 
-	if got := cfg.Resolve("/facebook/react", "v20"); len(got) != 0 {
-		t.Errorf("expected no matches for v20, got %d", len(got))
+	if got := cfg.Resolve("/facebook/react", "20"); len(got) != 0 {
+		t.Errorf("expected no matches for 20, got %d", len(got))
 	}
 }
 
@@ -544,10 +584,10 @@ libraries:
   - lib_id: /hashicorp/terraform
     kind: github-md
     versions:
-      v1.14: {}
-      v1.13: {}
+      "1.14": { ref: v1.14.6 }
+      "1.13": { ref: v1.13.5 }
     urls:
-      - https://example.com/tf/{version}/README.md
+      - https://example.com/tf/{ref}/README.md
 `)
 
 	got := cfg.Resolve("", "")
@@ -562,8 +602,8 @@ libraries:
 			t.Errorf("[%d].BaseLibID = %q, want /hashicorp/terraform", i, r.BaseLibID)
 		}
 	}
-	if got[0].Version != "v1.14" || got[1].Version != "v1.13" {
-		t.Errorf("versions = %q, %q; want v1.14, v1.13", got[0].Version, got[1].Version)
+	if got[0].Version != "1.14" || got[1].Version != "1.13" {
+		t.Errorf("versions = %q, %q; want 1.14, 1.13", got[0].Version, got[1].Version)
 	}
 }
 
@@ -605,10 +645,10 @@ libraries:
   - lib_id: /org/project
     kind: github-md
     versions:
-      v1: {}
-      v2: {}
+      "1.0": {}
+      "2.0": {}
     urls:
-      - https://example.com/{version}/{ref}/a.md
+      - https://example.com/{ref}/a.md
 `,
 			want: "neither versions",
 		},
@@ -631,9 +671,9 @@ libraries:
   - lib_id: /org/project
     kind: github-md
     versions:
-      v1: { ref: "tag with space" }
+      "1.0": { ref: "tag with space" }
     urls:
-      - https://example.com/{version}/{ref}/a.md
+      - https://example.com/{ref}/a.md
 `,
 			want: "whitespace",
 		},
@@ -707,20 +747,21 @@ func TestExpand_SingleVersionSubstitutesRef(t *testing.T) {
 func TestLoadConfig_VersionsMapShape(t *testing.T) {
 	cfg := mustLoadInline(t, `
 libraries:
-  - lib_id: /hashicorp/terraform
+  - lib_id: /modelcontextprotocol/go-sdk
     kind: github-md
     versions:
-      v1.14: { ref: v1.14.6 }
-      v1.13: { ref: v1.13.5 }
+      "1.5": { ref: v1.5.0 }
+      "1.4": { ref: v1.4.1 }
     urls:
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/intro/index.mdx
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/README.md
 `)
 	got := cfg.Resolve("", "")
 	if len(got) != 2 {
 		t.Fatalf("Resolve returned %d, want 2", len(got))
 	}
 	// Declaration order is preserved. LibID stays the base after #113;
-	// the version lives in Version.
+	// the version lives in Version and is a user-facing label that is
+	// not substituted into URLs anymore (#120).
 	want := []struct {
 		libID   string
 		version string
@@ -728,16 +769,16 @@ libraries:
 		url     string
 	}{
 		{
-			libID:   "/hashicorp/terraform",
-			version: "v1.14",
-			ref:     "v1.14.6",
-			url:     "https://raw.githubusercontent.com/hashicorp/web-unified-docs/v1.14.6/content/terraform/v1.14.x/docs/intro/index.mdx",
+			libID:   "/modelcontextprotocol/go-sdk",
+			version: "1.5",
+			ref:     "v1.5.0",
+			url:     "https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/v1.5.0/README.md",
 		},
 		{
-			libID:   "/hashicorp/terraform",
-			version: "v1.13",
-			ref:     "v1.13.5",
-			url:     "https://raw.githubusercontent.com/hashicorp/web-unified-docs/v1.13.5/content/terraform/v1.13.x/docs/intro/index.mdx",
+			libID:   "/modelcontextprotocol/go-sdk",
+			version: "1.4",
+			ref:     "v1.4.1",
+			url:     "https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/v1.4.1/README.md",
 		},
 	}
 	for i, w := range want {
@@ -764,39 +805,40 @@ libraries:
   - lib_id: /modelcontextprotocol/go-sdk
     kind: github-md
     urls:
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/README.md
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/server.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/README.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/server.md
     versions:
-      v1.4.1: {}
-      v1.5.0:
+      "1.4": { ref: v1.4.1 }
+      "1.5":
+        ref: v1.5.0
         urls:
-          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/README.md
-          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/server.md
-          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/quick_start.md
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/README.md
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/server.md
+          - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/quick_start.md
 `)
 	got := cfg.Resolve("", "")
 	if len(got) != 2 {
 		t.Fatalf("Resolve returned %d, want 2", len(got))
 	}
-	if got[0].Version != "v1.4.1" {
-		t.Fatalf("[0].Version = %q, want v1.4.1", got[0].Version)
+	if got[0].Version != "1.4" {
+		t.Fatalf("[0].Version = %q, want 1.4", got[0].Version)
 	}
 	if len(got[0].URLs) != 2 {
-		t.Errorf("v1.4.1 should inherit baseline (2 URLs), got %d", len(got[0].URLs))
+		t.Errorf("1.4 should inherit baseline (2 URLs), got %d", len(got[0].URLs))
 	}
 	for _, u := range got[0].URLs {
 		if !strings.Contains(u, "/v1.4.1/") {
-			t.Errorf("v1.4.1 URL not substituted: %q", u)
+			t.Errorf("1.4 URL not substituted: %q", u)
 		}
 	}
-	if got[1].Version != "v1.5.0" {
-		t.Fatalf("[1].Version = %q, want v1.5.0", got[1].Version)
+	if got[1].Version != "1.5" {
+		t.Fatalf("[1].Version = %q, want 1.5", got[1].Version)
 	}
 	if len(got[1].URLs) != 3 {
-		t.Errorf("v1.5.0 should use override (3 URLs), got %d", len(got[1].URLs))
+		t.Errorf("1.5 should use override (3 URLs), got %d", len(got[1].URLs))
 	}
 	if !strings.HasSuffix(got[1].URLs[2], "/docs/quick_start.md") {
-		t.Errorf("v1.5.0 URL[2] = %q, want …/docs/quick_start.md", got[1].URLs[2])
+		t.Errorf("1.5 URL[2] = %q, want …/docs/quick_start.md", got[1].URLs[2])
 	}
 }
 
@@ -807,30 +849,76 @@ libraries:
     kind: github-md
     ref: fallback-ref
     versions:
-      v1:
+      "1.0":
         ref: r1
         urls:
-          - https://example.com/{version}/{ref}/a.md
-      v2:
+          - https://example.com/{ref}/a.md
+      "2.0":
         urls:
-          - https://example.com/{version}/{ref}/a.md
-          - https://example.com/{version}/{ref}/b.md
+          - https://example.com/{ref}/a.md
+          - https://example.com/{ref}/b.md
 `)
 	got := cfg.Resolve("", "")
 	if len(got) != 2 {
 		t.Fatalf("Resolve returned %d, want 2", len(got))
 	}
-	if got[0].URLs[0] != "https://example.com/v1/r1/a.md" {
-		t.Errorf("v1 URL = %q", got[0].URLs[0])
+	if got[0].URLs[0] != "https://example.com/r1/a.md" {
+		t.Errorf("1.0 URL = %q", got[0].URLs[0])
 	}
 	if len(got[1].URLs) != 2 {
-		t.Fatalf("v2 URLs len = %d, want 2", len(got[1].URLs))
+		t.Fatalf("2.0 URLs len = %d, want 2", len(got[1].URLs))
 	}
-	if got[1].URLs[0] != "https://example.com/v2/fallback-ref/a.md" {
-		t.Errorf("v2 URLs[0] = %q", got[1].URLs[0])
+	if got[1].URLs[0] != "https://example.com/fallback-ref/a.md" {
+		t.Errorf("2.0 URLs[0] = %q", got[1].URLs[0])
 	}
-	if got[1].URLs[1] != "https://example.com/v2/fallback-ref/b.md" {
-		t.Errorf("v2 URLs[1] = %q", got[1].URLs[1])
+	if got[1].URLs[1] != "https://example.com/fallback-ref/b.md" {
+		t.Errorf("2.0 URLs[1] = %q", got[1].URLs[1])
+	}
+}
+
+// TestExpand_PerVersionURLsAbsorbVersionLiteral pins the terraform shape
+// from #120: when two versions of a lib can't share a URL template
+// because the path has a literal version segment, each version supplies
+// its own `urls:` block with the literal hardcoded. The `{ref}`
+// placeholder still substitutes from the shared top-level ref.
+func TestExpand_PerVersionURLsAbsorbVersionLiteral(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /hashicorp/terraform
+    kind: github-md
+    ref: 9c479db1ab97
+    versions:
+      "1.13":
+        urls:
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/intro/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/intro/core-workflow.mdx
+      "1.14":
+        urls:
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/intro/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/intro/core-workflow.mdx
+`)
+	got := cfg.Resolve("", "")
+	if len(got) != 2 {
+		t.Fatalf("Resolve returned %d, want 2", len(got))
+	}
+	if got[0].Version != "1.13" {
+		t.Errorf("[0].Version = %q, want 1.13", got[0].Version)
+	}
+	if got[0].URLs[0] != "https://raw.githubusercontent.com/hashicorp/web-unified-docs/9c479db1ab97/content/terraform/v1.13.x/docs/intro/index.mdx" {
+		t.Errorf("1.13 URL[0] = %q", got[0].URLs[0])
+	}
+	if got[1].Version != "1.14" {
+		t.Errorf("[1].Version = %q, want 1.14", got[1].Version)
+	}
+	if got[1].URLs[0] != "https://raw.githubusercontent.com/hashicorp/web-unified-docs/9c479db1ab97/content/terraform/v1.14.x/docs/intro/index.mdx" {
+		t.Errorf("1.14 URL[0] = %q", got[1].URLs[0])
+	}
+	// Both versions must resolve to the shared top-level ref since
+	// neither defines a per-version ref:.
+	for i, r := range got {
+		if r.Ref != "9c479db1ab97" {
+			t.Errorf("[%d].Ref = %q, want 9c479db1ab97 (top-level fallback)", i, r.Ref)
+		}
 	}
 }
 
@@ -847,26 +935,27 @@ libraries:
   - lib_id: /org/project
     kind: github-md
     urls:
-      - https://example.com/{version}/a.md
+      - https://example.com/{ref}/a.md
     versions:
-      v1: { urls: [] }
+      "1.0": { ref: v1.0.0, urls: [] }
 `,
 			want: "empty list",
 		},
 		{
-			name: "per-version url missing {version} placeholder",
+			name: "per-version override leaves no url with {ref}",
 			yaml: `
 libraries:
   - lib_id: /org/project
     kind: github-md
     urls:
-      - https://example.com/{version}/a.md
+      - https://example.com/{ref}/a.md
     versions:
-      v1:
+      "1.0":
+        ref: v1.0.0
         urls:
           - https://example.com/fixed/a.md
 `,
-			want: "missing the {version} placeholder",
+			want: "no effective url contains {ref}",
 		},
 		{
 			name: "inheriting version with empty baseline",
@@ -875,12 +964,13 @@ libraries:
   - lib_id: /org/project
     kind: github-md
     versions:
-      v1:
+      "1.0":
+        ref: v1.0.0
         urls:
-          - https://example.com/{version}/a.md
-      v2: {}
+          - https://example.com/{ref}/a.md
+      "2.0": { ref: v2.0.0 }
 `,
-			want: `versions["v2"] has no urls and the top-level urls is empty`,
+			want: `versions["2.0"] has no urls and the top-level urls is empty`,
 		},
 		{
 			name: "per-version urls not a list",
@@ -889,10 +979,11 @@ libraries:
   - lib_id: /org/project
     kind: github-md
     urls:
-      - https://example.com/{version}/a.md
+      - https://example.com/{ref}/a.md
     versions:
-      v1:
-        urls: "https://example.com/{version}/a.md"
+      "1.0":
+        ref: v1.0.0
+        urls: "https://example.com/{ref}/a.md"
 `,
 			want: "must be a list",
 		},
@@ -903,9 +994,10 @@ libraries:
   - lib_id: /org/project
     kind: github-md
     urls:
-      - https://example.com/{version}/a.md
+      - https://example.com/{ref}/a.md
     versions:
-      v1:
+      "1.0":
+        ref: v1.0.0
         urls:
           - "   "
 `,
@@ -932,26 +1024,27 @@ libraries:
   - lib_id: /org/project
     kind: github-md
     urls:
-      - https://example.com/{version}/a.md
+      - https://example.com/{ref}/a.md
     versions:
-      v1: {}
-      v2:
+      "1.0": { ref: v1.0.0 }
+      "2.0":
+        ref: v2.0.0
         urls:
-          - https://example.com/{version}/a.md
-          - https://example.com/{version}/b.md
+          - https://example.com/{ref}/a.md
+          - https://example.com/{ref}/b.md
 `)
 	got := cfg.Resolve("", "")
 	if len(got) != 2 {
 		t.Fatalf("Resolve returned %d, want 2", len(got))
 	}
-	if len(got[0].URLs) != 1 || got[0].URLs[0] != "https://example.com/v1/a.md" {
-		t.Errorf("v1 URLs = %v, want [https://example.com/v1/a.md]", got[0].URLs)
+	if len(got[0].URLs) != 1 || got[0].URLs[0] != "https://example.com/v1.0.0/a.md" {
+		t.Errorf("1.0 URLs = %v, want [https://example.com/v1.0.0/a.md]", got[0].URLs)
 	}
 	if len(got[1].URLs) != 2 {
-		t.Fatalf("v2 URLs len = %d, want 2", len(got[1].URLs))
+		t.Fatalf("2.0 URLs len = %d, want 2", len(got[1].URLs))
 	}
-	if got[1].URLs[1] != "https://example.com/v2/b.md" {
-		t.Errorf("v2 URLs[1] = %q", got[1].URLs[1])
+	if got[1].URLs[1] != "https://example.com/v2.0.0/b.md" {
+		t.Errorf("2.0 URLs[1] = %q", got[1].URLs[1])
 	}
 }
 
@@ -962,25 +1055,25 @@ libraries:
     kind: github-md
     ref: fallback-ref
     versions:
-      v1: { ref: per-version-ref }
-      v2: {}
+      "1.0": { ref: per-version-ref }
+      "2.0": {}
     urls:
-      - https://example.com/{version}/{ref}/a.md
+      - https://example.com/{ref}/a.md
 `)
 	got := cfg.Resolve("", "")
 	if len(got) != 2 {
 		t.Fatalf("Resolve returned %d, want 2", len(got))
 	}
 	if got[0].Ref != "per-version-ref" {
-		t.Errorf("v1 Ref = %q, want per-version-ref", got[0].Ref)
+		t.Errorf("1.0 Ref = %q, want per-version-ref", got[0].Ref)
 	}
 	if got[1].Ref != "fallback-ref" {
-		t.Errorf("v2 Ref = %q, want fallback-ref (top-level fallback)", got[1].Ref)
+		t.Errorf("2.0 Ref = %q, want fallback-ref (top-level fallback)", got[1].Ref)
 	}
-	if got[0].URLs[0] != "https://example.com/v1/per-version-ref/a.md" {
-		t.Errorf("v1 URL = %q", got[0].URLs[0])
+	if got[0].URLs[0] != "https://example.com/per-version-ref/a.md" {
+		t.Errorf("1.0 URL = %q", got[0].URLs[0])
 	}
-	if got[1].URLs[0] != "https://example.com/v2/fallback-ref/a.md" {
-		t.Errorf("v2 URL = %q", got[1].URLs[0])
+	if got[1].URLs[0] != "https://example.com/fallback-ref/a.md" {
+		t.Errorf("2.0 URL = %q", got[1].URLs[0])
 	}
 }

--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -22,15 +22,18 @@
 #             substituted at resolve time (#103). When used at top level,
 #             applies to every expanded version unless overridden.
 #
-#   versions  mapping of version tags to per-version overrides. When
-#             present, every URL must contain the literal "{version}"
-#             placeholder; one effective entry is produced per version
-#             with lib_id "<lib_id>/<version>". Shape:
+#   versions  mapping of version identifiers to per-version overrides.
+#             When present, every effective URL list (baseline or a
+#             per-version `urls:` override) must contain the literal
+#             "{ref}" placeholder; one effective entry is produced per
+#             version with lib_id "<lib_id>/<version>". The pre-#120
+#             "{version}" placeholder has been retired and is rejected
+#             at parse time. Shape:
 #
 #               versions:
-#                 v1: {}                       # no overrides
-#                 v2: { ref: v2.0.1 }          # per-version git pin
-#                 v3: { urls: [...] }          # per-version url list
+#                 "1.4": { ref: v1.4.1 }       # per-version git pin
+#                 "1.5": { ref: v1.5.0 }       # per-version git pin
+#                 "2.0": { urls: [...] }       # per-version url list
 #
 #             Per-version overrides:
 #               - `ref:`  pins this version's {ref} substitution,
@@ -39,22 +42,41 @@
 #                         wholesale (#115). Omit the field to inherit
 #                         the baseline; an explicit `urls: []` is
 #                         rejected. Use this when two versions of the
-#                         same lib diverge structurally (a file added,
-#                         renamed, or removed between versions).
+#                         same lib diverge structurally, or when the
+#                         URL path literal differs per version (see the
+#                         `hashicorp/terraform` entry below).
 #
 #             The legacy list shape `versions: [v1, v2]` is rejected at
-#             parse time — use `{v1: {}, v2: {}}` instead (see #117).
+#             parse time — use `{"1.4": {...}, "1.5": {...}}` instead
+#             (see #117).
 #
-# Version-pinning conventions in this file:
-#   - libs where the version IS the git ref use `versions: {<tag>: {}}`
-#     and reference `{version}` in URLs (the tag serves as both).
-#   - libs where the version is a PATH PREFIX and the git ref is a
-#     separate sha (e.g. hashicorp/terraform via web-unified-docs) use
-#     top-level `ref:` + `versions: {<ver>: {}}` and reference both
-#     `{ref}` and `{version}` in URLs.
+# Version-pinning conventions in this file (#120):
+#   - `versions:` keys are the user-facing IDENTIFIER surfaced by the
+#     MCP surface (`search_libraries`, `search_docs`). They are always
+#     `major.minor` with no `v` prefix (e.g. `1.14`, `0.135`, `3.14`).
+#   - The actual git tag used by the scraper lives in each version's
+#     `ref:` field. URLs reference `{ref}` — not `{version}` — so the
+#     patch bump (`v1.14.5` → `v1.14.6`) is a `ref:` edit that never
+#     touches the user-facing identifier or the consolidated DB shape.
+#   - Exception: `hashicorp/terraform` hardcodes the `v1.13.x` and
+#     `v1.14.x` path literals in each version's own `urls:` block
+#     (per-version URL override from #115). The repo interleaves every
+#     supported terraform version under different path prefixes, so
+#     the two versions share a top-level `ref:` (the web-unified-docs
+#     sha) but can't share a URL template under the `{ref}`-only
+#     placeholder vocabulary. Duplicating the URL list is cheap and
+#     keeps the vocabulary one-placeholder-wide.
+#   - Exception: `scaleway/scaleway-sdk-go` ships only
+#     `v1.0.0-beta.N` prereleases, so its two active minors collapse to
+#     the same `1.0` under the major.minor rule. Fallback: keep the full
+#     prerelease string (`v1.0.0-beta.35`, `v1.0.0-beta.36`) as the
+#     version key, and set per-version `ref:` to the same string so
+#     `{ref}` substitution resolves to the git tag.
 #   - We ship the last 2 minor releases of each lib's latest major
 #     (#113 "2 dernières versions"); single-version when the upstream
-#     has no stable tags or the URL set is trivially thin.
+#     has no stable tags or the URL set is trivially thin. The "last 2
+#     minors" policy (#118) indexes exactly one patch per minor, which
+#     is why dropping the patch from the identifier is lossless.
 #
 # Override this path with `deadzone scrape -config <path>`. Restrict a
 # run to one library with `-lib /org/project` (matches all versions) or
@@ -64,17 +86,17 @@ libraries:
   - lib_id: /modelcontextprotocol/go-sdk
     kind: github-md
     versions:
-      v1.4.1: {}
-      v1.5.0: {}
+      "1.4": { ref: v1.4.1 }
+      "1.5": { ref: v1.5.0 }
     urls:
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/README.md
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/README.md
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/server.md
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/client.md
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/protocol.md
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/mcpgodebug.md
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/troubleshooting.md
-      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{version}/docs/rough_edges.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/README.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/README.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/server.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/client.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/protocol.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/mcpgodebug.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/troubleshooting.md
+      - https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/{ref}/docs/rough_edges.md
 
   # FastAPI — repo transferred from tiangolo/fastapi to fastapi/fastapi
   # (new fastapi org). Docs site at fastapi.tiangolo.com is rendered
@@ -84,110 +106,110 @@ libraries:
   - lib_id: /fastapi/fastapi
     kind: github-md
     versions:
-      0.134.0: {}
-      0.135.3: {}
+      "0.134": { ref: 0.134.0 }
+      "0.135": { ref: 0.135.3 }
     urls:
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/additional-responses.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/additional-status-codes.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/advanced-dependencies.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/advanced-python-types.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/async-tests.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/behind-a-proxy.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/custom-response.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/dataclasses.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/events.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/generate-clients.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/index.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/json-base64-bytes.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/middleware.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/openapi-callbacks.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/openapi-webhooks.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/path-operation-advanced-configuration.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/response-change-status-code.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/response-cookies.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/response-directly.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/response-headers.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/security/http-basic-auth.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/security/index.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/security/oauth2-scopes.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/settings.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/stream-data.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/strict-content-type.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/sub-applications.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/templates.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/testing-dependencies.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/testing-events.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/testing-websockets.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/using-request-directly.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/websockets.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/advanced/wsgi.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/async.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/background-tasks.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/benchmarks.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/contributing.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/deployment/cloud.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/deployment/concepts.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/deployment/docker.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/deployment/https.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/deployment/index.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/deployment/manually.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/deployment/server-workers.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/deployment/versions.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/features.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/help-fastapi.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/index.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/learn/index.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/project-generation.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/python-types.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/resources/index.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/background-tasks.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/bigger-applications.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/body-fields.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/body-multiple-params.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/body-nested-models.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/body-updates.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/body.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/cookie-param-models.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/cookie-params.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/cors.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/debugging.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/dependencies/classes-as-dependencies.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/dependencies/dependencies-in-path-operation-decorators.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/dependencies/global-dependencies.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/dependencies/index.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/dependencies/sub-dependencies.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/encoder.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/extra-data-types.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/extra-models.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/first-steps.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/handling-errors.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/header-param-models.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/header-params.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/index.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/middleware.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/path-operation-configuration.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/path-params-numeric-validations.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/path-params.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/query-param-models.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/query-params-str-validations.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/query-params.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/request-files.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/request-form-models.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/request-forms-and-files.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/request-forms.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/response-model.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/response-status-code.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/schema-extra-example.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/security/first-steps.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/security/get-current-user.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/security/index.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/security/oauth2-jwt.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/security/simple-oauth2.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/sql-databases.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/static-files.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/tutorial/testing.md
-      - https://raw.githubusercontent.com/fastapi/fastapi/{version}/docs/en/docs/virtual-environments.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/additional-responses.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/additional-status-codes.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/advanced-dependencies.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/advanced-python-types.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/async-tests.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/behind-a-proxy.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/custom-response.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/dataclasses.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/events.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/generate-clients.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/index.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/json-base64-bytes.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/middleware.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/openapi-callbacks.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/openapi-webhooks.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/path-operation-advanced-configuration.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/response-change-status-code.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/response-cookies.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/response-directly.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/response-headers.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/security/http-basic-auth.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/security/index.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/security/oauth2-scopes.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/settings.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/stream-data.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/strict-content-type.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/sub-applications.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/templates.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/testing-dependencies.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/testing-events.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/testing-websockets.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/using-request-directly.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/websockets.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/advanced/wsgi.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/async.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/background-tasks.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/benchmarks.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/contributing.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/deployment/cloud.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/deployment/concepts.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/deployment/docker.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/deployment/https.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/deployment/index.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/deployment/manually.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/deployment/server-workers.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/deployment/versions.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/features.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/help-fastapi.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/index.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/learn/index.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/project-generation.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/python-types.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/resources/index.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/background-tasks.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/bigger-applications.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/body-fields.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/body-multiple-params.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/body-nested-models.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/body-updates.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/body.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/cookie-param-models.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/cookie-params.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/cors.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/debugging.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/dependencies/classes-as-dependencies.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/dependencies/dependencies-in-path-operation-decorators.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/dependencies/global-dependencies.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/dependencies/index.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/dependencies/sub-dependencies.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/encoder.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/extra-data-types.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/extra-models.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/first-steps.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/handling-errors.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/header-param-models.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/header-params.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/index.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/middleware.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/path-operation-configuration.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/path-params-numeric-validations.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/path-params.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/query-param-models.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/query-params-str-validations.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/query-params.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/request-files.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/request-form-models.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/request-forms-and-files.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/request-forms.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/response-model.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/response-status-code.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/schema-extra-example.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/security/first-steps.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/security/get-current-user.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/security/index.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/security/oauth2-jwt.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/security/simple-oauth2.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/sql-databases.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/static-files.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/tutorial/testing.md
+      - https://raw.githubusercontent.com/fastapi/fastapi/{ref}/docs/en/docs/virtual-environments.md
 
   # OpenJDK intentionally omitted from 0.1: docs.oracle.com javadoc is
   # pre-rendered HTML only (no markdown/rst source upstream), so pulling it
@@ -200,29 +222,29 @@ libraries:
   - lib_id: /python/cpython
     kind: github-rst
     versions:
-      v3.13.9: {}
-      v3.14.4: {}
+      "3.13": { ref: v3.13.9 }
+      "3.14": { ref: v3.14.4 }
     urls:
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/os.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/sys.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/pathlib.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/json.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/collections.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/itertools.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/functools.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/subprocess.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/asyncio.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/argparse.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/re.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/datetime.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/typing.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/dataclasses.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/enum.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/logging.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/urllib.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/http.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/socket.rst
-      - https://raw.githubusercontent.com/python/cpython/{version}/Doc/library/threading.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/os.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/sys.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/pathlib.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/json.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/collections.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/itertools.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/functools.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/subprocess.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/asyncio.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/argparse.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/re.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/datetime.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/typing.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/dataclasses.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/enum.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/logging.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/urllib.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/http.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/socket.rst
+      - https://raw.githubusercontent.com/python/cpython/{ref}/Doc/library/threading.rst
 
   # HashiCorp Terraform — docs live as MDX in hashicorp/web-unified-docs
   # under content/terraform/<version>.x/docs/. The git ref is a sha from
@@ -230,166 +252,221 @@ libraries:
   # version side-by-side under different path prefixes, so the same sha
   # serves both v1.13.x and v1.14.x). Bump the sha to refresh the
   # snapshot.
+  #
+  # Per-version `urls:` blocks instead of a shared baseline: the repo
+  # path contains a literal `v1.13.x` / `v1.14.x` segment, so the two
+  # versions can't share a single URL template under the post-#120
+  # placeholder vocabulary (the only placeholder is `{ref}`, which is
+  # the same sha for both). Duplicating the URL list is the cheap way
+  # to keep the vocab one-placeholder-wide.
   - lib_id: /hashicorp/terraform
     kind: github-md
     ref: 9c479db1ab97
     versions:
-      v1.13: {}
-      v1.14: {}
-    urls:
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/intro/index.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/intro/core-workflow.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/intro/use-cases.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/index.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/style.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/resources/index.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/resources/configure.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/resources/destroy.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/modules/index.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/modules/configuration.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/modules/sources.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/values/index.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/values/variables.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/values/outputs.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/values/locals.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/state/index.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/state/purpose.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/state/backends.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/state/remote.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/state/locking.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/state/workspaces.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/state/import.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/expressions/index.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/expressions/references.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/expressions/conditionals.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/expressions/for.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/expressions/function-calls.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/expressions/types.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/expressions/type-constraints.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/expressions/operators.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/expressions/strings.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/language/expressions/dynamic-blocks.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/init.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/plan.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/apply.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/destroy.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/import.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/validate.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/fmt.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/state/list.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/state/mv.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/state/rm.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/state/show.mdx
-      - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/{version}.x/docs/cli/commands/workspace/index.mdx
+      "1.13":
+        urls:
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/intro/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/intro/core-workflow.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/intro/use-cases.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/style.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/resources/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/resources/configure.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/resources/destroy.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/modules/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/modules/configuration.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/modules/sources.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/values/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/values/variables.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/values/outputs.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/values/locals.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/state/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/state/purpose.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/state/backends.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/state/remote.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/state/locking.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/state/workspaces.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/state/import.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/expressions/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/expressions/references.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/expressions/conditionals.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/expressions/for.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/expressions/function-calls.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/expressions/types.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/expressions/type-constraints.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/expressions/operators.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/expressions/strings.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/language/expressions/dynamic-blocks.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/init.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/plan.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/apply.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/destroy.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/import.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/validate.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/fmt.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/state/list.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/state/mv.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/state/rm.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/state/show.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.13.x/docs/cli/commands/workspace/index.mdx
+      "1.14":
+        urls:
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/intro/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/intro/core-workflow.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/intro/use-cases.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/style.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/resources/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/resources/configure.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/resources/destroy.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/modules/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/modules/configuration.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/modules/sources.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/values/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/values/variables.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/values/outputs.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/values/locals.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/state/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/state/purpose.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/state/backends.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/state/remote.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/state/locking.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/state/workspaces.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/state/import.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/expressions/index.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/expressions/references.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/expressions/conditionals.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/expressions/for.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/expressions/function-calls.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/expressions/types.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/expressions/type-constraints.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/expressions/operators.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/expressions/strings.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/language/expressions/dynamic-blocks.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/init.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/plan.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/apply.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/destroy.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/import.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/validate.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/fmt.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/state/list.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/state/mv.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/state/rm.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/state/show.mdx
+          - https://raw.githubusercontent.com/hashicorp/web-unified-docs/{ref}/content/terraform/v1.14.x/docs/cli/commands/workspace/index.mdx
 
   # OpenTofu — docs are MDX directly in the opentofu repo at
   # website/docs/. Terraform fork, so the tree shape mirrors hashicorp's.
   - lib_id: /opentofu/opentofu
     kind: github-md
     versions:
-      v1.10.9: {}
-      v1.11.6: {}
+      "1.10": { ref: v1.10.9 }
+      "1.11": { ref: v1.11.6 }
     urls:
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/intro/index.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/intro/core-workflow.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/intro/use-cases.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/intro/upgrading.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/intro/whats-new.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/index.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/resources/index.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/resources/syntax.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/resources/behavior.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/modules/index.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/modules/syntax.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/modules/sources.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/values/index.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/values/variables.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/values/outputs.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/values/locals.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/state/index.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/state/purpose.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/state/backends.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/state/remote.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/state/locking.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/state/workspaces.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/state/import.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/state/encryption.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/state/sensitive-data.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/expressions/index.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/expressions/references.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/expressions/conditionals.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/expressions/for.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/expressions/function-calls.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/expressions/types.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/expressions/type-constraints.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/expressions/operators.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/expressions/strings.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/language/expressions/dynamic-blocks.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/cli/commands/init.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/cli/commands/plan.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/cli/commands/apply.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/cli/commands/destroy.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/cli/commands/validate.mdx
-      - https://raw.githubusercontent.com/opentofu/opentofu/{version}/website/docs/cli/commands/fmt.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/intro/index.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/intro/core-workflow.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/intro/use-cases.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/intro/upgrading.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/intro/whats-new.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/index.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/resources/index.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/resources/syntax.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/resources/behavior.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/modules/index.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/modules/syntax.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/modules/sources.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/values/index.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/values/variables.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/values/outputs.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/values/locals.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/state/index.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/state/purpose.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/state/backends.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/state/remote.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/state/locking.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/state/workspaces.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/state/import.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/state/encryption.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/state/sensitive-data.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/expressions/index.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/expressions/references.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/expressions/conditionals.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/expressions/for.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/expressions/function-calls.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/expressions/types.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/expressions/type-constraints.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/expressions/operators.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/expressions/strings.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/language/expressions/dynamic-blocks.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/cli/commands/init.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/cli/commands/plan.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/cli/commands/apply.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/cli/commands/destroy.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/cli/commands/validate.mdx
+      - https://raw.githubusercontent.com/opentofu/opentofu/{ref}/website/docs/cli/commands/fmt.mdx
 
   # OVHcloud Go SDK — README is the canonical reference.
   - lib_id: /ovh/go-ovh
     kind: github-md
     versions:
-      v1.8.0: {}
-      v1.9.0: {}
+      "1.8": { ref: v1.8.0 }
+      "1.9": { ref: v1.9.0 }
     urls:
-      - https://raw.githubusercontent.com/ovh/go-ovh/{version}/README.md
+      - https://raw.githubusercontent.com/ovh/go-ovh/{ref}/README.md
 
   # OVHcloud CLI (v2). Canonical repo name is `ovhcloud-cli`, not `ovh-cli`.
   - lib_id: /ovh/ovhcloud-cli
     kind: github-md
     versions:
-      v0.10.0: {}
-      v0.11.0: {}
+      "0.10": { ref: v0.10.0 }
+      "0.11": { ref: v0.11.0 }
     urls:
-      - https://raw.githubusercontent.com/ovh/ovhcloud-cli/{version}/README.md
+      - https://raw.githubusercontent.com/ovh/ovhcloud-cli/{ref}/README.md
 
   # OVHcloud Terraform provider — README + top-level provider doc.
   - lib_id: /ovh/terraform-provider-ovh
     kind: github-md
     versions:
-      v2.12.0: {}
-      v2.13.0: {}
+      "2.12": { ref: v2.12.0 }
+      "2.13": { ref: v2.13.0 }
     urls:
-      - https://raw.githubusercontent.com/ovh/terraform-provider-ovh/{version}/README.md
-      - https://raw.githubusercontent.com/ovh/terraform-provider-ovh/{version}/docs/index.md
+      - https://raw.githubusercontent.com/ovh/terraform-provider-ovh/{ref}/README.md
+      - https://raw.githubusercontent.com/ovh/terraform-provider-ovh/{ref}/docs/index.md
 
-  # Scaleway Go SDK — still shipped as v1.0.0-beta.N (no stable); the
-  # two most recent betas are the "last two minors" analogue here.
+  # Scaleway Go SDK — still shipped as v1.0.0-beta.N (no stable). Both
+  # active betas would collapse to `1.0` under the major.minor rule, so
+  # this lib keeps the full prerelease string as the version key (the
+  # documented exception to the #120 convention). `ref:` mirrors the
+  # version key verbatim because the version IS the git tag for this lib.
   - lib_id: /scaleway/scaleway-sdk-go
     kind: github-md
     versions:
-      v1.0.0-beta.35: {}
-      v1.0.0-beta.36: {}
+      v1.0.0-beta.35: { ref: v1.0.0-beta.35 }
+      v1.0.0-beta.36: { ref: v1.0.0-beta.36 }
     urls:
-      - https://raw.githubusercontent.com/scaleway/scaleway-sdk-go/{version}/README.md
+      - https://raw.githubusercontent.com/scaleway/scaleway-sdk-go/{ref}/README.md
 
   # Scaleway CLI — README + cookbook + v2 migration guide.
   - lib_id: /scaleway/scaleway-cli
     kind: github-md
     versions:
-      v2.53.0: {}
-      v2.54.0: {}
+      "2.53": { ref: v2.53.0 }
+      "2.54": { ref: v2.54.0 }
     urls:
-      - https://raw.githubusercontent.com/scaleway/scaleway-cli/{version}/README.md
-      - https://raw.githubusercontent.com/scaleway/scaleway-cli/{version}/docs/cookbook.md
-      - https://raw.githubusercontent.com/scaleway/scaleway-cli/{version}/docs/migration_guide_v2.md
+      - https://raw.githubusercontent.com/scaleway/scaleway-cli/{ref}/README.md
+      - https://raw.githubusercontent.com/scaleway/scaleway-cli/{ref}/docs/cookbook.md
+      - https://raw.githubusercontent.com/scaleway/scaleway-cli/{ref}/docs/migration_guide_v2.md
 
   # Scaleway Terraform provider — README + top-level provider doc.
   - lib_id: /scaleway/terraform-provider-scaleway
     kind: github-md
     versions:
-      v2.71.0: {}
-      v2.72.0: {}
+      "2.71": { ref: v2.71.0 }
+      "2.72": { ref: v2.72.0 }
     urls:
-      - https://raw.githubusercontent.com/scaleway/terraform-provider-scaleway/{version}/README.md
-      - https://raw.githubusercontent.com/scaleway/terraform-provider-scaleway/{version}/docs/index.md
+      - https://raw.githubusercontent.com/scaleway/terraform-provider-scaleway/{ref}/README.md
+      - https://raw.githubusercontent.com/scaleway/terraform-provider-scaleway/{ref}/docs/index.md
 
   # opencode (AI coding CLI, formerly sst/opencode, transferred to
   # anomalyco). The project only tags a separate `vscode-*` extension


### PR DESCRIPTION
## Summary

- **Split user-facing identifier from git tag**: `versions:` map keys are now opaque `major.minor` labels (e.g. `"1.4"`, `"0.135"`); the actual git tag lives in each version's `ref:` field. This removes the coupling that leaked inconsistent tag formats (`v1.9.0`, `0.135.3`, `v3.14.4`) into the MCP surface.
- **Retired `{version}` placeholder**: URLs now use `{ref}` as the sole substitution token. The old `{version}` placeholder is rejected at parse time with a migration pointer at `{ref}` (see `rejectDeprecatedVersionPlaceholder`).
- **Tightened multi-version validation**: every effective URL list for a versioned entry must now contain `{ref}` — this was previously optional, letting entries slip through without any per-version differentiation.
- **Migrated all 11 libraries** in `libraries_sources.yaml` to the new key convention and `{ref}`-only URLs.

## Motivation

Pre-#120 the version key did double duty as both the user-facing label and the git ref, forcing the LLM to guess tag formats when resolving queries like *"how do I do X in terraform 1.14"*. Splitting the two concerns means:
- Patch bumps (`v1.14.5` → `v1.14.6`) are a `ref:` edit that never touches the user-facing identifier or consolidated DB shape
- One placeholder (`{ref}`), one concept, zero ambiguity

## Changed files

- `internal/scraper/config.go` — validation and expansion logic
- `internal/scraper/config_test.go` — updated test cases for new rules
- `libraries_sources.yaml` — migrated all entries
- `README.md` — updated examples and conventions
- `docs/research/ingestion-architecture.md` — added #120 design trace

## Test plan

- [ ] `go test ./internal/scraper/...` passes
- [ ] `just lint` passes
- [ ] Spot-check `just scrape /modelcontextprotocol/go-sdk` resolves URLs correctly with `{ref}` substitution
- [ ] Verify `{version}` in a URL is rejected at parse time with a helpful error message

<!-- emdash-issue-footer:start -->
Fixes #120
<!-- emdash-issue-footer:end -->