### PR TITLE
feat(libs): expand anomalyco/opencode coverage to full docs tree

### DIFF
--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -472,11 +472,52 @@ libraries:
   # and ships the CLI from its `dev` branch without release tags, so
   # we pin to a commit SHA from `dev` and single-version this entry.
   # Bump the sha to refresh.
+  #
+  # URLs enumerate the English-root `.mdx` files under
+  # `packages/web/src/content/docs/`. Translated locale subdirs
+  # (`ar/`, `bs/`, `da/`, `de/`, `es/`, `fr/`, `it/`, `ja/`, `ko/`,
+  # `nb/`, `pl/`, `pt-br/`, `ru/`, `th/`, `tr/`, `zh-cn/`, `zh-tw/`)
+  # are intentionally excluded — retrieval semantics target English.
+  # README.md is omitted; the docs supersede it. See #149.
   - lib_id: /anomalyco/opencode
     kind: github-md
-    ref: d312c677c588
+    ref: c4a2353ac3a962d7fe0f4deaa539854345e1c11e
     urls:
-      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/README.md
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/acp.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/agents.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/cli.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/commands.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/config.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/custom-tools.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/ecosystem.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/enterprise.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/formatters.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/github.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/gitlab.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/go.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/ide.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/index.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/keybinds.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/lsp.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/mcp-servers.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/models.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/modes.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/network.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/permissions.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/plugins.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/providers.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/rules.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/sdk.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/server.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/share.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/skills.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/themes.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/tools.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/troubleshooting.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/tui.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/web.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/windows-wsl.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/zen.mdx
 
   # tursodatabase/turso-go — Go driver for Turso/Limbo. No releases yet
   # (`gh api repos/tursodatabase/turso-go/releases/latest` → "no releases"


### PR DESCRIPTION
## Summary

Expands the `/anomalyco/opencode` library source from a single `README.md` to the full English docs set under `packages/web/src/content/docs/` (34 `.mdx` files).

## Changes

- Bumped `ref` from short SHA `d312c677c588` to full commit `c4a2353ac3a962d7fe0f4deaa539854345e1c11e` on `dev`
- Replaced `README.md` URL with 34 `.mdx` doc pages (acp, agents, cli, commands, config, custom-tools, ecosystem, enterprise, formatters, github, gitlab, go, ide, index, keybinds, lsp, mcp-servers, models, modes, network, permissions, plugins, providers, rules, sdk, server, share, skills, themes, tools, troubleshooting, tui, web, windows-wsl, zen)
- Added a comment block documenting the rationale: English-only retrieval, translated locale subdirs (`ar/`, `de/`, `fr/`, `ja/`, `zh-cn/`, etc.) are intentionally excluded, README is superseded by docs

## Rationale

The README is a thin pointer; the actual user-facing documentation lives in the Astro Starlight site. Indexing the docs tree gives retrieval much richer surface area for CLI flags, config keys, providers, modes, permissions, and plugin authoring. Refs #149.

## Notes

- Locale subdirs excluded by design — retrieval is English-targeted
- Single-version entry preserved (no release tags upstream, still tracking `dev`)
- Bump the pinned SHA to refresh

<!-- emdash-issue-footer:start -->
Fixes #149
<!-- emdash-issue-footer:end -->