### PR TITLE
refactor(ci): centralize TOKENIZERS_VERSION as install-native-deps input

### DIFF
--- a/.github/actions/build-appimage/action.yml
+++ b/.github/actions/build-appimage/action.yml
@@ -6,9 +6,10 @@ description: |
 
   `AppImage/appimagetool` release `1.9.1` is pinned here instead of
   the `continuous` tag; bumping it is a conscious step (same philosophy
-  as TOKENIZERS_VERSION in release.yml). The older `AppImage/AppImageKit`
-  repo is archived and all its release-13 assets have been renamed
-  `obsolete-*` — don't use them.
+  as the `tokenizers-version` input default in
+  `.github/actions/install-native-deps/action.yml`). The older
+  `AppImage/AppImageKit` repo is archived and all its release-13 assets
+  have been renamed `obsolete-*` — don't use them.
 
 inputs:
   tarball:

--- a/.github/actions/install-native-deps/action.yml
+++ b/.github/actions/install-native-deps/action.yml
@@ -6,10 +6,20 @@ description: |
   SHA256-verifies, and caches it at first use (see #73).
 
   Runs on Linux amd64/arm64 and macOS arm64. The asset is picked from
-  the daulet/tokenizers release matching `$TOKENIZERS_VERSION` (set in
-  the caller workflow env). Output lives at
-  /tmp/deadzone-deps/tokenizers/libtokenizers.a — point CGO_LDFLAGS or
-  DEADZONE_TOKENIZERS_LIB at that directory.
+  the daulet/tokenizers release matching the `tokenizers-version`
+  input. Output lives at /tmp/deadzone-deps/tokenizers/libtokenizers.a
+  — point CGO_LDFLAGS or DEADZONE_TOKENIZERS_LIB at that directory.
+
+inputs:
+  tokenizers-version:
+    description: |
+      daulet/tokenizers release tag — single source of truth for the
+      pinned version (#158). Callers should not override; the default
+      is what ships. Override exists only for ad-hoc bump testing in a
+      PR without touching the action default.
+    default: 'v1.26.0'
+    required: false
+
 runs:
   using: composite
   steps:
@@ -18,19 +28,23 @@ runs:
       uses: actions/cache@v5
       with:
         path: /tmp/deadzone-deps
-        # Composite actions cannot read ${{ env.* }} from the caller,
-        # so we key on the caller workflow file — bumping the pinned
-        # TOKENIZERS_VERSION there naturally invalidates the cache.
-        # runner.arch is in the key because ubuntu-24.04 and
-        # ubuntu-24.04-arm both report runner.os=Linux but need
-        # different .a archives.
-        key: deadzone-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/ci.yml', '.github/workflows/release.yml') }}
+        # Cache identity = (os, arch, tokenizers version). The version
+        # appears as a string literal in the key — bumping the input
+        # default (or any caller override) auto-invalidates without
+        # needing hashFiles. runner.arch is in the key because
+        # ubuntu-24.04 and ubuntu-24.04-arm both report runner.os=Linux
+        # but need different .a archives.
+        key: deadzone-deps-${{ runner.os }}-${{ runner.arch }}-${{ inputs.tokenizers-version }}
     - name: Download libtokenizers.a
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
+      env:
+        # Surface the input as the same env name the shell logic
+        # historically read — minimal diff inside the script.
+        TOKENIZERS_VERSION: ${{ inputs.tokenizers-version }}
       run: |
         set -euo pipefail
-        tok_version="${TOKENIZERS_VERSION:?TOKENIZERS_VERSION must be set in the caller workflow env}"
+        tok_version="${TOKENIZERS_VERSION:?TOKENIZERS_VERSION must be set}"
 
         case "$(uname -sm)" in
           "Darwin arm64")           asset="libtokenizers.darwin-arm64.tar.gz" ;;

--- a/.github/workflows/cache-keepalive.yml
+++ b/.github/workflows/cache-keepalive.yml
@@ -30,10 +30,9 @@ permissions:
 # before the embedder at runtime — build tags select files to compile,
 # not symbols to link, so CGO_LDFLAGS is mandatory or `ld` can't find
 # libtokenizers.a that install-native-deps unpacked into /tmp/deadzone-deps.
-# TOKENIZERS_VERSION must also stay defined here even when the deps cache
-# is warm — on a cold cache the composite action fails fast without it.
+# Pinned tokenizers release lives in install-native-deps as the
+# `tokenizers-version` input default — single source of truth (#158).
 env:
-  TOKENIZERS_VERSION: v1.26.0
   CGO_ENABLED: "1"
   CGO_LDFLAGS: -L/tmp/deadzone-deps/tokenizers
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,15 @@ on:
 # — bumping is a conscious step, not a passive upgrade from an upstream
 # "latest" tag.
 #
-# TOKENIZERS_VERSION tracks the daulet/tokenizers Go module version in
-# go.mod; the release tag for the prebuilt libtokenizers.a archive uses
-# the same scheme (see hugot's scripts/download-tokenizers.sh).
+# The pinned tokenizers release lives in
+# .github/actions/install-native-deps/action.yml as the
+# `tokenizers-version` input default — single source of truth (#158).
 #
 # The libonnxruntime shared library is NOT installed here. It is
 # fetched at first use by internal/ort.Bootstrap, SHA256-verified
 # against a pinned digest, and cached at DEADZONE_ORT_CACHE (below) so
 # actions/cache can persist it across jobs. Bumping the pinned version
 # is a one-line change in internal/ort/ort.go.
-env:
-  TOKENIZERS_VERSION: v1.26.0
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,9 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-# TOKENIZERS_VERSION is the daulet/tokenizers release tag; bumping is
-# a conscious step — the composite action keys its cache on this file
-# so a bump invalidates cached archives on all three runners.
-env:
-  TOKENIZERS_VERSION: v1.26.0
+# Pinned tokenizers release lives in
+# .github/actions/install-native-deps/action.yml as the
+# `tokenizers-version` input default — single source of truth (#158).
 
 jobs:
   build:

--- a/.github/workflows/scrape-pack.yml
+++ b/.github/workflows/scrape-pack.yml
@@ -41,11 +41,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Mirror ci.yml verbatim — same pinned tokenizer static archive, same
-  # model + ORT cache roots. Bumping TOKENIZERS_VERSION in ci.yml
-  # invalidates the composite action's cache key via its own hashFiles
-  # rule; this workflow piggybacks on that invalidation.
-  TOKENIZERS_VERSION: v1.26.0
+  # Pinned tokenizers release lives in
+  # .github/actions/install-native-deps/action.yml as the
+  # `tokenizers-version` input default — single source of truth (#158).
   DEADZONE_HUGOT_CACHE: ${{ github.workspace }}/.deadzone-cache/models
   DEADZONE_ORT_CACHE: ${{ github.workspace }}/.deadzone-cache/ort
   CGO_ENABLED: "1"


### PR DESCRIPTION
## Summary

- `install-native-deps/action.yml` exposes `tokenizers-version` as an
  `inputs:` field with `default: 'v1.26.0'` — single source of truth.
- Cache key uses the input value as a string literal in the key, so
  bumping the default auto-invalidates without `hashFiles()`.
- The four `env: TOKENIZERS_VERSION:` blocks in `ci.yml`,
  `release.yml`, `scrape-pack.yml`, `cache-keepalive.yml` are removed;
  stale comments rewritten to point at the new source of truth.
- Orphan reference in `build-appimage/action.yml` doc-string also
  repointed.

## Why now

The four duplicate declarations enabled a silent failure mode: a
partial bump (one workflow, not the others) goes undetected because
the composite action's cache key only hashed two of the four files.
Surfaces as ABI mismatch downstream, never at the bump itself.

## Out of scope (deliberate)

Per #158's Decision block, the per-artifact cache key in
`scrape-pack.yml:131` and `cache-keepalive.yml:106` still excludes the
tokenizers version. Probability of a future ABI-incompatible bump is
low; cost of mitigation (full re-scrape) is bounded; widening this key
would invalidate every artifact cache on every workflow edit
downstream.

## Test plan

- [x] \`actionlint .github/workflows/*.yml\` clean (exit 0)
- [x] \`grep -rn TOKENIZERS_VERSION .github/\` returns only 2 matches,
      both inside \`install-native-deps/action.yml\` (input→env mapping
      + shell read).
- [ ] **Post-merge smoke 1 (cold)**: dispatch
      \`gh workflow run scrape-pack.yml --ref main -f lib=\"\" -f tag=\"\"\`
      after merge. Expected: 100% cache miss on
      \`install-native-deps\` across all matrix slots (new key shape
      orphans the old caches).
- [ ] **Post-merge smoke 2 (warm)**: re-dispatch the same workflow
      with no changes. Expected: 100% cache hit on
      \`install-native-deps\`. A miss here means the key is
      non-deterministic — investigate before declaring closed.

## Migration cost

First post-merge run rebuilds the deps cache from scratch on every
runner. ~30s extra per runner per workflow, paid once.

Closes #158