### PR TITLE
ci(scrape-pack): commit manifest.yaml after dbrelease

### DIFF
--- a/.github/workflows/scrape-pack.yml
+++ b/.github/workflows/scrape-pack.yml
@@ -237,6 +237,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: go run -tags ORT ./cmd/deadzone dbrelease --db deadzone.db --tag "${{ inputs.tag }}"
+      - name: Commit manifest (if tag and diff)
+        # dbrelease rewrites artifacts/manifest.yaml as its last action (see
+        # #101 decision 5 and cmd/deadzone/dbrelease.go). In the laptop path
+        # the operator commits that diff; in CI nothing does, so the audit
+        # trace on `main` goes stale (issue #145). The `inputs.tag != ''`
+        # gate duplicates the Release step's gate on purpose — without it,
+        # `git diff --quiet` would run on the empty-tag path where the file
+        # was never rewritten, wasting a step.
+        #
+        # `HEAD:${{ github.ref_name }}` pushes the detached-HEAD commit back
+        # to the dispatch ref (typically main) — actions/checkout@v6 leaves
+        # us in detached HEAD, so `git push` alone has no upstream.
+        if: inputs.tag != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet artifacts/manifest.yaml; then
+            echo "manifest.yaml unchanged — skipping commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add artifacts/manifest.yaml
+          git commit -m "chore(release): update manifest for ${{ inputs.tag }}"
+          git push origin "HEAD:${{ github.ref_name }}"
       - name: Summary
         if: always()
         shell: bash


### PR DESCRIPTION
## Summary

Closes the audit-trail gap from issue #145: `deadzone dbrelease` rewrites `artifacts/manifest.yaml` as its final step, but in CI nothing was committing that diff back to `main`, so the manifest on `main` drifted from the released DB.

## Changes

- Add a `Commit manifest (if tag and diff)` step to the `consolidate` job in `.github/workflows/scrape-pack.yml`
- Gated on `inputs.tag != ''` (mirrors the `Release` step — no manifest rewrite happens on the empty-tag path)
- No-op when `git diff --quiet artifacts/manifest.yaml` shows no change
- Commits as `github-actions[bot]` and pushes `HEAD:${{ github.ref_name }}` to handle the detached-HEAD state left by `actions/checkout@v6`

## Notes

- Relies on the existing `permissions: contents: write` already declared at the workflow level for `dbrelease` asset uploads
- Commit message format: `chore(release): update manifest for <tag>`

<!-- emdash-issue-footer:start -->
Fixes #145
<!-- emdash-issue-footer:end -->