### PR TITLE
chore(ci): bump actions/checkout v5 → v6 in update-package-channels.yml

### DIFF
--- a/.github/workflows/update-package-channels.yml
+++ b/.github/workflows/update-package-channels.yml
@@ -55,7 +55,7 @@ jobs:
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
       - name: Checkout caller repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Extract platform sha256
         id: sha
@@ -65,7 +65,7 @@ jobs:
           asset-suffix: ${{ env.ASSET_SUFFIX }}
 
       - name: Checkout tap repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: laradji/homebrew-deadzone
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary

- `update-package-channels.yml:58` and `:68` use `actions/checkout@v5` while every other workflow in the suite is on `@v6`. Bumps both to `@v6` for consistency.

## Why this scope (and what was deferred)

The original audit finding (#162) bundled this checkout bump with a SHA-pin sweep on `jdx/mise-action`. The SHA-pin part was intentionally deferred — the project's blast radius (narrow PAT scopes, no production secrets) does not justify the maintenance overhead of manual SHA tracking on every major bump. See issue comment for the full rationale.

This PR ships the consistency bump only.

## Test plan

- [x] \`actionlint .github/workflows/update-package-channels.yml\` clean (exit 0)
- [x] \`grep -rn "actions/checkout" .github/\` confirms uniformity at \`@v6\` across the suite
- [ ] CI: \`lint\`, \`build\`, \`test\`, \`licenses\` must pass

Closes #162