### PR TITLE
fix(ci): add concurrency group to release.yml to prevent same-tag race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,21 @@ on:
   # there is no tag to attach assets to.
   workflow_dispatch:
 
+# Serialize releases on the same ref so two concurrent runs (tag push
+# racing a manual workflow_dispatch on the same tag, or two near-
+# simultaneous tag pushes) don't upload artifacts to the same GH
+# Release in parallel. Group key includes github.ref so different
+# tags don't queue behind each other unnecessarily.
+#
+# cancel-in-progress: false because aborting a half-uploaded release
+# is strictly worse than serializing — a killed run leaves a partial
+# Release on GitHub (some assets present, others missing), and the
+# replacement run has no clean signal to detect/repair that state.
+# Queueing waits, but the eventual state is consistent. See #157.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 # TOKENIZERS_VERSION is the daulet/tokenizers release tag; bumping is
 # a conscious step — the composite action keys its cache on this file
 # so a bump invalidates cached archives on all three runners.


### PR DESCRIPTION
## Summary

- Adds a top-level `concurrency:` block to `release.yml` so two
  simultaneous runs on the same tag (push + `workflow_dispatch`, or
  two near-simultaneous tag pushes) serialize instead of racing on
  artifact upload to the same GitHub Release.
- Group key is `release-${{ github.ref }}` — different tags don't
  queue behind each other unnecessarily.
- `cancel-in-progress: false` because aborting a half-uploaded release
  leaves a partial Release on GitHub with no clean repair signal;
  serializing waits, but the eventual state is consistent.

## Test plan

- [x] `actionlint .github/workflows/release.yml` clean (exit 0)
- [ ] **Post-merge smoke**: push a scratch tag (`v0.0.0-concurrency-probe`)
      twice in quick succession; second run should queue (status
      "Pending"), not run in parallel. Tag + release cleaned up
      afterwards.
- [ ] Confirm no other workflow regression — `gh workflow list` after
      merge should show all workflows enabled and running normally.

Closes #157