### PR TITLE
update(libs): expand /anomalyco/opencode coverage beyond README

### DIFF
--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -471,12 +471,48 @@ libraries:
   # anomalyco). The project only tags a separate `vscode-*` extension
   # and ships the CLI from its `dev` branch without release tags, so
   # we pin to a commit SHA from `dev` and single-version this entry.
-  # Bump the sha to refresh.
+  # Bump the sha to refresh. Source files are .mdx under
+  # packages/web/src/content/docs/ at the English root only — translated
+  # subdirs (bs/, ar/, fr/, etc.) are intentionally excluded. See #149.
   - lib_id: /anomalyco/opencode
     kind: github-md
-    ref: d312c677c588
+    ref: 908e28175f9e
     urls:
-      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/README.md
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/acp.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/agents.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/cli.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/commands.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/config.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/custom-tools.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/ecosystem.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/enterprise.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/formatters.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/github.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/gitlab.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/go.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/ide.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/index.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/keybinds.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/lsp.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/mcp-servers.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/models.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/modes.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/network.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/permissions.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/plugins.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/providers.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/rules.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/sdk.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/server.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/share.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/skills.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/themes.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/tools.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/troubleshooting.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/tui.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/web.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/windows-wsl.mdx
+      - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/zen.mdx
 
   # tursodatabase/turso-go — Go driver for Turso/Limbo. No releases yet
   # (`gh api repos/tursodatabase/turso-go/releases/latest` → "no releases"


### PR DESCRIPTION
## Summary

- Replaces the single `README.md` URL for `/anomalyco/opencode` with the 35 `.mdx` pages under `packages/web/src/content/docs/` at the English root.
- Bumps `ref:` from `d312c677c588` to `908e28175f9e` (HEAD of `anomalyco/opencode` `dev` branch on 2026-04-30).
- Yields **203 docs** after scrape (vs ~5 from README only). `libs` count: 1.

## Why

The previous entry only scraped the project's README, leaving `search_docs /anomalyco/opencode` blind to config / agents / providers / mcp-servers / skills / tools / permissions and ~30 other authoritative pages — exactly the surface a coding agent needs when helping a user debug opencode setup.

Closes #149.

## Test plan

- [x] `just scrape /anomalyco/opencode` succeeds end-to-end (libs_ok: 1, libs_failed: 0)
- [x] `sqlite3 artifacts/anomalyco_opencode/artifact.db 'select count(*) from docs'` → 203 (≥ 30)
- [x] `sqlite3 artifacts/anomalyco_opencode/artifact.db 'select count(*) from libs'` → 1
- [ ] CI passes
- [ ] Re-release `deadzone.db` via `just consolidate && just dbrelease <tag>` after merge (separate operator step)

## Out of scope

- Mintlify-style sub-docs at `packages/docs/*.mdx` (smaller, file separately if useful).
- Versioned mode — opencode does not publish stable release tags with doc snapshots; rolling latest is the right semantic.
- The `deadzone.db` re-release itself.