### PR TITLE
fix(ci): use PAT in release.yml so release.published fires downstream

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,8 +307,12 @@ jobs:
       - name: Create GitHub release
         # Tag-push only; workflow_dispatch stops after the checksums step.
         if: github.event_name == 'push' && github.ref_type == 'tag'
+        # Fine-grained PAT (Contents: Read and write, this repo only) so the
+        # `release.published` event spawns downstream workflows. The default
+        # GITHUB_TOKEN is anti-recursion-gated and would not fire
+        # update-package-channels.yml — see #130.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PUBLISH_TOKEN }}
           VERSION: ${{ steps.meta.outputs.version }}
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- Substitutes `GH_TOKEN` on `release.yml`'s `Create GitHub release` step from the default `GITHUB_TOKEN` to a fine-grained PAT (`RELEASE_PUBLISH_TOKEN`, scope `laradji/deadzone` only, `Contents: Read and write`).
- Restores the `release.published` → `update-package-channels.yml` chain that GitHub's anti-recursion rule blocks when the publish event is emitted by the default token.
- Build matrix and other workflow steps untouched — least privilege.

## Why

GitHub's documented behaviour: events triggered by the default `GITHUB_TOKEN` do **not** spawn new workflow runs. v0.2.0 (2026-04-17) confirmed this in production — the tap bump never auto-fired and had to be triggered manually via the `workflow_dispatch` escape hatch added in `1edd01d`. That escape hatch stays as the manual fallback (out of scope for this change, per #130).

## Operator action required before this is effective

- [ ] PAT exists and has been added to repo secrets as `RELEASE_PUBLISH_TOKEN` (scope: this repo only, `Contents: Read and write`, no other permissions).
- [ ] Post-merge probe: scratch tag `v0.0.0-token-probe` → confirm `update-package-channels.yml` fires automatically → cleanup release + tag.

## Test plan

- [x] `grep -c 'GH_TOKEN' .github/workflows/release.yml` → still 1 active site (the publish step), no other substitutions
- [x] Build matrix (`build` job) still uses no token override — only the final `Create GitHub release` step takes the PAT
- [ ] Operator probe with `v0.0.0-token-probe` after merge, per #130 acceptance criteria

Closes #130