### PR TITLE
fix: set CGO env in cache-keepalive workflow

### DIFF
--- a/.github/workflows/cache-keepalive.yml
+++ b/.github/workflows/cache-keepalive.yml
@@ -23,6 +23,18 @@ on:
 permissions:
   contents: read # no writes anywhere — keepalive never publishes
 
+# Mirror scrape-pack.yml's CGO env: `go run -tags ORT ./cmd/deadzone` in
+# expand-libs builds the full binary even though `--list` short-circuits
+# before the embedder at runtime — build tags select files to compile,
+# not symbols to link, so CGO_LDFLAGS is mandatory or `ld` can't find
+# libtokenizers.a that install-native-deps unpacked into /tmp/deadzone-deps.
+# TOKENIZERS_VERSION must also stay defined here even when the deps cache
+# is warm — on a cold cache the composite action fails fast without it.
+env:
+  TOKENIZERS_VERSION: v1.26.0
+  CGO_ENABLED: "1"
+  CGO_LDFLAGS: -L/tmp/deadzone-deps/tokenizers
+
 concurrency:
   # Serial by design: overlapping dispatches would race on the same
   # restore keys. A miss is not a failure, so cancel-in-progress: false


### PR DESCRIPTION
## Summary

- `cache-keepalive.yml` was missing the workflow-level `env:` block that `scrape-pack.yml` defines, so `go run -tags ORT ./cmd/deadzone scrape --list` in `expand-libs` failed at link time with `/usr/bin/ld: cannot find -ltokenizers`.
- Build tags select files to compile, not symbols to link — even though `--list` short-circuits before the embedder at runtime, the binary still has to link `libtokenizers.a` at build time, which requires `CGO_LDFLAGS=-L/tmp/deadzone-deps/tokenizers`.
- Also pins `TOKENIZERS_VERSION: v1.26.0` so `install-native-deps` does not fail on a cold deps cache (today's failed run skipped the download step thanks to a warm cache, which masked the missing pin).

## Failing run

[run 24977441636](https://github.com/laradji/deadzone/actions/runs/24977441636) — Mon 2026-04-27 04:00 UTC schedule.

## Test plan

- [ ] After merge, dispatch `cache-keepalive` manually (`gh workflow run cache-keepalive.yml`) and verify the `expand-libs` job links cleanly and emits the resolved libs JSON.
- [ ] Confirm subsequent scheduled runs (Mon/Thu 04:00 UTC) succeed.