### PR TITLE
fix scraper: persist libs.doc_count on mid-loop abort (#65)

### DIFF
--- a/cmd/deadzone/scrape.go
+++ b/cmd/deadzone/scrape.go
@@ -553,16 +553,16 @@ func scrapeLibToArtifact(
 		docsTotal += docsInserted
 	}
 
-	// The libs catalog row is updated by the deferred UpdateLibCount
-	// installed earlier in this function (see #65) — it runs on every
-	// exit path so a mid-loop abort still persists the partial count.
-
-	// Write the `.state` sidecar AFTER the `.db` is committed and the
-	// libs catalog row is updated, so a failure mid-scrape leaves any
-	// pre-existing sidecar intact (operators can re-run the scrape to
-	// regenerate both). `created_at` is preserved from the sidecar we
-	// read before the wipe; absent or zero on the first scrape, in
-	// which case it is seeded from `now` below.
+	// Write the `.state` sidecar once the docs table is fully populated;
+	// the libs catalog row is updated by the deferred UpdateLibCount
+	// installed earlier in this function (see #65), which runs just
+	// before `d.Close()` on every exit path. Reaching this point means
+	// the URL loop completed without a fatal error, so writing the
+	// sidecar here reflects a fully successful scrape — a mid-scrape
+	// abort returns above and leaves any pre-existing sidecar intact.
+	// `created_at` is preserved from the sidecar we read before the
+	// wipe; absent or zero on the first scrape, in which case it is
+	// seeded from `now` below.
 	now := time.Now().UTC()
 	state := &packs.StateFile{
 		LibID:         src.LibID,

--- a/cmd/deadzone/scrape.go
+++ b/cmd/deadzone/scrape.go
@@ -318,7 +318,7 @@ func scrapeLibToArtifact(
 	meta db.Meta,
 	artifactsDir string,
 	src scraper.ResolvedSource,
-) (int, int, error) {
+) (docsTotal int, skippedThisLib int, err error) {
 	artifactDir := packs.ArtifactDir(artifactsDir, src.LibID, src.Version)
 	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
 		return 0, 0, fmt.Errorf("create artifact dir %s: %w", artifactDir, err)
@@ -382,13 +382,34 @@ func scrapeLibToArtifact(
 	// filled in at the end of this function once we know the real
 	// number. Each ResolvedSource covers exactly one (lib_id, version)
 	// slot so a single upsert per source is the correct grain.
-	if err := db.UpsertLibIfNew(d, src.LibID, src.Version, e); err != nil {
-		return 0, 0, fmt.Errorf("upsert lib %q version %q: %w", src.LibID, src.Version, err)
+	if upsertErr := db.UpsertLibIfNew(d, src.LibID, src.Version, e); upsertErr != nil {
+		return 0, 0, fmt.Errorf("upsert lib %q version %q: %w", src.LibID, src.Version, upsertErr)
 	}
 
+	// Deferred so libs.doc_count reflects what actually landed in the
+	// docs table even if the URL loop aborts mid-way (#65). The named
+	// docsTotal return captures the running total at defer time;
+	// LIFO ordering puts this before defer d.Close() so the Exec still
+	// runs against an open handle. Never clobbers a non-nil err from
+	// the loop — the update failure is logged and only promoted to the
+	// returned error when the scrape would otherwise have succeeded.
+	defer func() {
+		updateErr := db.UpdateLibCount(d, src.LibID, src.Version, docsTotal)
+		if updateErr == nil {
+			return
+		}
+		slog.Error("scraper.update_lib_count_failed",
+			"lib_id", src.LibID,
+			"version", src.Version,
+			"docs_total", docsTotal,
+			"err", updateErr.Error(),
+		)
+		if err == nil {
+			err = fmt.Errorf("update lib count %q version %q: %w", src.LibID, src.Version, updateErr)
+		}
+	}()
+
 	libStart := time.Now()
-	var docsTotal int
-	var skippedThisLib int
 
 	for _, u := range src.URLs {
 		// Per-URL fetch — split out from the embed/insert loop so the
@@ -532,20 +553,9 @@ func scrapeLibToArtifact(
 		docsTotal += docsInserted
 	}
 
-	// Update the libs catalog with the final indexed doc count so
-	// search_libraries can rank by "how well-indexed is this lib".
-	// Each artifact is rebuilt from scratch, so docsTotal is the
-	// absolute row count for the lib in this artifact — no append-
-	// vs-replace ambiguity.
-	if err := db.UpdateLibCount(d, src.LibID, src.Version, docsTotal); err != nil {
-		slog.Error("scraper.update_lib_count_failed",
-			"lib_id", src.LibID,
-			"version", src.Version,
-			"docs_total", docsTotal,
-			"err", err.Error(),
-		)
-		return docsTotal, skippedThisLib, fmt.Errorf("update lib count %q version %q: %w", src.LibID, src.Version, err)
-	}
+	// The libs catalog row is updated by the deferred UpdateLibCount
+	// installed earlier in this function (see #65) — it runs on every
+	// exit path so a mid-loop abort still persists the partial count.
 
 	// Write the `.state` sidecar AFTER the `.db` is committed and the
 	// libs catalog row is updated, so a failure mid-scrape leaves any

--- a/cmd/deadzone/scrape_test.go
+++ b/cmd/deadzone/scrape_test.go
@@ -370,6 +370,85 @@ func TestScraper_NoStateOnFailure(t *testing.T) {
 	}
 }
 
+// TestScraper_LibCountReflectsDocsOnMidLoopAbort covers #65: when the
+// URL loop aborts mid-way (hard error on an intermediate URL), the
+// `libs.doc_count` column must still reflect the docs that actually
+// landed in the `docs` table — not stay at the 0 that UpsertLibIfNew
+// seeded. Before the defer fix, the `UpdateLibCount` call at the end
+// of scrapeLibToArtifact was skipped by any early `return` on a fatal
+// error, leaving the catalog row stale.
+func TestScraper_LibCountReflectsDocsOnMidLoopAbort(t *testing.T) {
+	// Not t.Parallel(): see TestScraper_WritesState_FirstScrape for the
+	// purego+race+checkptr trade-off.
+
+	// One-H2 markdown so each OK URL produces exactly one doc; that
+	// makes the expected doc_count trivially equal to the number of
+	// OK URLs processed before the abort.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/fail") {
+			// 404 is classified as a fatal (non-soft) error by
+			// classifyFetchErr, so it aborts the lib immediately
+			// rather than tripping the skipped_ceiling.
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/markdown")
+		fmt.Fprint(w, "# Title\n\n## Section\n\nBody text.\n")
+	}))
+	defer srv.Close()
+
+	artifacts := t.TempDir()
+	e, meta := newStubMeta()
+	libID := "/test/midabort"
+	sources := []scraper.ResolvedSource{{
+		LibID: libID, BaseLibID: libID, Kind: scraper.KindGithubMD,
+		URLs: []string{
+			srv.URL + "/ok-0.md",
+			srv.URL + "/ok-1.md",
+			srv.URL + "/fail.md",
+			srv.URL + "/ok-2.md",
+		},
+	}}
+
+	results := scrapeSources(context.Background(), http.DefaultClient, nil, e, meta, artifacts, sources,
+		map[string]int{scraper.KindGithubMD: 1})
+	if results[0].err == nil {
+		t.Fatal("expected scrape to fail on /fail.md, got nil err")
+	}
+	wantDocs := results[0].docs
+	if wantDocs == 0 {
+		t.Fatalf("expected >=1 doc inserted before abort, got 0 (test fixture regressed)")
+	}
+
+	// Reopen the artifact and read libs.doc_count directly. Without the
+	// #65 fix this row stays at 0 even though `wantDocs` snippets are
+	// sitting in the docs table.
+	artifactPath := packs.ArtifactDBPath(artifacts, libID, "")
+	d, err := db.OpenArtifact(artifactPath, meta, libID, "")
+	if err != nil {
+		t.Fatalf("reopen artifact %s: %v", artifactPath, err)
+	}
+	defer d.Close()
+
+	var docCount int
+	if err := d.QueryRow(`SELECT doc_count FROM libs WHERE lib_id = ? AND version = ?`, libID, "").Scan(&docCount); err != nil {
+		t.Fatalf("read libs.doc_count: %v", err)
+	}
+	if docCount != wantDocs {
+		t.Errorf("libs.doc_count = %d after mid-loop abort, want %d (docs actually inserted)", docCount, wantDocs)
+	}
+
+	// Sanity: the docs table agrees with the libs catalog. If these
+	// diverge in the future, the scraper has a different bug to chase.
+	var docsRows int
+	if err := d.QueryRow(`SELECT count(*) FROM docs WHERE lib_id = ?`, libID).Scan(&docsRows); err != nil {
+		t.Fatalf("read docs count: %v", err)
+	}
+	if docsRows != wantDocs {
+		t.Errorf("docs table row count = %d, want %d (matches scrape result)", docsRows, wantDocs)
+	}
+}
+
 // TestEnvIntOr covers the three branches the flag defaults depend on:
 // unset, bad, and good values. Silent fallback on a bad value is by
 // design (see envIntOr's comment).


### PR DESCRIPTION
Closes #65.

## Summary

`scrapeLibToArtifact` calls `db.UpdateLibCount` to record how many docs landed in the artifact. Previously that call was the last statement of the function, so any early `return` from the URL loop (fatal fetch error, insert failure) skipped it — leaving `libs.doc_count = 0` even though docs were committed. This biases `search_libraries` ranking against partially-scraped libs and was flagged during the #58 FastAPI smoke test.

## Fix

Option A from the issue: named return values + `defer` the `UpdateLibCount`, installed right after `UpsertLibIfNew` so the libs row already exists when the deferred Exec runs. LIFO ordering puts it before `defer d.Close()` so the handle is still open. The defer never clobbers an existing `err` — an update failure is logged unconditionally and only promoted to the returned error when the scrape would otherwise have succeeded.

## Test

`TestScraper_LibCountReflectsDocsOnMidLoopAbort` drives four URLs through an `httptest.Server` where URL 3 returns 404 (fatal per `classifyFetchErr`). After the aborted run, it reopens the artifact and asserts `libs.doc_count` equals the actual row count in `docs` (instead of 0). Also sanity-checks docs-table agreement.

## Verification

- `just test` (cmd/deadzone package, ORT tag): all pass
- `just vet`: clean
- Test was confirmed failing before the `defer` fix on a scratch run (baseline: `doc_count = 0`, expected = 2)

## Out of scope

- Reconciling stale `doc_count` on pre-existing DBs — fresh scrapes fix themselves; old ones can be re-scraped or repaired with a one-shot `UPDATE libs SET doc_count = (SELECT COUNT(*) FROM docs WHERE docs.lib_id = libs.lib_id)`.