### PR TITLE
fix(db): restore multi-process `deadzone server` via tursogo file-lock bypass

### DIFF
--- a/cmd/deadzone/server.go
+++ b/cmd/deadzone/server.go
@@ -316,14 +316,17 @@ func runServer() error {
 		return fmt.Errorf("stat db %s: %w", dbPath, err)
 	}
 
-	// db.OpenReader validates the embedder's reported meta against
-	// whatever the database was created with; a mismatch fails fast
-	// and tells the user to rebuild against a fresh file. Unlike
-	// db.Open (used by mutator subcommands like consolidate / scrape /
-	// dbrelease) it does NOT run any DDL and sets PRAGMA query_only on
-	// the connection, so N concurrent `deadzone server` processes can
-	// share the same deadzone.db file without racing each other on
-	// SQLite write-intent locks (#131).
+	// Opt this server process into the multi-process reader bypass so
+	// a second `deadzone server` against the same DB file does not
+	// fail on tursogo's fcntl lock (#172). Server-only — mutator
+	// subcommands run in their own process and keep the lock.
+	db.EnableMultiProcessReaders()
+
+	// db.OpenReader pins the connection to PRAGMA query_only and runs
+	// no DDL, so combined with the lock bypass above N concurrent
+	// `deadzone server` processes share the same deadzone.db (#131,
+	// #172). On embedder/schema mismatch the call fails fast with the
+	// stored vs requested values so the user knows what to rebuild.
 	e, err := embed.New(embedderKind)
 	if err != nil {
 		return fmt.Errorf("embedder: %w", err)
@@ -340,6 +343,9 @@ func runServer() error {
 		ModelVersion: e.ModelVersion(),
 	})
 	if err != nil {
+		if errors.Is(err, db.ErrReaderBusy) {
+			return fmt.Errorf("open db: another `deadzone server` process is already using %s — stop it (or pass a different --db path) before starting a new one", dbPath)
+		}
 		return fmt.Errorf("open db: %w", err)
 	}
 	defer d.Close()

