### PR TITLE
chore(ci): bump node-based actions to v5/v6/v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       # mise supplies the Go + just versions pinned in .mise.toml, so
       # CI builds with the same toolchain as a dev laptop running
       # `just build-release`.
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
 
       - name: Install native deps
         uses: ./.github/actions/install-native-deps
@@ -107,7 +107,7 @@ jobs:
           tar -czf "${name}.tar.gz" "${name}"
           echo "archive=${name}.tar.gz" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: deadzone-${{ matrix.goos }}-${{ matrix.goarch }}
           path: ${{ steps.pkg.outputs.archive }}
@@ -148,7 +148,7 @@ jobs:
     steps:
       # Deliberately no actions/checkout — the whole point of this job is
       # to prove the tarball works without any project files on disk.
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: deadzone-${{ matrix.goos }}-${{ matrix.goarch }}
 
@@ -214,7 +214,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: deadzone-linux-${{ matrix.goarch }}
 
@@ -249,7 +249,7 @@ jobs:
             -artifacts ./empty-artifacts \
             -db /tmp/deadzone-appimage-smoke.db
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: deadzone-linux-${{ matrix.goarch }}-appimage
           path: ${{ steps.build.outputs.appimage }}
@@ -267,7 +267,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: deadzone-*
           merge-multiple: true

--- a/.github/workflows/scrape-pack.yml
+++ b/.github/workflows/scrape-pack.yml
@@ -150,7 +150,7 @@ jobs:
         #      consolidate's summary falls back to "failed" on a
         #      missing .run_status file.
         #
-        #   2. artifacts/.pack-root anchors upload-artifact@v4's LCA
+        #   2. artifacts/.pack-root anchors upload-artifact@v7's LCA
         #      calculation at `artifacts/`. Without it, matching only
         #      `artifacts/<slug>/...` would collapse the LCA to
         #      `artifacts/<slug>/`, stripping the slug prefix from the
@@ -169,7 +169,7 @@ jobs:
             echo scraped > "artifacts/${{ matrix.entry.slug }}/.run_status"
           fi
       - name: Stage artifact for consolidate
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # Pattern B fan-in staging — see research doc §4 for why
           # Pattern C (REST cache API) is not buildable today. Retention
@@ -220,7 +220,7 @@ jobs:
           restore-keys: |
             ort-lib-${{ runner.os }}-
       - name: Fetch staged artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           # Each scrape slot uploaded with LCA = artifacts/, so every
           # archive carries `<slug>/...` at its root. Extracting under


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions to current major versions across release and scrape-pack workflows.

## Changes

- `jdx/mise-action`: `v2` → `v4`
- `actions/upload-artifact`: `v4` → `v7`
- `actions/download-artifact`: `v4` → `v8`

## Files

- `.github/workflows/release.yml`
- `.github/workflows/scrape-pack.yml`

Inline comment referencing `upload-artifact@v4` updated to match the new version.

<!-- emdash-issue-footer:start -->
Fixes #129
<!-- emdash-issue-footer:end -->