### PR TITLE
feat(ci): pre-validate release secrets and require dbrelease --tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Fail fast: a missing/rotated PAT otherwise surfaces as a 401
+      # deep in `gh release create`. Gated like the publish step so
+      # dry-run dispatches skip it. See #161.
+      - name: Validate secrets
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        env:
+          RELEASE_PUBLISH_TOKEN: ${{ secrets.RELEASE_PUBLISH_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_PUBLISH_TOKEN" ]; then
+            echo "::error::RELEASE_PUBLISH_TOKEN missing or empty — required PAT (Contents: read+write on this repo) so release.published spawns update-package-channels.yml. See repo settings → secrets and #161."
+            exit 1
+          fi
+
       - uses: actions/download-artifact@v8
         with:
           pattern: deadzone-*

--- a/.github/workflows/update-package-channels.yml
+++ b/.github/workflows/update-package-channels.yml
@@ -54,6 +54,17 @@ jobs:
       # `inputs.tag`. Fallback short-circuits on the first non-empty.
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
+      # Fail fast: a missing/rotated PAT otherwise surfaces as a 401
+      # from the tap-repo checkout below. See #161.
+      - name: Validate secrets
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN missing or empty — required fine-grained PAT (Contents: read+write on laradji/homebrew-deadzone). See repo settings → secrets and #161."
+            exit 1
+          fi
+
       - name: Checkout caller repo
         uses: actions/checkout@v6
 
@@ -68,6 +79,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: laradji/homebrew-deadzone
+          # HOMEBREW_TAP_TOKEN is a fine-grained PAT scoped to:
+          #   - Repository: laradji/homebrew-deadzone (only this repo)
+          #   - Permissions: Contents = read+write (push the formula bump commit)
+          # Owner: maintainer-only secret, rotated via repo settings → secrets.
+          # Rotation cadence: renew when GitHub's "Last used" age exceeds
+          # 180 days, or sooner if a leak is suspected. The Validate
+          # secrets step above catches an empty/missing value; a
+          # wrong-scope value surfaces as a 401 here.
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: tap
 

--- a/cmd/deadzone/dbrelease.go
+++ b/cmd/deadzone/dbrelease.go
@@ -76,6 +76,9 @@ func init() {
 		"manifest to update")
 	dbreleaseCmd.Flags().BoolVar(&dbreleaseVerbose, "verbose", false,
 		"enable Debug-level slog output")
+	// Cobra's required check fires on flag.Changed, so the runtime
+	// TrimSpace guard in runDBRelease still has to catch `--tag ""`.
+	_ = dbreleaseCmd.MarkFlagRequired("tag")
 	rootCmd.AddCommand(dbreleaseCmd)
 }
 

--- a/cmd/deadzone/dbrelease_test.go
+++ b/cmd/deadzone/dbrelease_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestDBRelease_TagFlagRequired pins the cobra MarkFlagRequired wiring
+// for `dbrelease --tag` so a future flag rename can't silently drop the
+// guard. See #161.
+func TestDBRelease_TagFlagRequired(t *testing.T) {
+	// Cobra's required-flag check looks at pflag.Changed, not the
+	// bound variable's value, so reset both: the global default may
+	// still be "" but a sibling test could have set Changed=true.
+	tagFlag := dbreleaseCmd.Flags().Lookup("tag")
+	if tagFlag == nil {
+		t.Fatal("dbrelease cmd missing --tag flag")
+	}
+	tagFlag.Changed = false
+	dbreleaseTag = ""
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	// Empty slice (not nil) — nil makes cobra fall back to os.Args[1:],
+	// which under `go test` carries flags like -test.v and breaks the
+	// parser before it ever checks required flags.
+	rootCmd.SetArgs([]string{"dbrelease"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("expected required-flag error when --tag is missing; got nil (output: %s)", buf.String())
+	}
+	const want = `required flag(s) "tag" not set`
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error %q does not contain %q", err.Error(), want)
+	}
+}


### PR DESCRIPTION
## Summary

Fail-fast guards for the release pipeline so missing PATs and empty `--tag` values surface immediately instead of as cryptic 401s or silent no-ops. See #161.

## Changes

- **`.github/workflows/release.yml`**: new `Validate secrets` step on the publish job checks `RELEASE_PUBLISH_TOKEN` is non-empty before `gh release create` runs. Gated on `push` + `tag` so dry-run dispatches still skip it.
- **`.github/workflows/update-package-channels.yml`**: new `Validate secrets` step checks `HOMEBREW_TAP_TOKEN` before the tap-repo checkout. Adds inline scope/rotation docs next to the `token:` usage (fine-grained PAT, Contents r+w on `laradji/homebrew-deadzone`, rotate at >180 days `Last used`).
- **`cmd/deadzone/dbrelease.go`**: `MarkFlagRequired("tag")` so cobra rejects invocations without `--tag`. Comment notes the existing `TrimSpace` guard still handles `--tag ""` since cobra checks `flag.Changed`, not the value.
- **`cmd/deadzone/dbrelease_test.go`**: pins the wiring with a test that resets `Changed`/`dbreleaseTag`, runs `rootCmd.Execute()` with `[]string{"dbrelease"}`, and asserts the `required flag(s) "tag" not set` error.

## Test plan

- [ ] `go test ./cmd/deadzone/...` passes
- [ ] Workflow dispatch with empty `HOMEBREW_TAP_TOKEN` fails on `Validate secrets` (not on checkout)
- [ ] Tagged push with empty `RELEASE_PUBLISH_TOKEN` fails on `Validate secrets` (not on `gh release create`)
- [ ] `deadzone dbrelease` (no flag) exits non-zero with the required-flag message

<!-- emdash-issue-footer:start -->
Fixes #161
<!-- emdash-issue-footer:end -->