--- a/docs/research/multi-process-lock.md
+++ b/docs/research/multi-process-lock.md
@@ -1,0 +1,159 @@
+# Multi-process locking on `deadzone.db` (issue #172)
+
+## TL;DR
+
+`tursogo` v0.5.3 takes an OS-level (fcntl) file lock on the first I/O
+against a database file, which by default excludes a second process
+opening the same file. The Rust core ships **two escape hatches** that
+skip the lock — one is reachable from the Go driver as it stands today.
+deadzone uses it: `cmd/deadzone/server.go` sets the
+`LIMBO_DISABLE_FILE_LOCK=1` env var before `db.OpenReader`, restoring
+the multi-process contract claimed by #131. A defense-in-depth
+`db.ErrReaderBusy` sentinel still wraps the raw tursogo lock error so
+any future regression surfaces with a human-readable message.
+
+## Reproducer (pre-fix)
+
+One-line shell repro against any consolidated `deadzone.db`:
+
+```sh
+deadzone server --db ./deadzone.db & sleep 2 && deadzone server --db ./deadzone.db
+```
+
+Pre-fix the second invocation failed with:
+
+```
+deadzone: open db: open db reader ./deadzone.db: set query_only:
+turso: error: Locking error: Failed locking file. File is locked by another process
+```
+
+The failure happened on `PRAGMA query_only = 1` — the first real query
+that forces tursogo to actually open a connection and acquire the
+file lock.
+
+## What was tried, and what works
+
+### DSN flags (`?key=value`)
+
+`tursogo`'s `parseDSN` (`driver_db.go:622`) accepts `experimental`,
+`async`, `vfs`, `encryption_*`, `_busy_timeout`. **Notably absent vs
+libSQL / mattn-sqlite3**: `mode=ro`, `immutable=1`, `nolock=1`,
+`cache=shared`. None of the supported flags disable the OS-level
+lock for a file-backed database.
+
+### `?experimental=multiprocess_wal`
+
+Turso (the engine) gained a real cross-process WAL coordinator in
+`core/storage/shared_wal_coordination.rs` — a `.tshm` shared memory
+file plus byte-range locks gating writer / checkpointer / reader
+slots. The matching `multiprocess_wal` experimental feature is
+parsed by `sdk-kit/src/rsapi.rs` and flips `OpenFlags::NoLock`.
+
+**Caveat — not in v0.5.3.** A `git grep "multiprocess_wal"` against
+the `bindings/go/v0.5.3` tag returns 0 hits in `sdk-kit/src/rsapi.rs`.
+The feature landed in master between v0.5.3 (2026-04-02) and
+v0.6.0-pre.X. Empirical test on v0.6.0-pre.25 with both processes
+passing `?experimental=multiprocess_wal`: `.tshm` is created, but
+the second-process open still fails with the same lock error —
+likely a still-baking ABI / binding wiring gap. Not a path to ship
+on today.
+
+### `LIMBO_DISABLE_FILE_LOCK` env var (chosen)
+
+`core/io/common.rs` defines:
+
+```rust
+pub const ENV_DISABLE_FILE_LOCK: &str = "LIMBO_DISABLE_FILE_LOCK";
+```
+
+Every IO backend (`unix.rs`, `io_uring.rs`, `windows.rs`,
+`win_iocp.rs`) honors it:
+
+```rust
+if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
+    && !flags.contains(OpenFlags::ReadOnly)
+{
+    unix_file.lock_file(true)?;
+}
+```
+
+So setting `LIMBO_DISABLE_FILE_LOCK=1` in the environment makes
+`open_file` skip `lock_file` entirely. Empirically verified against
+tursogo v0.5.3:
+
+- Without the env var: process B's `PRAGMA query_only = 1` returns
+  `turso: error: Locking error: …`.
+- With `LIMBO_DISABLE_FILE_LOCK=1` in both processes: B opens the
+  same file, runs `SELECT count(*) FROM t`, gets `3`. Both processes
+  remain alive.
+
+This is the path deadzone uses today.
+
+### `OpenFlags::ReadOnly` (Rust-side equivalent)
+
+The same `unix.rs` snippet shows that passing `OpenFlags::ReadOnly`
+**also** skips `lock_file`. The `tursodb --readonly` CLI flag
+exercises this. But tursogo's Go binding does NOT expose
+`OpenFlags::ReadOnly` — neither the DSN nor `TursoDatabaseConfig`
+carry it. The env var is the only Go-reachable lever.
+
+## Decision: env-var bypass + ErrReaderBusy fallback
+
+`cmd/deadzone/server.go` calls `os.Setenv("LIMBO_DISABLE_FILE_LOCK",
+"1")` before `db.OpenReader`. Process-scoped: only the server
+processes opt out of the lock. Mutator subcommands (`consolidate`,
+`scrape`, `dbrelease`) live in their own processes and never set
+the var, so concurrent writers are still serialised by fcntl as
+before — only the read path is widened.
+
+`db.ErrReaderBusy` and the substring detection in
+`db.isTursoLockError` stay in place as defense in depth: if the env
+var is somehow stripped (sandbox, env scrubber, future tursogo bump
+renaming the var), the lock failure surfaces with a clear human
+message instead of the raw tursogo string. The
+`TestOpenReader_MultiProcess/FallbackErrReaderBusyWithoutEnvVar`
+sub-test pins this branch.
+
+## Risks and re-evaluate-when
+
+- **The env var is internal.** `LIMBO_DISABLE_FILE_LOCK` lives in
+  `core/io/common.rs` with no public-docs commitment. A rename to
+  `TURSO_DISABLE_FILE_LOCK` is plausible mid-development. Mitigation:
+  pin tursogo in `go.mod` (`v0.5.3`) and re-validate the var name on
+  every bump. The `FallbackErrReaderBusyWithoutEnvVar` sub-test
+  catches a regression because the env var name is the only knob —
+  if a rename silently disables it, the unit test still asserts the
+  fallback path gives a clear error.
+
+- **Shared `.tshm` coordinator may eventually be the right answer.**
+  When `multiprocess_wal` ships in a stable tursogo Go release with
+  working `.tshm` semantics, switch to `?experimental=multiprocess_wal`
+  in the DSN and drop the env var. That path supports concurrent
+  *writers* too (via the single-writer slot in `.tshm`), not just
+  readers — bigger upside for any future "consolidate while serving"
+  workflow.
+
+- **Lock bypass weakens the protection against a stray writer in the
+  same process.** Not relevant here: `runServer` only calls
+  `db.OpenReader` and pins every connection to `PRAGMA query_only`,
+  so the server cannot accidentally write. `cmd/deadzone/consolidate.go`
+  et al. live in separate processes that do NOT set the env var.
+
+## Out of scope
+
+- Forking tursogo or swapping it for `mattn/go-sqlite3`.
+- Daemon-of-servers architecture multiplexing multiple MCP clients
+  through a single in-memory `deadzone server`.
+- NFS / CIFS / GFS2 / Lustre validation — `multiprocess_wal` docs
+  call those out as unsafe; the env-var bypass inherits the same
+  caveats. deadzone targets local filesystems only.
+
+## Test commands
+
+- Reproduce pre-fix: `LIMBO_DISABLE_FILE_LOCK= deadzone server &
+  sleep 2 && LIMBO_DISABLE_FILE_LOCK= deadzone server` (force-empty
+  env to defeat the bypass).
+- Verify post-fix: `deadzone server & sleep 2 && deadzone server` —
+  both processes should run.
+- `mise exec -- go test ./internal/db/... -run TestOpenReader_MultiProcess -v`
+- `just test`

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -213,6 +213,15 @@ func Open(path string, meta Meta) (*DB, error) {
 // errors.Is to detect.
 var ErrReaderNotInitialized = errors.New("database was never initialized by a mutator")
 
+// ErrReaderBusy is returned by OpenReader when another process already
+// holds the OS-level file lock on the database file. Surfaces the
+// otherwise-cryptic tursogo "Locking error: Failed locking file" with
+// a typed sentinel so callers (e.g. cmd/deadzone/server.go) can print
+// a human-readable message naming the offending file. See
+// docs/research/multi-process-lock.md for why this is needed and what
+// it costs to detect. Wrap with errors.Is.
+var ErrReaderBusy = errors.New("another process is using this database file")
+
 // OpenReader opens an existing deadzone database in read-only mode. It
 // is the entry point used by `deadzone server` and any other caller
 // that issues only SELECTs. Unlike Open it does NOT run any DDL and
@@ -274,8 +283,20 @@ func OpenReader(path string, meta Meta) (*DB, error) {
 	// issue a write. The tursogo DSN is a bare path and does not
 	// support a ?mode=ro query string (documented at db.go:117), so
 	// this pragma is the portable way to enforce the read-only contract.
+	//
+	// This is also the first real query against the file, which forces
+	// tursogo to actually open a connection and acquire its OS-level
+	// file lock. Tursogo v0.5.3 does not support cross-process readers
+	// — a second process trying to open the same file fails here with a
+	// generic "Locking error: Failed locking file" surfaced as
+	// turso.ErrTursoGeneric. Translate that into ErrReaderBusy so
+	// callers can print a useful message instead of the raw driver
+	// string. See docs/research/multi-process-lock.md.
 	if _, err := raw.Exec(`PRAGMA query_only = 1`); err != nil {
 		raw.Close()
+		if isTursoLockError(err) {
+			return nil, fmt.Errorf("%w: %s", ErrReaderBusy, path)
+		}
 		return nil, fmt.Errorf("open db reader %s: set query_only: %w", path, err)
 	}
 
@@ -864,6 +885,49 @@ func writeMeta(raw *sql.DB, m Meta) error {
 		}
 	}
 	return nil
+}
+
+// EnvDisableFileLock is the tursogo (Limbo) escape hatch that makes
+// every IO backend skip the OS-level fcntl lock at file-open time.
+// Set to any non-empty value before the first OpenReader call.
+// Defined in tursogo's core/io/common.rs as ENV_DISABLE_FILE_LOCK.
+const EnvDisableFileLock = "LIMBO_DISABLE_FILE_LOCK"
+
+// EnableMultiProcessReaders opts the current process into the lock
+// bypass so multiple readers can coexist on the same database file.
+// Safe to call repeatedly. Intended for callers (e.g. deadzone server)
+// that only ever use OpenReader: the bypass weakens cross-process
+// protection against concurrent writers, so processes that take the
+// mutator path (Open, OpenArtifact) must NOT call this.
+//
+// Why an env var rather than an open flag: tursogo v0.5.3 does not
+// expose OpenFlags::ReadOnly through its DSN or config struct, so the
+// env-var escape hatch is the only Go-reachable lever. See
+// docs/research/multi-process-lock.md for the full audit and the
+// migration plan once tursogo ships native multi-process support.
+func EnableMultiProcessReaders() {
+	os.Setenv(EnvDisableFileLock, "1")
+}
+
+// tursoLockErrorSubstring is the message tursogo v0.5.3 emits when a
+// second process tries to open a database file the first process has
+// already opened. The full driver error is
+// "turso: error: Locking error: Failed locking file. File is locked by
+// another process" — wrapping turso.ErrTursoGeneric. Until tursogo
+// exposes a typed sentinel for this case, substring matching is the
+// only reliable signal. Re-validate against tursogo on every version
+// bump in go.mod; a message change reverts behavior to "raw driver
+// error surfaces", never to a silent false negative.
+const tursoLockErrorSubstring = "Locking error: Failed locking file"
+
+// isTursoLockError reports whether err is the cross-process file-lock
+// failure tursogo surfaces from a second-process open. Centralised so
+// the brittle substring check has one home; see
+// docs/research/multi-process-lock.md for why we cannot use
+// errors.Is(err, turso.ErrTursoBusy) here (lock conflicts wrap
+// ErrTursoGeneric, not ErrTursoBusy).
+func isTursoLockError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), tursoLockErrorSubstring)
 }
 
 func keysOf(m map[string]string) []string {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,15 +1,20 @@
 package db_test
 
 import (
+	"bufio"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/laradji/deadzone/internal/db"
 	"github.com/laradji/deadzone/internal/embed"
@@ -22,6 +27,15 @@ import (
 var testEmbedder *embed.Hugot
 
 func TestMain(m *testing.M) {
+	// Multi-process helper short-circuit: when the parent test re-execs
+	// us with this env var set, run the DB-holder loop and exit without
+	// touching the Hugot embedder or calling m.Run(). See
+	// TestOpenReader_MultiProcess for the parent side.
+	if path := os.Getenv("DEADZONE_TEST_HOLD_DB_PATH"); path != "" {
+		runHoldDBHelper(path)
+		return
+	}
+
 	e, err := embed.NewHugot(embed.DefaultHugotModel, hugotTestCacheDir())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "TestMain: NewHugot: %v\n", err)
@@ -31,6 +45,40 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	_ = e.Close()
 	os.Exit(code)
+}
+
+// runHoldDBHelper opens path through the same code path OpenReader
+// uses (sql.Open + PRAGMA query_only on a pinned connection),
+// announces readiness on stdout, and blocks until the parent closes
+// stdin. Direct sql.Open is on purpose — calling db.OpenReader would
+// require the embedder meta to validate, which would force this child
+// process to load Hugot (multi-second startup). The lock acquired by
+// PRAGMA query_only is byte-identical to what OpenReader takes, so
+// the parent's lock-conflict assertion still pins the same code path.
+func runHoldDBHelper(path string) {
+	d, err := sql.Open("turso", path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hold helper: sql.Open: %v\n", err)
+		os.Exit(1)
+	}
+	d.SetMaxOpenConns(1)
+	d.SetMaxIdleConns(1)
+	d.SetConnMaxLifetime(0)
+	d.SetConnMaxIdleTime(0)
+	if _, err := d.Exec(`PRAGMA query_only = 1`); err != nil {
+		fmt.Fprintf(os.Stderr, "hold helper: PRAGMA query_only: %v\n", err)
+		os.Exit(1)
+	}
+	if _, err := fmt.Println("ready"); err != nil {
+		os.Exit(1)
+	}
+	// Block on stdin EOF — parent closes its end of the pipe to signal
+	// "you can release the lock and exit". Deliberately avoids signals
+	// so a Ctrl-C in the parent test runner naturally tears the child
+	// down via SIGPIPE on its next write attempt.
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	_ = d.Close()
+	os.Exit(0)
 }
 
 // hugotTestCacheDir picks a cache directory for tests. Honors
@@ -876,22 +924,17 @@ func TestOpenReader_DoesNotIssueDDL(t *testing.T) {
 	}
 }
 
-// TestOpenReader_CoexistsWithWriterOnSameFile holds a write-intent
-// lock on the main DB via a mutator-opened `BEGIN IMMEDIATE`, then
-// spawns multiple OpenReader calls against the same file. The
-// assertion is that every reader opens and answers its SELECT without
-// a SQLITE_BUSY, proving the reader path is safe under the exact
-// condition the old Open boot race could have hit: a writer actively
-// holding the reserved lock while a would-be reader starts up.
+// TestOpenReader_CoexistsInProcess holds a write-intent lock on the
+// main DB via a mutator-opened `BEGIN IMMEDIATE`, then spawns
+// multiple OpenReader calls against the same file. Asserts every
+// reader opens and answers its SELECT without SQLITE_BUSY, proving
+// the reader path is safe against an active in-process writer (#131
+// boot-race). Combined with TestOpenReader_DoesNotIssueDDL.
 //
-// Tursogo enables WAL by default (see the comment at db.go:129), so
-// in WAL mode readers and a writer coexist by design — this test
-// documents that we rely on that property and that OpenReader does
-// nothing to break it. Combined with TestOpenReader_DoesNotIssueDDL
-// (no boot-time DDL), the two together pin down the whole contract:
-// zero writes on boot, plus WAL concurrency, equals N readers safe
-// against 1 writer.
-func TestOpenReader_CoexistsWithWriterOnSameFile(t *testing.T) {
+// SCOPE — single process only: every goroutine shares the same
+// tursogo driver instance and the same fcntl FD. The cross-process
+// contract is pinned by TestOpenReader_MultiProcess (#172).
+func TestOpenReader_CoexistsInProcess(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "reader.db")
 	seedMainDB(t, path)
 
@@ -982,6 +1025,150 @@ func TestOpenReader_CoexistsWithWriterOnSameFile(t *testing.T) {
 		if n != 2 {
 			t.Errorf("reader %d: count=%d, want 2 (uncommitted writer must be invisible)", i, n)
 		}
+	}
+}
+
+// TestOpenReader_MultiProcess pins the user-visible cross-process
+// behavior of issue #172. Two sub-tests cover the two paths the
+// production code can take:
+//
+//   - CoexistsWithEnvVar — the primary path: cmd/deadzone/server.go
+//     sets LIMBO_DISABLE_FILE_LOCK=1 so tursogo skips the OS-level
+//     fcntl lock on the database file. With both processes running
+//     under that env var, db.OpenReader succeeds in both — restoring
+//     the #131 contract that N concurrent `deadzone server` processes
+//     can share the same deadzone.db.
+//
+//   - FallbackErrReaderBusyWithoutEnvVar — defense-in-depth: if a
+//     wrapper strips the env var (sandbox, env scrubber, future
+//     tursogo bump renaming the var), the second process must still
+//     fail with db.ErrReaderBusy and a message naming the file —
+//     never the raw tursogo "Locking error: Failed locking file"
+//     string the user originally reported.
+//
+// Mechanics: each sub-test re-execs its own test binary in a "hold"
+// mode (TestMain short-circuits on the DEADZONE_TEST_HOLD_DB_PATH env
+// var, runs runHoldDBHelper, and exits without loading Hugot). The
+// helper takes the lock via the same sql.Open + PRAGMA query_only
+// call sequence OpenReader uses, prints "ready" on stdout, and
+// blocks on stdin EOF. Re-execing the test binary instead of the
+// real `deadzone` binary keeps `go test` self-contained — the OS
+// lock is what matters and the helper acquires it through
+// byte-identical driver calls.
+//
+// Not gated on `-short`: the contract this validates is the user-
+// visible failure mode and CI must catch a regression unconditionally.
+func TestOpenReader_MultiProcess(t *testing.T) {
+	t.Run("CoexistsWithEnvVar", func(t *testing.T) {
+		// Children inherit os.Environ(); t.Setenv restores the prior
+		// state on exit so sibling tests are not affected.
+		t.Setenv(db.EnvDisableFileLock, "1")
+
+		path := filepath.Join(t.TempDir(), "reader.db")
+		seedMainDB(t, path)
+		startHoldHelper(t, path)
+
+		d, err := db.OpenReader(path, metaFor(testEmbedder))
+		if err != nil {
+			t.Fatalf("OpenReader against held file: got %v, want success (env-var bypass should let processes coexist)", err)
+		}
+		defer d.Close()
+
+		var n int
+		if err := d.QueryRow(`SELECT count(*) FROM docs`).Scan(&n); err != nil {
+			t.Fatalf("parent SELECT count(*): %v", err)
+		}
+		if n < 1 {
+			t.Errorf("docs count = %d, want >= 1 (seedMainDB should populate)", n)
+		}
+	})
+
+	t.Run("FallbackErrReaderBusyWithoutEnvVar", func(t *testing.T) {
+		// Register restore BEFORE mutating the env so a panic between
+		// the two lines cannot leak state to sibling tests.
+		old, present := os.LookupEnv(db.EnvDisableFileLock)
+		t.Cleanup(func() {
+			if present {
+				os.Setenv(db.EnvDisableFileLock, old)
+			} else {
+				os.Unsetenv(db.EnvDisableFileLock)
+			}
+		})
+		os.Unsetenv(db.EnvDisableFileLock)
+
+		path := filepath.Join(t.TempDir(), "reader.db")
+		seedMainDB(t, path)
+		startHoldHelper(t, path)
+
+		d, err := db.OpenReader(path, metaFor(testEmbedder))
+		if err == nil {
+			_ = d.Close()
+			t.Fatal("OpenReader unexpectedly succeeded against a held file with the env var unset; tursogo should have rejected the open")
+		}
+		if !errors.Is(err, db.ErrReaderBusy) {
+			t.Fatalf("OpenReader error = %v; want errors.Is(_, db.ErrReaderBusy)", err)
+		}
+		if !strings.Contains(err.Error(), path) {
+			t.Errorf("OpenReader error = %q; want it to mention the DB path %q", err.Error(), path)
+		}
+	})
+}
+
+// startHoldHelper re-execs the test binary in DB-holder mode against
+// path and registers its own cleanup so the child cannot be orphaned
+// even if the caller t.Fatals before its own cleanup line. The
+// helper inherits the parent's environment, so each sub-test
+// controls the LIMBO_DISABLE_FILE_LOCK policy by setting it before
+// the call.
+func startHoldHelper(t *testing.T, path string) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run", "^$")
+	cmd.Env = append(os.Environ(), "DEADZONE_TEST_HOLD_DB_PATH="+path)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe: %v", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("StdinPipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start hold helper: %v", err)
+	}
+	// Register cleanup the moment the child is alive — Kill + Wait
+	// regardless of how the readiness check below resolves.
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	readyCh := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		if scanner.Scan() {
+			if scanner.Text() != "ready" {
+				readyCh <- fmt.Errorf("hold helper: unexpected line %q", scanner.Text())
+				return
+			}
+			readyCh <- nil
+			return
+		}
+		if err := scanner.Err(); err != nil {
+			readyCh <- err
+			return
+		}
+		readyCh <- io.EOF
+	}()
+	select {
+	case err := <-readyCh:
+		if err != nil {
+			t.Fatalf("hold helper never became ready: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatalf("hold helper readiness timeout")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `db.OpenReader` previously claimed (per #131) to support N concurrent
  `deadzone server` processes against the same `deadzone.db`, but the
  test only covered in-process goroutines. In production, a second
  process failed at `PRAGMA query_only = 1` with the cryptic
  `turso: error: Locking error: Failed locking file. File is locked by another process`.
- This PR ships the multi-process contract for real, plus a clear
  fallback for the case where the bypass is unavailable.

## What changed

- **Investigation doc**: `docs/research/multi-process-lock.md` —
  documents what was tried (DSN flags, `?experimental=multiprocess_wal`)
  and what landed (`LIMBO_DISABLE_FILE_LOCK=1` env var, an internal
  tursogo escape hatch). Risk profile + re-evaluate-when included.
- **`internal/db/db.go`**:
  - `db.EnableMultiProcessReaders()` opts the calling process into
    the lock bypass via the env var. Public helper so callers don't
    hardcode the env-var name.
  - `db.ErrReaderBusy` sentinel + private `isTursoLockError(err)`
    substring detector so a second-process open with the env var
    stripped (sandbox, future rename) surfaces with a human-readable
    message instead of the raw tursogo string.
- **`cmd/deadzone/server.go`**: calls
  `db.EnableMultiProcessReaders()` before `db.OpenReader`, and prints
  a friendly message naming the offending DB path on `ErrReaderBusy`.
  Stale doc-comment about #131's contract rewritten to match reality.
- **`internal/db/db_test.go`**:
  - New `TestOpenReader_MultiProcess` with two sub-tests
    (`CoexistsWithEnvVar`, `FallbackErrReaderBusyWithoutEnvVar`).
    Re-execs the test binary as a real subprocess via `exec.Command`
    — pins the genuine cross-process behavior, not just goroutines.
  - `TestMain` short-circuits on `DEADZONE_TEST_HOLD_DB_PATH` to act
    as a DB-holder helper without loading Hugot — keeps the
    subprocess startup near-instant.
  - Existing `TestOpenReader_CoexistsWithWriterOnSameFile` renamed
    to `TestOpenReader_CoexistsInProcess` with a corrected docstring
    acknowledging its in-process scope.

## Test plan

- [ ] CI: `lint`, `build`, `test`, `licenses` — must pass on both Linux
      and macOS runners (cross-process fcntl semantics differ slightly,
      so multi-platform is the real validation here).
- [ ] **Post-merge smoke**: `deadzone server &` then a second
      `deadzone server` in another terminal — both processes must run
      simultaneously without the locking error.
- [ ] **Negative-path manual verification** (optional):
      `LIMBO_DISABLE_FILE_LOCK= deadzone server &` then a second
      one — second invocation fails fast with the new
      `another \`deadzone server\` process is already using …` message
      (no raw tursogo string).

Closes #172