### PR TITLE
refactor(configlibs): expand short SHA pins to full 40-char SHAs

### DIFF
--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -82,6 +82,9 @@
 # run to one library with `--lib /org/project` (matches all versions) or
 # pin to one version with `--lib /org/project --version <tag>` (#113).
 
+# Ref policy: prefer git tags; fall back to full 40-char SHAs.
+# Short SHAs are forbidden — they are not collision-resistant on
+# large repos and are subject to upstream GC.
 libraries:
   - lib_id: /modelcontextprotocol/go-sdk
     kind: github-md
@@ -260,7 +263,7 @@ libraries:
   # to keep the vocab one-placeholder-wide.
   - lib_id: /hashicorp/terraform
     kind: github-md
-    ref: 9c479db1ab97
+    ref: 9c479db1ab97a2f175e049c0d5bbf31c24959c7e
     versions:
       "1.13":
         urls:
@@ -476,7 +479,7 @@ libraries:
   # subdirs (bs/, ar/, fr/, etc.) are intentionally excluded. See #149.
   - lib_id: /anomalyco/opencode
     kind: github-md
-    ref: 908e28175f9e
+    ref: 908e28175f9e5c46206c8884bdd9a7dbb31d0f0b
     urls:
       - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/acp.mdx
       - https://raw.githubusercontent.com/anomalyco/opencode/{ref}/packages/web/src/content/docs/agents.mdx


### PR DESCRIPTION
## Summary

Replaces short SHA pins with full 40-character SHAs in `libraries_sources.yaml` and documents the ref policy.

## Changes

- Added a **Ref policy** comment block: prefer git tags, fall back to full 40-char SHAs; short SHAs are forbidden (not collision-resistant on large repos, subject to upstream GC).
- Expanded `/hashicorp/terraform` ref: `9c479db1ab97` → `9c479db1ab97a2f175e049c0d5bbf31c24959c7e`.
- Expanded `/anomalyco/opencode` ref: `908e28175f9e` → `908e28175f9e5c46206c8884bdd9a7dbb31d0f0b`.

## Why

Short SHAs are ambiguous on large repositories and may be garbage-collected upstream, breaking reproducibility. Pinning to full SHAs ensures deterministic, long-lived references.

<!-- emdash-issue-footer:start -->
Fixes #168
<!-- emdash-issue-footer:end -->