### PR TITLE
fix(justfile): set CGO env for fmt and tidy targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,15 +235,12 @@ Then add a `kind: scrape-via-agent` entry to `libraries_sources.yaml` with a lis
 
 ## Local pipeline (contributors)
 
+Two-step bootstrap: toolchain first, then the CGO native dep — kept separate so air-gapped / CI runners with vendored `libtokenizers.a` can skip step 2 by overriding `DEADZONE_TOKENIZERS_LIB`.
+
 ```sh
-# 1. Install the pinned toolchain (Go 1.26.2 + just)
-mise install
-
-# 2. Fetch libtokenizers.a for your platform into ./lib/
-just fetch-tokenizers
-
-# 3. Build, scrape, consolidate, serve
-just build
+just bootstrap            # Go 1.26.2 + just toolchain (mise install)
+just fetch-tokenizers     # libtokenizers.a — one-shot CGO setup
+just build                # CGO + ORT, all packages
 just scrape                       # all libs — one artifact folder per lib
 just scrape /hashicorp/terraform  # one base lib, every version
 just scrape /hashicorp/terraform/1.14   # one exact version

--- a/cmd/deadzone/coverage_test.go
+++ b/cmd/deadzone/coverage_test.go
@@ -165,4 +165,3 @@ func TestWriteAtomic_CreatesParentDir(t *testing.T) {
 		t.Errorf("content = %q, want %q", got, "ok\n")
 	}
 }
-

--- a/internal/scraper/agent_test.go
+++ b/internal/scraper/agent_test.go
@@ -402,9 +402,9 @@ func TestVerifyCodeBlocks_MultipleBlocksAllChecked(t *testing.T) {
 
 func TestContentTypeHint_VariesByType(t *testing.T) {
 	cases := map[string]string{
-		"text/html":               "raw HTML",
-		"text/markdown":           "Markdown",
-		"text/plain":              "plain text",
+		"text/html":                "raw HTML",
+		"text/markdown":            "Markdown",
+		"text/plain":               "plain text",
 		"application/octet-stream": "documentation content", // fallback
 	}
 	for ct, fragment := range cases {

--- a/justfile
+++ b/justfile
@@ -108,16 +108,20 @@ test: _check-tokenizers
 
 # Format all Go sources
 fmt:
-    mise exec -- go fmt ./...
+    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+        mise exec -- go fmt ./...
 
 # Run `go vet` over every package
 vet: _check-tokenizers
     CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
         mise exec -- go vet -tags ORT ./...
 
-# Sync go.mod / go.sum with the source
+# Sync go.mod / go.sum. `go mod tidy` has no -tags flag, so we pass it
+# via GOFLAGS to keep ORT-only imports (internal/embed/hugot.go) in graph.
 tidy:
-    mise exec -- go mod tidy
+    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    GOFLAGS="-tags=ORT" \
+        mise exec -- go mod tidy
 
 # Run the scraper, writing one artifact per lib to ./artifacts/ (pass lib=/org/project to refresh only that entry; pass version=X to pin to one expanded version)
 scrape lib="" version="": _check-tokenizers


### PR DESCRIPTION
## Summary

Fixes `just fmt` and `just tidy` so they work in environments where CGO needs to locate `libtokenizers.a`. Without these env vars, both targets fail on machines that rely on the pinned local `./lib/` or an overridden `DEADZONE_TOKENIZERS_LIB` path.

## Changes

- **`justfile`**: propagate `CGO_ENABLED=1` and `CGO_LDFLAGS` to `fmt` and `tidy`. `tidy` additionally sets `GOFLAGS=-tags=ORT` since `go mod tidy` has no `-tags` flag, ensuring ORT-only imports (`internal/embed/hugot.go`) stay in the module graph.
- **`README.md`**: clarify the two-step local bootstrap (`just bootstrap` then `just fetch-tokenizers`) and document why they're separate — air-gapped/CI runners with vendored `libtokenizers.a` can skip step 2 via `DEADZONE_TOKENIZERS_LIB`.
- **`internal/scraper/agent_test.go`**: realign map literal whitespace flagged by `gofmt`.
- **`cmd/deadzone/coverage_test.go`**: trim trailing blank line.

## Test plan

- [ ] `just fmt` succeeds on a fresh checkout
- [ ] `just tidy` produces no diff and keeps `hugot` in `go.sum`
- [ ] `just build` and `just test` still pass

<!-- emdash-issue-footer:start -->
Fixes #166
<!-- emdash-issue-footer:end -->