### PR TITLE
refactor(db): split reader/mutator Open paths to unblock concurrent servers (#131)

### DIFF
--- a/cmd/deadzone/server.go
+++ b/cmd/deadzone/server.go
@@ -287,9 +287,14 @@ func runServer(args []string) error {
 		return fmt.Errorf("stat db %s: %w", *dbPath, err)
 	}
 
-	// db.Open validates the embedder's reported meta against whatever
-	// the database was created with; a mismatch fails fast and tells
-	// the user to rebuild against a fresh file.
+	// db.OpenReader validates the embedder's reported meta against
+	// whatever the database was created with; a mismatch fails fast
+	// and tells the user to rebuild against a fresh file. Unlike
+	// db.Open (used by mutator subcommands like consolidate / scrape /
+	// dbrelease) it does NOT run any DDL and sets PRAGMA query_only on
+	// the connection, so N concurrent `deadzone server` processes can
+	// share the same deadzone.db file without racing each other on
+	// SQLite write-intent locks (#131).
 	e, err := embed.New(*embedderKind)
 	if err != nil {
 		return fmt.Errorf("embedder: %w", err)
@@ -300,7 +305,7 @@ func runServer(args []string) error {
 		}
 	}()
 
-	d, err := db.Open(*dbPath, db.Meta{
+	d, err := db.OpenReader(*dbPath, db.Meta{
 		EmbedderKind: e.Kind(),
 		EmbeddingDim: e.Dim(),
 		ModelVersion: e.ModelVersion(),

--- a/docs/research/ingestion-architecture.md
+++ b/docs/research/ingestion-architecture.md
@@ -514,6 +514,10 @@ When #44 (the `libs` vector table) was being designed, it became clear that addi
 
 When adding a table or making a breaking schema change, bump the constant in the same commit.
 
+### Reader / mutator open split (#131)
+
+A second layering grew on top of `Open` in 0.3: `db.OpenReader` is the read-only entry point for `deadzone server` and any future SELECT-only caller, while `db.Open` remains the mutator entry point used by `scrape`, `consolidate`, and `dbrelease`. The reader path skips all schema DDL and sets `PRAGMA query_only = 1` on the pinned connection, so N concurrent `deadzone server` processes can share the same `deadzone.db` file without racing each other on SQLite write-intent locks. Schema + embedder-meta cross-checks (`ErrSchemaMismatch`, `ErrEmbedderMismatch`) surface identically from both paths. The **contract is that mutator paths own all DDL** — `OpenReader` never creates, migrates, or repairs — so the schema-versioning pattern above stays a single-writer story even when a fleet of readers is attached.
+
 ### Migration policy (locked pre-0.2): no back-compat on `deadzone.db`
 
 Explicit position for future schema changes — the repo has **zero external users of `deadzone.db`** today and the release pipeline rebuilds the DB from scratch on every tag:

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -214,6 +214,125 @@ func Open(path string, meta Meta) (*DB, error) {
 	return &DB{DB: raw, Meta: meta}, nil
 }
 
+// ErrReaderNotInitialized is returned by OpenReader when the file
+// exists but has no meta rows — i.e. a mutator has never opened it to
+// lay down the schema. Readers must not bootstrap DBs themselves (that
+// is exclusively the mutator path's job), so the right fix is to run a
+// mutator command (consolidate / dbrelease / scrape) first. Wrap with
+// errors.Is to detect.
+var ErrReaderNotInitialized = errors.New("database was never initialized by a mutator")
+
+// OpenReader opens an existing deadzone database in read-only mode. It
+// is the entry point used by `deadzone server` and any other caller
+// that issues only SELECTs. Unlike Open it does NOT run any DDL and
+// does NOT accept writes: a PRAGMA query_only = 1 is set on the
+// connection immediately after open so any subsequent INSERT / UPDATE /
+// DELETE / CREATE TABLE returns a SQLite "attempt to write a readonly
+// database" error.
+//
+// Motivation: Open's unconditional CREATE TABLE IF NOT EXISTS meta
+// takes a write-intent lock on every boot, which serializes concurrent
+// MCP server processes against the same deadzone.db file. OpenReader
+// skips all schema DDL so N reader processes can coexist without
+// SQLITE_BUSY, while preserving the usual schema + embedder meta
+// cross-check semantics.
+//
+// Contract vs Open:
+//
+//   - Same validateMeta / schema_version / embedder meta checks.
+//     ErrSchemaMismatch and ErrEmbedderMismatch surface exactly as they
+//     do from Open, so callers can errors.Is them identically.
+//   - The file MUST exist. If it does not, os.ErrNotExist is returned
+//     wrapped with the path — readers never fabricate empty stubs.
+//   - The file MUST have been initialized by a mutator: if the meta
+//     table is absent or empty, ErrReaderNotInitialized is returned.
+//   - Writes fail fast via query_only and (as a second line of defence)
+//     the caller-facing *DB has no helper that attempts mutations.
+func OpenReader(path string, meta Meta) (*DB, error) {
+	if err := validateMeta(meta); err != nil {
+		return nil, fmt.Errorf("open db reader: %w", err)
+	}
+
+	// Stat first so a missing file surfaces as os.ErrNotExist rather
+	// than tursogo quietly creating a new empty DB. The mutator path
+	// (Open) intentionally creates-if-missing; the reader path never
+	// does.
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("open db reader %s: %w", path, err)
+	}
+
+	raw, err := sql.Open("turso", path)
+	if err != nil {
+		return nil, fmt.Errorf("open db reader: %w", err)
+	}
+
+	// Same tursogo-beta defensive serialization as Open. We also pin
+	// the idle pool to one connection with unlimited lifetime so the
+	// single connection we set PRAGMA query_only on below is the exact
+	// connection every subsequent query reuses. Without that pin, the
+	// pool could close and re-open an unpragma'd connection under load,
+	// silently dropping the read-only contract.
+	raw.SetMaxOpenConns(1)
+	raw.SetMaxIdleConns(1)
+	raw.SetConnMaxLifetime(0)
+	raw.SetConnMaxIdleTime(0)
+
+	// query_only turns the connection into a strict SELECT-only view of
+	// the database at the SQLite layer. It is intentionally set BEFORE
+	// any readMeta so even the meta-validation path cannot accidentally
+	// issue a write. The tursogo DSN is a bare path and does not
+	// support a ?mode=ro query string (documented at db.go:117), so
+	// this pragma is the portable way to enforce the read-only contract.
+	if _, err := raw.Exec(`PRAGMA query_only = 1`); err != nil {
+		raw.Close()
+		return nil, fmt.Errorf("open db reader %s: set query_only: %w", path, err)
+	}
+
+	// Probe sqlite_master before readMeta so a DB file that exists but
+	// has no meta table at all (e.g. a stray `touch deadzone.db`, or a
+	// half-failed bootstrap) surfaces as ErrReaderNotInitialized rather
+	// than as a raw "no such table: meta" driver error. Without this
+	// probe the caller can't tell a "please run a mutator first"
+	// situation from an honest I/O failure via errors.Is.
+	var metaTableCount int
+	if err := raw.QueryRow(`SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'meta'`).Scan(&metaTableCount); err != nil {
+		raw.Close()
+		return nil, fmt.Errorf("open db reader %s: probe meta: %w", path, err)
+	}
+	if metaTableCount == 0 {
+		raw.Close()
+		return nil, fmt.Errorf("%w: %s: run `deadzone consolidate` or `deadzone dbrelease` to populate it",
+			ErrReaderNotInitialized, path)
+	}
+
+	stored, storedSchemaVersion, hasMeta, err := readMeta(raw)
+	if err != nil {
+		raw.Close()
+		return nil, fmt.Errorf("open db reader %s: read meta: %w", path, err)
+	}
+	if !hasMeta {
+		raw.Close()
+		return nil, fmt.Errorf("%w: %s: run `deadzone consolidate` or `deadzone dbrelease` to populate it",
+			ErrReaderNotInitialized, path)
+	}
+
+	// Schema version before embedder meta so an old DB with matching
+	// embedder but pre-libs schema surfaces as a schema problem rather
+	// than a spurious embedder mismatch — same ordering as Open.
+	if storedSchemaVersion != CurrentSchemaVersion {
+		raw.Close()
+		return nil, fmt.Errorf("%w: stored=%d current=%d; use a fresh database file and re-scrape until an in-place migration is implemented",
+			ErrSchemaMismatch, storedSchemaVersion, CurrentSchemaVersion)
+	}
+	if stored != meta {
+		raw.Close()
+		return nil, fmt.Errorf("%w: stored=%+v requested=%+v; use a fresh database file or rebuild with the matching embedder",
+			ErrEmbedderMismatch, stored, meta)
+	}
+
+	return &DB{DB: raw, Meta: stored}, nil
+}
+
 // OpenArtifact opens (or creates) a per-(lib_id, version) artifact
 // database. An artifact carries a single (lib_id, version) pair
 // recorded in its meta table; the recorded values are the source of

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -149,18 +149,9 @@ func Open(path string, meta Meta) (*DB, error) {
 	}
 
 	if hasMeta {
-		// Schema version is checked before embedder meta so that an old
-		// DB (with matching embedder but pre-libs schema) surfaces as a
-		// schema problem rather than a spurious embedder mismatch.
-		if storedSchemaVersion != CurrentSchemaVersion {
+		if err := checkStoredMeta(stored, storedSchemaVersion, meta); err != nil {
 			raw.Close()
-			return nil, fmt.Errorf("%w: stored=%d current=%d; use a fresh database file and re-scrape until an in-place migration is implemented",
-				ErrSchemaMismatch, storedSchemaVersion, CurrentSchemaVersion)
-		}
-		if stored != meta {
-			raw.Close()
-			return nil, fmt.Errorf("%w: stored=%+v requested=%+v; use a fresh database file or rebuild with the matching embedder",
-				ErrEmbedderMismatch, stored, meta)
+			return nil, err
 		}
 	} else {
 		if err := writeMeta(raw, meta); err != nil {
@@ -316,18 +307,9 @@ func OpenReader(path string, meta Meta) (*DB, error) {
 			ErrReaderNotInitialized, path)
 	}
 
-	// Schema version before embedder meta so an old DB with matching
-	// embedder but pre-libs schema surfaces as a schema problem rather
-	// than a spurious embedder mismatch — same ordering as Open.
-	if storedSchemaVersion != CurrentSchemaVersion {
+	if err := checkStoredMeta(stored, storedSchemaVersion, meta); err != nil {
 		raw.Close()
-		return nil, fmt.Errorf("%w: stored=%d current=%d; use a fresh database file and re-scrape until an in-place migration is implemented",
-			ErrSchemaMismatch, storedSchemaVersion, CurrentSchemaVersion)
-	}
-	if stored != meta {
-		raw.Close()
-		return nil, fmt.Errorf("%w: stored=%+v requested=%+v; use a fresh database file or rebuild with the matching embedder",
-			ErrEmbedderMismatch, stored, meta)
+		return nil, err
 	}
 
 	return &DB{DB: raw, Meta: stored}, nil
@@ -769,6 +751,27 @@ const (
 	// single-version form and is persisted as such.
 	metaKeyVersion = "version"
 )
+
+// checkStoredMeta validates that the on-disk schema version and
+// embedder identity match what the caller is bringing. Shared by Open
+// and OpenReader so the reader/mutator split cannot drift on error
+// messages, sentinels, or the ordering of the two checks.
+//
+// Schema version is checked before embedder meta on purpose: an old
+// DB whose embedder still matches but whose schema predates a required
+// table (e.g. pre-libs #55) must surface as a schema problem rather
+// than as a spurious embedder mismatch.
+func checkStoredMeta(storedMeta Meta, storedSchemaVersion int, wantMeta Meta) error {
+	if storedSchemaVersion != CurrentSchemaVersion {
+		return fmt.Errorf("%w: stored=%d current=%d; use a fresh database file and re-scrape until an in-place migration is implemented",
+			ErrSchemaMismatch, storedSchemaVersion, CurrentSchemaVersion)
+	}
+	if storedMeta != wantMeta {
+		return fmt.Errorf("%w: stored=%+v requested=%+v; use a fresh database file or rebuild with the matching embedder",
+			ErrEmbedderMismatch, storedMeta, wantMeta)
+	}
+	return nil
+}
 
 func validateMeta(m Meta) error {
 	if m.EmbedderKind == "" {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/laradji/deadzone/internal/db"
@@ -603,6 +604,291 @@ func TestTopLibsByDocCount_OrdersDescending(t *testing.T) {
 		if results[i].LibID != w {
 			t.Errorf("position %d: got %q, want %q", i, results[i].LibID, w)
 		}
+	}
+}
+
+// seedMainDB writes a fully-valid consolidated DB at path via the
+// mutator path, inserts a handful of docs, and closes it. Used by the
+// OpenReader tests to get a realistic on-disk file without repeating
+// the Open/Insert boilerplate in every case.
+func seedMainDB(t *testing.T, path string) {
+	t.Helper()
+	d, err := db.Open(path, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("seed: Open: %v", err)
+	}
+	docs := []db.Doc{
+		{LibID: "/a/one", Title: "one", Content: "first doc"},
+		{LibID: "/b/two", Title: "two", Content: "second doc"},
+	}
+	for _, doc := range docs {
+		if err := db.Insert(d, doc, embedText(t, testEmbedder, doc)); err != nil {
+			t.Fatalf("seed: Insert %q: %v", doc.Title, err)
+		}
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("seed: Close: %v", err)
+	}
+}
+
+// TestOpenReader_ExistingDB checks the happy path: a DB seeded via the
+// mutator Open path can be reopened via OpenReader and answer SELECTs
+// with the same row count. Covers AC bullet "TestOpenReader_existingDB".
+func TestOpenReader_ExistingDB(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reader.db")
+	seedMainDB(t, path)
+
+	d, err := db.OpenReader(path, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("OpenReader: %v", err)
+	}
+	defer d.Close()
+
+	var count int
+	if err := d.QueryRow(`SELECT count(*) FROM docs`).Scan(&count); err != nil {
+		t.Fatalf("SELECT count(*): %v", err)
+	}
+	if count != 2 {
+		t.Errorf("doc count = %d, want 2", count)
+	}
+	if d.Meta != metaFor(testEmbedder) {
+		t.Errorf("Meta = %+v, want %+v", d.Meta, metaFor(testEmbedder))
+	}
+}
+
+// TestOpenReader_RejectsWrite is the core invariant: once a DB is
+// opened via OpenReader, the connection must refuse any write. Both an
+// INSERT and a CREATE TABLE are attempted so the test catches a
+// half-finished implementation that only guards one shape of mutation.
+func TestOpenReader_RejectsWrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reader.db")
+	seedMainDB(t, path)
+
+	d, err := db.OpenReader(path, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("OpenReader: %v", err)
+	}
+	defer d.Close()
+
+	// INSERT must fail — the stored vector width matches the
+	// embedder's dim, so if query_only didn't fire we'd silently
+	// succeed and the test would pass for the wrong reason.
+	insertVec := embedText(t, testEmbedder, db.Doc{Title: "t", Content: "c"})
+	if err := db.Insert(d, db.Doc{LibID: "x", Title: "t", Content: "c"}, insertVec); err == nil {
+		t.Error("Insert on reader: expected error, got nil")
+	}
+
+	// CREATE TABLE must also fail — the issue's acceptance criterion
+	// explicitly names it because the mutator Open path itself issues
+	// CREATE TABLE IF NOT EXISTS at boot, and a reader that still
+	// allows DDL would re-introduce the exact lock contention we are
+	// trying to eliminate.
+	if _, err := d.Exec(`CREATE TABLE canary (id INTEGER PRIMARY KEY)`); err == nil {
+		t.Error("CREATE TABLE on reader: expected error, got nil")
+	}
+
+	// UPDATE and DELETE round out the mutation surface. query_only
+	// covers all three in one pragma, so a failure in any one branch
+	// points at a regression in the pragma-lifetime handling rather
+	// than a missing case in OpenReader.
+	if _, err := d.Exec(`UPDATE docs SET title = 'x' WHERE lib_id = '/a/one'`); err == nil {
+		t.Error("UPDATE on reader: expected error, got nil")
+	}
+	if _, err := d.Exec(`DELETE FROM docs WHERE lib_id = '/a/one'`); err == nil {
+		t.Error("DELETE on reader: expected error, got nil")
+	}
+}
+
+// TestOpenReader_MissingFile pins the "readers never spawn empty DBs"
+// contract. If the path does not exist, OpenReader must return an
+// os.ErrNotExist-wrapping error and must NOT create a stub file on
+// disk — otherwise a typo in -db on the server CLI would produce a
+// nonsense empty database that silently answers zero results.
+func TestOpenReader_MissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "never-created.db")
+
+	d, err := db.OpenReader(path, metaFor(testEmbedder))
+	if err == nil {
+		d.Close()
+		t.Fatal("OpenReader on missing file: expected error, got nil")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected os.ErrNotExist, got %v", err)
+	}
+	if _, statErr := os.Stat(path); statErr == nil {
+		t.Errorf("OpenReader created a stub file at %s; it must not", path)
+	}
+}
+
+// TestOpenReader_SchemaMismatch rebuilds a v1 (pre-libs) database by
+// hand and asserts that OpenReader rejects it with ErrSchemaMismatch.
+// Parity with TestDB_RejectsPreLibsSchema for the mutator path — the
+// reader must surface the same sentinel so callers using errors.Is can
+// treat the two paths interchangeably.
+func TestOpenReader_SchemaMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.db")
+
+	raw, err := sql.Open("turso", path)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	raw.SetMaxOpenConns(1)
+	if _, err := raw.Exec(`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatalf("create meta: %v", err)
+	}
+	for _, kv := range [][2]string{
+		{"embedder_kind", testEmbedder.Kind()},
+		{"embedding_dim", fmt.Sprintf("%d", testEmbedder.Dim())},
+		{"model_version", testEmbedder.ModelVersion()},
+	} {
+		if _, err := raw.Exec(`INSERT INTO meta(key, value) VALUES (?, ?)`, kv[0], kv[1]); err != nil {
+			t.Fatalf("insert meta %s: %v", kv[0], err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+
+	d, err := db.OpenReader(path, metaFor(testEmbedder))
+	if err == nil {
+		d.Close()
+		t.Fatal("expected ErrSchemaMismatch, got nil")
+	}
+	if !errors.Is(err, db.ErrSchemaMismatch) {
+		t.Errorf("expected ErrSchemaMismatch, got %v", err)
+	}
+}
+
+// TestOpenReader_EmbedderMismatch seeds a DB with the real embedder
+// meta, then tries to OpenReader it with three different shapes of
+// mismatched meta (kind, dim, model version). Mirrors
+// TestDB_RejectsEmbedderMismatch so the reader and mutator paths share
+// identical meta-enforcement semantics.
+func TestOpenReader_EmbedderMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reader.db")
+	seedMainDB(t, path)
+
+	cases := []struct {
+		name string
+		meta db.Meta
+	}{
+		{
+			name: "different kind",
+			meta: db.Meta{EmbedderKind: "fake", EmbeddingDim: testEmbedder.Dim(), ModelVersion: testEmbedder.ModelVersion()},
+		},
+		{
+			name: "different dim",
+			meta: db.Meta{EmbedderKind: testEmbedder.Kind(), EmbeddingDim: testEmbedder.Dim() + 1, ModelVersion: testEmbedder.ModelVersion()},
+		},
+		{
+			name: "different model version",
+			meta: db.Meta{EmbedderKind: testEmbedder.Kind(), EmbeddingDim: testEmbedder.Dim(), ModelVersion: "made-up-model-v9"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := db.OpenReader(path, tc.meta)
+			if err == nil {
+				d.Close()
+				t.Fatal("expected ErrEmbedderMismatch, got nil")
+			}
+			if !errors.Is(err, db.ErrEmbedderMismatch) {
+				t.Errorf("expected ErrEmbedderMismatch, got %v", err)
+			}
+		})
+	}
+}
+
+// TestOpenReader_Concurrent is the load-bearing acceptance test for
+// #131: three goroutines call OpenReader against the same file and
+// each issues a SELECT; none of them must hit SQLITE_BUSY. Before the
+// reader/mutator split, three concurrent Open calls could race on the
+// boot-time CREATE TABLE IF NOT EXISTS meta write-intent lock. This
+// test would have caught that by observing a "database is locked"
+// error on at least one goroutine.
+func TestOpenReader_Concurrent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reader.db")
+	seedMainDB(t, path)
+
+	const workers = 3
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		counts []int
+		errs   []error
+	)
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			d, err := db.OpenReader(path, metaFor(testEmbedder))
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("OpenReader: %w", err))
+				mu.Unlock()
+				return
+			}
+			defer d.Close()
+			var n int
+			if err := d.QueryRow(`SELECT count(*) FROM docs`).Scan(&n); err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("SELECT: %w", err))
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			counts = append(counts, n)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if len(errs) > 0 {
+		for _, e := range errs {
+			t.Errorf("concurrent reader: %v", e)
+		}
+		t.FailNow()
+	}
+	if len(counts) != workers {
+		t.Fatalf("got %d counts, want %d", len(counts), workers)
+	}
+	for i, n := range counts {
+		if n != counts[0] {
+			t.Errorf("worker %d: count=%d, worker 0: count=%d; readers must see identical state", i, n, counts[0])
+		}
+	}
+}
+
+// TestOpenReader_Uninitialized checks the "DB file exists but was
+// never populated" case. A bare SQLite file with no meta table must
+// surface as ErrReaderNotInitialized — not as a silent success with
+// zero rows — so a misconfigured -db path fails loudly instead of
+// answering every query with "no match" forever.
+func TestOpenReader_Uninitialized(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.db")
+
+	// Create the file via the driver without any schema. This is what
+	// a stray `touch empty.db` or a half-failed bootstrap looks like.
+	raw, err := sql.Open("turso", path)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	// Force the file to actually exist on disk by issuing a trivial
+	// query; tursogo defers the create until the first operation.
+	if _, err := raw.Exec(`CREATE TABLE canary (x INTEGER)`); err != nil {
+		t.Fatalf("raw exec: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+
+	d, err := db.OpenReader(path, metaFor(testEmbedder))
+	if err == nil {
+		d.Close()
+		t.Fatal("expected ErrReaderNotInitialized, got nil")
+	}
+	if !errors.Is(err, db.ErrReaderNotInitialized) {
+		t.Errorf("expected ErrReaderNotInitialized, got %v", err)
 	}
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,11 +1,13 @@
 package db_test
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"testing"
 
@@ -799,26 +801,148 @@ func TestOpenReader_EmbedderMismatch(t *testing.T) {
 	}
 }
 
-// TestOpenReader_Concurrent is the load-bearing acceptance test for
-// #131: three goroutines call OpenReader against the same file and
-// each issues a SELECT; none of them must hit SQLITE_BUSY. Before the
-// reader/mutator split, three concurrent Open calls could race on the
-// boot-time CREATE TABLE IF NOT EXISTS meta write-intent lock. This
-// test would have caught that by observing a "database is locked"
-// error on at least one goroutine.
-func TestOpenReader_Concurrent(t *testing.T) {
+// listTables returns the names of every user-defined table in the
+// database at path, in lexicographic order. Used by
+// TestOpenReader_DoesNotIssueDDL to snapshot the schema around an
+// OpenReader call.
+func listTables(t *testing.T, path string) []string {
+	t.Helper()
+	raw, err := sql.Open("turso", path)
+	if err != nil {
+		t.Fatalf("listTables: open: %v", err)
+	}
+	defer raw.Close()
+	rows, err := raw.Query(`SELECT name FROM sqlite_master WHERE type = 'table'`)
+	if err != nil {
+		t.Fatalf("listTables: query: %v", err)
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("listTables: scan: %v", err)
+		}
+		names = append(names, n)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("listTables: rows: %v", err)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestOpenReader_DoesNotIssueDDL is the direct structural test for
+// the #131 root-cause fix: OpenReader must not create, alter, or drop
+// any table on the file it opens. Before the reader/mutator split,
+// `deadzone server`'s boot would run `CREATE TABLE IF NOT EXISTS meta`
+// unconditionally (db.go:137, pre-refactor), taking a SQLite
+// write-intent lock on every start and racing other boots on the
+// same file. This test snapshots the full sqlite_master table list
+// before and after OpenReader and fails if the two differ — a much
+// stronger assertion than "N concurrent readers don't time out",
+// because it pins down WHY concurrent readers work rather than
+// verifying the symptom.
+func TestOpenReader_DoesNotIssueDDL(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "reader.db")
 	seedMainDB(t, path)
 
-	const workers = 3
+	before := listTables(t, path)
+
+	d, err := db.OpenReader(path, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("OpenReader: %v", err)
+	}
+	// Issue a representative SELECT so any lazy DDL the driver might
+	// defer until first query has a chance to fire before we snapshot.
+	var n int
+	if err := d.QueryRow(`SELECT count(*) FROM docs`).Scan(&n); err != nil {
+		d.Close()
+		t.Fatalf("SELECT: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	after := listTables(t, path)
+	if len(before) != len(after) {
+		t.Fatalf("OpenReader changed table count: before=%v after=%v", before, after)
+	}
+	for i := range before {
+		if before[i] != after[i] {
+			t.Errorf("OpenReader altered schema: before=%v after=%v", before, after)
+			break
+		}
+	}
+}
+
+// TestOpenReader_CoexistsWithWriterOnSameFile holds a write-intent
+// lock on the main DB via a mutator-opened `BEGIN IMMEDIATE`, then
+// spawns multiple OpenReader calls against the same file. The
+// assertion is that every reader opens and answers its SELECT without
+// a SQLITE_BUSY, proving the reader path is safe under the exact
+// condition the old Open boot race could have hit: a writer actively
+// holding the reserved lock while a would-be reader starts up.
+//
+// Tursogo enables WAL by default (see the comment at db.go:129), so
+// in WAL mode readers and a writer coexist by design — this test
+// documents that we rely on that property and that OpenReader does
+// nothing to break it. Combined with TestOpenReader_DoesNotIssueDDL
+// (no boot-time DDL), the two together pin down the whole contract:
+// zero writes on boot, plus WAL concurrency, equals N readers safe
+// against 1 writer.
+func TestOpenReader_CoexistsWithWriterOnSameFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reader.db")
+	seedMainDB(t, path)
+
+	mutator, err := db.Open(path, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("mutator Open: %v", err)
+	}
+	defer mutator.Close()
+
+	// Pin a connection and hold a reserved lock via BEGIN IMMEDIATE.
+	// SetMaxOpenConns(1) on the mutator side means there is a single
+	// conn; Conn() returns it, and the BEGIN IMMEDIATE sticks on that
+	// conn for the life of the test. Rollback on defer so we never
+	// leak a half-open tx into the pool.
+	ctx := context.Background()
+	writerConn, err := mutator.Conn(ctx)
+	if err != nil {
+		t.Fatalf("mutator Conn: %v", err)
+	}
+	defer writerConn.Close()
+
+	if _, err := writerConn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE: %v", err)
+	}
+	defer func() {
+		if _, err := writerConn.ExecContext(context.Background(), "ROLLBACK"); err != nil {
+			t.Logf("ROLLBACK: %v", err)
+		}
+	}()
+
+	// Force real acquisition of the reserved lock by issuing a write
+	// on the pinned tx. BEGIN IMMEDIATE alone is intended to grab it,
+	// but writing a row removes any ambiguity about driver behaviour.
+	if _, err := writerConn.ExecContext(ctx,
+		`UPDATE docs SET title = 'held-' || title WHERE lib_id = '/a/one'`); err != nil {
+		t.Fatalf("writer UPDATE: %v", err)
+	}
+
+	// Now spawn N OpenReader calls. None of them should block
+	// indefinitely or fail with SQLITE_BUSY. A 5-second implicit
+	// timeout via the test runner's default would catch a hang; we
+	// assert success inline.
+	const readers = 3
 	var (
 		wg     sync.WaitGroup
 		mu     sync.Mutex
 		counts []int
 		errs   []error
 	)
-	wg.Add(workers)
-	for i := 0; i < workers; i++ {
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
 		go func() {
 			defer wg.Done()
 			d, err := db.OpenReader(path, metaFor(testEmbedder))
@@ -845,26 +969,57 @@ func TestOpenReader_Concurrent(t *testing.T) {
 
 	if len(errs) > 0 {
 		for _, e := range errs {
-			t.Errorf("concurrent reader: %v", e)
+			t.Errorf("reader vs held writer: %v", e)
 		}
 		t.FailNow()
 	}
-	if len(counts) != workers {
-		t.Fatalf("got %d counts, want %d", len(counts), workers)
+	if len(counts) != readers {
+		t.Fatalf("got %d reader results, want %d", len(counts), readers)
 	}
+	// Sanity: readers all see the pre-writer state (writer's tx is
+	// uncommitted, so its UPDATE is invisible). Seed inserts 2 rows.
 	for i, n := range counts {
-		if n != counts[0] {
-			t.Errorf("worker %d: count=%d, worker 0: count=%d; readers must see identical state", i, n, counts[0])
+		if n != 2 {
+			t.Errorf("reader %d: count=%d, want 2 (uncommitted writer must be invisible)", i, n)
 		}
 	}
 }
 
-// TestOpenReader_Uninitialized checks the "DB file exists but was
-// never populated" case. A bare SQLite file with no meta table must
-// surface as ErrReaderNotInitialized — not as a silent success with
-// zero rows — so a misconfigured -db path fails loudly instead of
-// answering every query with "no match" forever.
-func TestOpenReader_Uninitialized(t *testing.T) {
+// TestOpenReader_PinsSingleConnection freezes the pool-posture
+// invariant that the read-only contract relies on. PRAGMA query_only
+// is per-connection, not per-DB — if a future change raises
+// SetMaxOpenConns past 1 (e.g. to parallelize reads under #45), the
+// database/sql pool can spawn a second, un-pragma'd connection and
+// silently accept writes on it. Pinning the cap at 1 at Stats() level
+// catches that regression before it can hit prod.
+func TestOpenReader_PinsSingleConnection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reader.db")
+	seedMainDB(t, path)
+
+	d, err := db.OpenReader(path, metaFor(testEmbedder))
+	if err != nil {
+		t.Fatalf("OpenReader: %v", err)
+	}
+	defer d.Close()
+
+	stats := d.Stats()
+	if stats.MaxOpenConnections != 1 {
+		t.Errorf("MaxOpenConnections = %d, want 1; raising the cap requires re-establishing PRAGMA query_only per-connection (see #131 — query_only is not a DB-level pragma)",
+			stats.MaxOpenConnections)
+	}
+}
+
+// TestOpenReader_RejectsForeignSqliteFile covers the case where the
+// path points at a SQLite file the mutator path never touched — e.g.
+// a user pointed -db at somebody else's database by mistake, or a
+// half-failed bootstrap produced a file with an unrelated schema.
+// A readable file with no meta table must surface as
+// ErrReaderNotInitialized (actionable: "run consolidate") rather
+// than as a raw "no such table: meta" driver error (which looks like
+// corruption). A fresh deadzone.db created by a mutator always has
+// the meta table, so this branch does not fire on in-tree workflows
+// — it guards against pointing OpenReader at foreign files.
+func TestOpenReader_RejectsForeignSqliteFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "empty.db")
 
 	// Create the file via the driver without any schema. This is what


### PR DESCRIPTION
## Summary

Splits `db.Open` into two entry points so multiple `deadzone server` processes can share the same `deadzone.db` file without racing on SQLite write-intent locks.

- New `db.OpenReader` — read-only entry point used by `deadzone server`. Skips all DDL, sets `PRAGMA query_only = 1` on a pinned single connection, and refuses to bootstrap a missing or uninitialized file (returns `ErrReaderNotInitialized`).
- `db.Open` stays the mutator entry point for `scrape`, `consolidate`, and `dbrelease` — it remains the sole owner of schema DDL.
- `cmd/deadzone/server.go` switched to `OpenReader`.

## Why

`Open`'s unconditional `CREATE TABLE IF NOT EXISTS meta` takes a write-intent lock on every boot, which serialized concurrent MCP server processes against the same file. The reader path now skips DDL entirely, so N readers coexist without `SQLITE_BUSY`.

Schema + embedder-meta cross-checks (`ErrSchemaMismatch`, `ErrEmbedderMismatch`) surface identically from both paths, so callers can keep using `errors.Is` unchanged.

## Changes

- `internal/db/db.go` — add `OpenReader` + `ErrReaderNotInitialized`
- `internal/db/db_test.go` — coverage for read-only enforcement, missing file, uninitialized DB, schema/embedder mismatch parity with `Open`
- `cmd/deadzone/server.go` — use `OpenReader`
- `docs/research/ingestion-architecture.md` — document the reader/mutator split and the single-writer invariant

## Test plan

- [x] `go test ./internal/db/...`
- [ ] Run two `deadzone server` instances against the same `deadzone.db` and confirm no `SQLITE_BUSY`
- [ ] Verify `deadzone server` against a missing DB returns the `ErrReaderNotInitialized` hint pointing at `consolidate` / `dbrelease`

<!-- emdash-issue-footer:start -->
Fixes #131
<!-- emdash-issue-footer:end -->