### PR TITLE
feat: add Homebrew tap distribution for macOS (#105)

### DIFF
--- a/.github/actions/extract-release-sha256/action.yml
+++ b/.github/actions/extract-release-sha256/action.yml
@@ -1,0 +1,57 @@
+name: Extract release asset sha256
+description: |
+  Download the per-release `<project>_<version>_checksums.txt` asset produced by
+  release.yml and extract the sha256 of a single tarball identified by a
+  platform suffix (e.g. `_darwin_arm64.tar.gz`, `_linux_amd64.tar.gz`).
+
+  Reusable across package-channel auto-bump jobs: Homebrew today, AUR/AppImage
+  when #106 lands. The suffix-based contract means a new channel only needs to
+  pass its own platform string, not a custom URL builder.
+
+inputs:
+  checksums-url:
+    description: Full URL to the per-release checksums.txt asset.
+    required: true
+  asset-suffix:
+    description: |
+      Platform suffix matched against the end of a checksums.txt line
+      (e.g. `_darwin_arm64.tar.gz`). Must match exactly one line or the
+      action fails — pass a suffix unique enough to disambiguate.
+    required: true
+
+outputs:
+  sha256:
+    description: Hex-encoded sha256 of the matched asset.
+    value: ${{ steps.extract.outputs.sha256 }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download and extract
+      id: extract
+      shell: bash
+      env:
+        CHECKSUMS_URL: ${{ inputs.checksums-url }}
+        ASSET_SUFFIX: ${{ inputs.asset-suffix }}
+      run: |
+        set -euo pipefail
+        checksums="$(curl -fsSL "$CHECKSUMS_URL")"
+        # Fixed-string match, then validate end-anchoring in bash — avoids
+        # regex surprises if a suffix ever contains metacharacters.
+        matches=""
+        while IFS= read -r line; do
+          [[ "$line" == *"${ASSET_SUFFIX}" ]] && matches+="${line}"$'\n'
+        done <<< "$checksums"
+        match_count="$(printf '%s' "$matches" | grep -c . || true)"
+        if [[ "$match_count" -eq 0 ]]; then
+          echo "::error::No line ending in '${ASSET_SUFFIX}' found in ${CHECKSUMS_URL}"
+          printf '%s\n' "$checksums" >&2
+          exit 1
+        fi
+        if [[ "$match_count" -gt 1 ]]; then
+          echo "::error::Suffix '${ASSET_SUFFIX}' matched ${match_count} lines; expected exactly 1"
+          printf '%s' "$matches" >&2
+          exit 1
+        fi
+        sha256="$(printf '%s' "$matches" | awk '{print $1}')"
+        echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-package-channels.yml
+++ b/.github/workflows/update-package-channels.yml
@@ -1,0 +1,81 @@
+# Auto-bump downstream package manifests when a stable release is published.
+#
+# Today this only bumps the Homebrew tap at laradji/homebrew-deadzone.
+# #106 will add sibling jobs (`update-aur`, `update-appimage-manifest`, or
+# whichever Linux channel wins) — the generic filename and the factored
+# extract-release-sha256 action exist so that work plugs in without a
+# rewrite. If you're adding a new channel, copy update-homebrew as a
+# template and parameterize it with your own asset-suffix + PAT.
+
+name: update-package-channels
+
+on:
+  release:
+    types: [published]
+
+# Prevent a rapid second release from racing an earlier bump against the
+# same tap repo. Channel-scoped (concurrency per job, not per workflow)
+# would be ideal but isn't expressible here — a whole-workflow lock is
+# fine at 0.1.x cadence.
+concurrency:
+  group: update-package-channels
+  cancel-in-progress: false
+
+jobs:
+  update-homebrew:
+    name: Bump Homebrew tap
+    runs-on: ubuntu-latest
+    # Skip pre-releases (rc/beta/alpha) — Homebrew users expect stable.
+    if: github.event.release.prerelease == false
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v5
+
+      - name: Extract darwin-arm64 sha256
+        id: sha
+        uses: ./.github/actions/extract-release-sha256
+        with:
+          checksums-url: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/deadzone_${{ github.event.release.tag_name }}_checksums.txt
+          asset-suffix: _darwin_arm64.tar.gz
+
+      - name: Checkout tap repo
+        uses: actions/checkout@v5
+        with:
+          repository: laradji/homebrew-deadzone
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Rewrite formula
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          SHA256: ${{ steps.sha.outputs.sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd tap
+          version="${TAG#v}"
+          # Single-platform formula: one `sha256` line at 6-space indent
+          # inside the on_arm do block. When Linux channels add more
+          # sha256 lines to this formula, this rewriter must become
+          # context-aware (anchor on the preceding url line, or switch
+          # to a Ruby-aware rewriter). See #106.
+          sed -i -E "s|^(  version \")[^\"]+(\")|\1${version}\2|"             Formula/deadzone.rb
+          sed -i -E "s|^(      sha256 \")[0-9a-f]+(\")|\1${SHA256}\2|"        Formula/deadzone.rb
+          git --no-pager diff -- Formula/deadzone.rb
+
+      - name: Commit and push
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd tap
+          git config user.name  "deadzone-release-bot"
+          git config user.email "noreply@github.com"
+          git add Formula/deadzone.rb
+          if git diff --cached --quiet; then
+            echo "Formula already at ${TAG} — nothing to commit."
+            exit 0
+          fi
+          git commit -m "deadzone ${TAG}"
+          git push

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Documentation is fetched by the `deadzone scrape` subcommand, embedded into vect
 
 Pre-built binaries for **macOS Apple Silicon**, **Linux amd64**, and **Linux arm64** are published on the [Releases page](https://github.com/laradji/deadzone/releases). Windows is blocked upstream (no `libtokenizers.a`). If you want to build from source instead — most useful if you're contributing or running on an unsupported platform — skip to [Build from source](#build-from-source).
 
+macOS Apple Silicon users can also install via [Homebrew](#homebrew-macos-apple-silicon) below — it's a one-liner and skips the quarantine workaround.
+
+### Homebrew (macOS Apple Silicon)
+
+```bash
+brew install laradji/deadzone/deadzone
+```
+
+That resolves to the custom tap at [`laradji/homebrew-deadzone`](https://github.com/laradji/homebrew-deadzone) (not `homebrew-core`). `brew upgrade deadzone` pulls the newest tagged release.
+
+Apple Silicon only — Intel Macs aren't built by the release pipeline. If you need darwin-amd64, [build from source](#build-from-source).
+
+Homebrew installs into a non-quarantined location, so the [quarantine workaround](#macos-clear-the-quarantine-attribute) below doesn't apply.
+
 ### Quick install
 
 Pick the archive for your platform and extract it into the directory you want to run deadzone from:
@@ -87,7 +101,9 @@ shasum -a 256 --ignore-missing -c "deadzone_${VERSION}_checksums.txt"
 
 ### macOS: clear the quarantine attribute
 
-The 0.1.x binaries are unsigned, so Gatekeeper blocks them on first launch. Strip the quarantine xattr once, after extracting the archive:
+Skip this if you installed via [Homebrew](#homebrew-macos-apple-silicon) — it doesn't set the quarantine attribute in the first place.
+
+The 0.1.x binaries are unsigned, so Gatekeeper blocks them on first launch when extracted from a downloaded tarball. Strip the quarantine xattr once, after extracting the archive:
 
 ```bash
 xattr -d com.apple.quarantine deadzone


### PR DESCRIPTION
Closes #105.

## Summary

- New one-liner install path for macOS arm64: `brew install laradji/deadzone/deadzone`, resolving to the custom tap at [`laradji/homebrew-deadzone`](https://github.com/laradji/homebrew-deadzone) (not `homebrew-core` — revisit post-1.0 per the issue decision).
- README `Install` section grows a `Homebrew (macOS Apple Silicon)` subsection and a note on the quarantine workaround explaining it doesn't apply to brew installs.
- Release-triggered auto-bump plumbing lands in a **deliberately generic** shape so #106 (Linux channels) can reuse it:
  - `.github/actions/extract-release-sha256/` — composite action; take `checksums-url` + `asset-suffix`, get a sha256 out. Zero assumptions about project name or platform.
  - `.github/workflows/update-package-channels.yml` — `release.published` trigger, `update-homebrew` job today, sibling jobs for AUR/AppImage to land in #106. Pre-releases are filtered out (`prerelease == false`).

## Out of band (not in this PR)

- **Tap repo** — `laradji/homebrew-deadzone@4a01336` already has `Formula/deadzone.rb` for v0.1.0. Published manually before this workflow existed so the brew install works today.
- **Secret** — `HOMEBREW_TAP_TOKEN` is set on this repo (fine-grained PAT scoped to the tap repo, Contents: read+write). The workflow fails loudly at the push step if the secret is missing on a future release, which is the signal to renew.

## Acceptance criteria

- [x] Repository `laradji/homebrew-deadzone` exists and is public
- [x] `Formula/deadzone.rb` builds against v0.1.0 — smoke-tested on macOS arm64
- [x] `brew test deadzone` passes
- [x] `which deadzone` after install resolves to `$(brew --prefix)/bin/deadzone`
- [x] First-launch `deadzone server` works end-to-end (ORT bootstrap + libtokenizers static link survive Homebrew install)
- [x] README `Install` section mentions Homebrew alongside the tarball path
- [x] Auto-update vs manual-update decision made: **auto-update**, via this workflow. Manual bump was used for v0.1.0 only (workflow didn't exist yet).
- [x] Workflow at `update-package-channels.yml` with generic `update-homebrew` job and factored sha256-extraction step

## Tap formula rewrite: single-platform assumption

The workflow's sed-based rewrite assumes exactly one `sha256` line in the formula (the darwin-arm64 one under `on_arm do`). When #106 adds a Linux platform to the formula, the rewriter must become context-aware (anchor on the preceding `url` line, or move to a Ruby-aware rewriter). There's an inline comment in the workflow flagging this, referencing #106.

## Test plan

- [x] `brew install laradji/deadzone/deadzone` on macOS arm64 (done pre-merge)
- [x] `brew test deadzone` (done pre-merge)
- [x] `deadzone server -db <empty.db>` first-launch reaches serving state (done pre-merge)
- [ ] Next tagged release (v0.1.1) triggers the workflow and auto-bumps the tap — validates the end-to-end path including the PAT. If the bump fails, fall back to manual edit and file a follow-up.

## Related

- #106 — Linux distribution channels; will plug jobs into `update-package-channels.yml` and reuse `extract-release-sha256`.