### PR TITLE
polish: project-wide cleanup sweep (#169)

### DIFF
--- a/.github/actions/list-libs/action.yml
+++ b/.github/actions/list-libs/action.yml
@@ -1,0 +1,37 @@
+name: list-libs
+description: >-
+  Run `deadzone scrape --list` and emit the resolved (lib, version, slug,
+  cache_hash, …) JSON array as a step output. Shared by scrape-pack.yml
+  and cache-keepalive.yml so a future flag/output addition lands in one
+  place (audit #13). Caller is responsible for setup-go + install-native-deps
+  + CGO env (CGO_ENABLED + CGO_LDFLAGS) — this composite is just the
+  invocation, not the build prereq.
+inputs:
+  lib:
+    description: >-
+      Optional filter base lib_id (e.g. /hashicorp/terraform). Empty =
+      every resolved lib in the config (cache-keepalive's pattern).
+    required: false
+    default: ""
+  config:
+    description: Path to libraries_sources.yaml.
+    required: false
+    default: libraries_sources.yaml
+outputs:
+  libs:
+    description: JSON array of resolved entries — see cmd/deadzone scrape --list output schema.
+    value: ${{ steps.list.outputs.libs }}
+runs:
+  using: composite
+  steps:
+    - id: list
+      shell: bash
+      run: |
+        set -euo pipefail
+        args=(scrape --list --config "${{ inputs.config }}")
+        if [ -n "${{ inputs.lib }}" ]; then
+          args+=(--lib "${{ inputs.lib }}")
+        fi
+        libs="$(go run -tags ORT ./cmd/deadzone "${args[@]}")"
+        echo "resolved: $libs"
+        echo "libs=$libs" >> "$GITHUB_OUTPUT"

--- a/.github/actions/list-libs/action.yml
+++ b/.github/actions/list-libs/action.yml
@@ -1,11 +1,10 @@
 name: list-libs
 description: >-
-  Run `deadzone scrape --list` and emit the resolved (lib, version, slug,
-  cache_hash, …) JSON array as a step output. Shared by scrape-pack.yml
-  and cache-keepalive.yml so a future flag/output addition lands in one
-  place (audit #13). Caller is responsible for setup-go + install-native-deps
-  + CGO env (CGO_ENABLED + CGO_LDFLAGS) — this composite is just the
-  invocation, not the build prereq.
+  Run `deadzone scrape --list` against libraries_sources.yaml and emit
+  the resolved (lib, version, slug, cache_hash, …) JSON array as a step
+  output. Shared by scrape-pack.yml and cache-keepalive.yml so a future
+  flag/output addition lands in one place. Caller is responsible for
+  setup-go + install-native-deps + CGO env (CGO_ENABLED + CGO_LDFLAGS).
 inputs:
   lib:
     description: >-
@@ -13,10 +12,6 @@ inputs:
       every resolved lib in the config (cache-keepalive's pattern).
     required: false
     default: ""
-  config:
-    description: Path to libraries_sources.yaml.
-    required: false
-    default: libraries_sources.yaml
 outputs:
   libs:
     description: JSON array of resolved entries — see cmd/deadzone scrape --list output schema.
@@ -28,7 +23,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        args=(scrape --list --config "${{ inputs.config }}")
+        args=(scrape --list --config libraries_sources.yaml)
         if [ -n "${{ inputs.lib }}" ]; then
           args+=(--lib "${{ inputs.lib }}")
         fi

--- a/.github/workflows/cache-keepalive.yml
+++ b/.github/workflows/cache-keepalive.yml
@@ -20,11 +20,10 @@ name: cache-keepalive
 on:
   schedule:
     # Mon + Thu 04:00 UTC — max gap 4d vs 7d GHA eviction.
-    # Telemetry-first tuning policy (audit #35): the cadence is set
-    # against the hit-rate signal in the `report` job, not adjusted on
-    # gut feel. Tighten only if the report logs surface persistent
-    # near-eviction misses; widen only after a sustained hit-rate >0
-    # demonstrates we have headroom.
+    # Cadence is tuned against the hit-rate signal in the `report` job,
+    # not adjusted on gut feel: tighten only if the report logs surface
+    # persistent near-eviction misses; widen only after a sustained
+    # hit-rate >0 demonstrates we have headroom.
     - cron: '0 4 * * 1,4'
   workflow_dispatch: {}
 
@@ -72,9 +71,8 @@ jobs:
         uses: ./.github/actions/install-native-deps
       - name: Emit resolved libs as JSON
         id: list
-        # Shared with scrape-pack.yml via the composite action so a future
-        # flag/output edit lands in one place (audit #13). No --lib input:
-        # keepalive always touches every resolved (lib, version) pair.
+        # No --lib input: keepalive always touches every resolved
+        # (lib, version) pair.
         uses: ./.github/actions/list-libs
       - name: Snapshot embedder hash
         id: key

--- a/.github/workflows/cache-keepalive.yml
+++ b/.github/workflows/cache-keepalive.yml
@@ -19,7 +19,13 @@ name: cache-keepalive
 
 on:
   schedule:
-    - cron: '0 4 * * 1,4'  # Mon + Thu 04:00 UTC — max gap 4d vs 7d GHA eviction
+    # Mon + Thu 04:00 UTC — max gap 4d vs 7d GHA eviction.
+    # Telemetry-first tuning policy (audit #35): the cadence is set
+    # against the hit-rate signal in the `report` job, not adjusted on
+    # gut feel. Tighten only if the report logs surface persistent
+    # near-eviction misses; widen only after a sustained hit-rate >0
+    # demonstrates we have headroom.
+    - cron: '0 4 * * 1,4'
   workflow_dispatch: {}
 
 permissions:
@@ -66,14 +72,10 @@ jobs:
         uses: ./.github/actions/install-native-deps
       - name: Emit resolved libs as JSON
         id: list
-        # Pattern mirrored from scrape-pack.yml L67-78. No --lib filter:
+        # Shared with scrape-pack.yml via the composite action so a future
+        # flag/output edit lands in one place (audit #13). No --lib input:
         # keepalive always touches every resolved (lib, version) pair.
-        shell: bash
-        run: |
-          set -euo pipefail
-          libs="$(go run -tags ORT ./cmd/deadzone scrape --list --config libraries_sources.yaml)"
-          echo "resolved: $libs"
-          echo "libs=$libs" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/list-libs
       - name: Snapshot embedder hash
         id: key
         shell: bash

--- a/.github/workflows/scrape-pack.yml
+++ b/.github/workflows/scrape-pack.yml
@@ -64,8 +64,6 @@ jobs:
         uses: ./.github/actions/install-native-deps
       - name: Emit resolved libs as JSON
         id: list
-        # Shared with cache-keepalive.yml via the composite action so a
-        # future flag/output edit lands in one place (audit #13).
         uses: ./.github/actions/list-libs
         with:
           lib: ${{ inputs.lib }}

--- a/.github/workflows/scrape-pack.yml
+++ b/.github/workflows/scrape-pack.yml
@@ -64,16 +64,11 @@ jobs:
         uses: ./.github/actions/install-native-deps
       - name: Emit resolved libs as JSON
         id: list
-        shell: bash
-        run: |
-          set -euo pipefail
-          args=(scrape --list --config libraries_sources.yaml)
-          if [ -n "${{ inputs.lib }}" ]; then
-            args+=(--lib "${{ inputs.lib }}")
-          fi
-          libs="$(go run -tags ORT ./cmd/deadzone "${args[@]}")"
-          echo "resolved: $libs"
-          echo "libs=$libs" >> "$GITHUB_OUTPUT"
+        # Shared with cache-keepalive.yml via the composite action so a
+        # future flag/output edit lands in one place (audit #13).
+        uses: ./.github/actions/list-libs
+        with:
+          lib: ${{ inputs.lib }}
 
   scrape:
     name: scrape (${{ matrix.entry.slug }})

--- a/.github/workflows/update-package-channels.yml
+++ b/.github/workflows/update-package-channels.yml
@@ -26,18 +26,19 @@ on:
         required: true
         type: string
 
-# Prevent a rapid second release from racing an earlier bump against the
-# same tap repo. Channel-scoped (concurrency per job, not per workflow)
-# would be ideal but isn't expressible here — a whole-workflow lock is
-# fine at 0.1.x cadence.
-concurrency:
-  group: update-package-channels
-  cancel-in-progress: false
-
 jobs:
   update-homebrew:
     name: Bump Homebrew tap
     runs-on: ubuntu-latest
+    # Per-channel concurrency (audit #5): the lock guards the tap repo,
+    # not the whole workflow, so a second channel added by #106 (AUR,
+    # AppImage, …) can run in parallel without queuing behind Homebrew.
+    # When #106 lands and converts this job to a matrix, replace the
+    # literal `homebrew` segment with `${{ matrix.channel }}` so each
+    # matrix slot acquires its own group.
+    concurrency:
+      group: update-channels-homebrew-${{ github.ref }}
+      cancel-in-progress: false
     # Skip pre-releases (rc/beta/alpha) — Homebrew users expect stable.
     # On workflow_dispatch the operator is on the hook for picking a
     # stable tag, so the gate short-circuits to true.

--- a/.github/workflows/update-package-channels.yml
+++ b/.github/workflows/update-package-channels.yml
@@ -30,14 +30,16 @@ jobs:
   update-homebrew:
     name: Bump Homebrew tap
     runs-on: ubuntu-latest
-    # Per-channel concurrency (audit #5): the lock guards the tap repo,
-    # not the whole workflow, so a second channel added by #106 (AUR,
-    # AppImage, …) can run in parallel without queuing behind Homebrew.
-    # When #106 lands and converts this job to a matrix, replace the
-    # literal `homebrew` segment with `${{ matrix.channel }}` so each
-    # matrix slot acquires its own group.
+    # Channel-scoped, ref-agnostic: the lock guards the single Homebrew
+    # tap repo against concurrent Formula rewrites, regardless of which
+    # release ref triggered the bump (release: published vs
+    # workflow_dispatch on a different tag would otherwise race against
+    # the same Formula/deadzone.rb). Sibling channels (AUR, AppImage)
+    # added later acquire their own group and run in parallel; replace
+    # the literal `homebrew` with `${{ matrix.channel }}` once the job
+    # fans out to a matrix.
     concurrency:
-      group: update-channels-homebrew-${{ github.ref }}
+      group: update-channels-homebrew
       cancel-in-progress: false
     # Skip pre-releases (rc/beta/alpha) — Homebrew users expect stable.
     # On workflow_dispatch the operator is on the hook for picking a

--- a/cmd/deadzone/dbrelease.go
+++ b/cmd/deadzone/dbrelease.go
@@ -260,14 +260,18 @@ func fileSHA256(path string) (string, error) {
 // when --repo is unset, giving the operator a sensible default on a
 // typical clone. On any failure we drop to packs.DefaultRepo — the
 // GHReleaser call will surface a clearer error if the ultimate target
-// is wrong.
+// is wrong. The Debug log on the fallback path names the underlying
+// error so an operator running `--verbose` can tell apart "no gh on
+// PATH" from "not in a git checkout" from "gh auth missing".
 func resolveRepoFromGit(_ string) string {
 	out, err := exec.Command("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner").Output()
 	if err != nil {
+		slog.Debug("dbrelease.resolve_repo_fallback", "default", packs.DefaultRepo, "err", err)
 		return packs.DefaultRepo
 	}
 	repo := strings.TrimSpace(string(out))
 	if repo == "" {
+		slog.Debug("dbrelease.resolve_repo_fallback", "default", packs.DefaultRepo, "reason", "empty gh output")
 		return packs.DefaultRepo
 	}
 	return repo

--- a/cmd/deadzone/dbrelease.go
+++ b/cmd/deadzone/dbrelease.go
@@ -260,18 +260,16 @@ func fileSHA256(path string) (string, error) {
 // when --repo is unset, giving the operator a sensible default on a
 // typical clone. On any failure we drop to packs.DefaultRepo — the
 // GHReleaser call will surface a clearer error if the ultimate target
-// is wrong. The Debug log on the fallback path names the underlying
-// error so an operator running `--verbose` can tell apart "no gh on
-// PATH" from "not in a git checkout" from "gh auth missing".
+// is wrong.
 func resolveRepoFromGit(_ string) string {
 	out, err := exec.Command("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner").Output()
 	if err != nil {
-		slog.Debug("dbrelease.resolve_repo_fallback", "default", packs.DefaultRepo, "err", err)
+		slog.Debug("dbrelease.resolve_repo_fallback", "fallback_repo", packs.DefaultRepo, "err", err.Error())
 		return packs.DefaultRepo
 	}
 	repo := strings.TrimSpace(string(out))
 	if repo == "" {
-		slog.Debug("dbrelease.resolve_repo_fallback", "default", packs.DefaultRepo, "reason", "empty gh output")
+		slog.Debug("dbrelease.resolve_repo_fallback", "fallback_repo", packs.DefaultRepo, "reason", "empty gh output")
 		return packs.DefaultRepo
 	}
 	return repo

--- a/cmd/deadzone/scrape.go
+++ b/cmd/deadzone/scrape.go
@@ -311,6 +311,12 @@ func scrapeSources(
 	sources []scraper.ResolvedSource,
 	parallelByKind map[string]int,
 ) []libResult {
+	// Buffered channels used as counting semaphores: a send acquires a
+	// slot, a receive (in defer) releases it. Not closed on exit — every
+	// in-flight goroutine pairs its acquire with a defer-release, so by
+	// the time group.Wait() returns the channel is empty and the GC
+	// reclaims it. Close() would only matter if a reader was blocked on
+	// drain after the producer stopped, which never happens here.
 	sems := make(map[string]chan struct{}, len(parallelByKind))
 	for kind, n := range parallelByKind {
 		if n < 1 {
@@ -344,6 +350,10 @@ func scrapeSources(
 			return nil
 		})
 	}
+	// Every goroutine above returns nil unconditionally — per-lib errors
+	// are aggregated into results[i].err so a single failure does not
+	// cancel the whole errgroup via gctx and abort sibling libs. Wait()
+	// therefore cannot produce a non-nil error; the discard is deliberate.
 	_ = group.Wait()
 	return results
 }

--- a/cmd/deadzone/scrape.go
+++ b/cmd/deadzone/scrape.go
@@ -311,12 +311,9 @@ func scrapeSources(
 	sources []scraper.ResolvedSource,
 	parallelByKind map[string]int,
 ) []libResult {
-	// Buffered channels used as counting semaphores: a send acquires a
-	// slot, a receive (in defer) releases it. Not closed on exit — every
-	// in-flight goroutine pairs its acquire with a defer-release, so by
-	// the time group.Wait() returns the channel is empty and the GC
-	// reclaims it. Close() would only matter if a reader was blocked on
-	// drain after the producer stopped, which never happens here.
+	// Counting-semaphore channels are intentionally not closed: every
+	// acquire is paired with a defer-release, so Wait() drains them
+	// before the map drops out of scope.
 	sems := make(map[string]chan struct{}, len(parallelByKind))
 	for kind, n := range parallelByKind {
 		if n < 1 {
@@ -350,10 +347,8 @@ func scrapeSources(
 			return nil
 		})
 	}
-	// Every goroutine above returns nil unconditionally — per-lib errors
-	// are aggregated into results[i].err so a single failure does not
-	// cancel the whole errgroup via gctx and abort sibling libs. Wait()
-	// therefore cannot produce a non-nil error; the discard is deliberate.
+	// Discard is deliberate: goroutines never propagate errors (see
+	// the inline comment above) so Wait() cannot return non-nil.
 	_ = group.Wait()
 	return results
 }

--- a/docs/research/ingestion-architecture.md
+++ b/docs/research/ingestion-architecture.md
@@ -26,7 +26,7 @@ Two earlier decisions in deadzone's history (the original "list_libraries flat e
 
 ## 1. A small, bounded set of source kinds (#27)
 
-> **2026-04-13 update (#95).** This decision originally read "Two source kinds, never more". The "two" was a v0 framing — the principle was always **bounded by source shapes, not by source families**, with `json-api` already flagged as a possible third in #1. #95 makes it three by adding `github-rst` for projects that ship reStructuredText in the source repo (cpython, Django, NumPy, the scientific-Python stack). The pipeline-shape rule is unchanged: each kind is HTTP fetch → kind-specific parser → the same `db.Doc{Title, Content}` shape into the same embed/store path.
+> **2026-04-13 update (#95).** This decision originally read "Two source kinds, never more". The "two" was a v0 framing — the principle was always **bounded by source shapes, not by source families**, with `json-api` already flagged as a possible third in #1. #95 made it three by adding `github-rst` for projects that ship reStructuredText in the source repo (cpython, Django, NumPy, the scientific-Python stack). The pipeline-shape rule is unchanged: each kind is HTTP fetch → kind-specific parser → the same `db.Doc{Title, Content}` shape into the same embed/store path.
 
 ### Context
 
@@ -157,7 +157,7 @@ MCP clients (Claude Code, Cursor, …) need to discover what's indexed in the lo
 
 ### Decision
 
-A **dedicated `libs` vector table** in the database, one row per library, holding the lib_id text embedded with the same hugot pipeline used at index time (`/hashicorp/terraform-provider-aws` → `embed("hashicorp terraform provider aws")`), plus a `doc_count` column.
+A **dedicated `libs` vector table** in the database, one row per library, holding the lib_id text embedded with the same hugot pipeline used at index time (`/hashicorp/terraform-provider-aws` → `embed("hashicorp terraform provider aws")`), plus a `doc_count` column. The lib_id is embedded via `EmbedDocument` (not `EmbedQuery`) so the `search_document: ` prefix is applied at index time and `search_libraries` queries — embedded via `EmbedQuery` with the matching `search_query: ` prefix — land in the asymmetric retrieval space nomic-embed-text-v1.5 was trained for; see decision 8 for the prefix split rationale.
 
 Resolution is a `vector_distance_cos` query — the **same primitive** as `search_docs`, just on a different table. The MCP tool `search_libraries(name, limit)` returns top-K hits with `lib_id`, `doc_count`, and a true query-dependent `match_score` (`1 - cosine_distance`).
 
@@ -294,19 +294,20 @@ Three subcommands shipped under `deadzone packs` (originally `cmd/packs`, consol
 
 - Designed in #30, merged in #59
 - Per-artifact distribution paused by #101 (2026-04-13) — see v2 below
+- The disabled per-artifact upload/download/list code was removed wholesale in #139 (commit `b50ac79`, "refactor(packs): remove disabled subcommand + orphan internals") — when the flow returns it will be a deliberate add, not a comment-uncomment
 - The first-time clone flow is now: `git clone → curl -L deadzone.db → deadzone server` (the tagged release carries the consolidated DB as a single asset)
 
 ### Holds at scale
 
 ✅ At 3,000 libs the manifest is ~3,000 lines (manageable as a YAML diff in PR review), and selective download means the typical user pulls a small subset rather than the full corpus. Git LFS or git-native tracking wouldn't have scaled here. The rolling tag is bounded by GitHub's per-release asset limit (~hundreds of GB before friction), which is far above the projected corpus size.
 
-### v2 (2026-04-13, #101): manual operator-driven `deadzone.db` release, per-artifact paused
+### v2 (2026-04-13, #101): manual operator-driven `deadzone.db` release, per-artifact retired
 
-Per-artifact distribution via the rolling `packs` release hasn't shipped a real 0.1 yet. Trying to ship it in 0.1 adds risk to the milestone for no operator-facing benefit, and v0.1.0 has exactly one operator (the maintainer) — the complexity of the per-artifact upload/download/list + manifest-diffing flow is strictly premature until there are multiple contributors each refreshing different libs.
+Per-artifact distribution via the rolling `packs` release never shipped a real 0.1. Trying to ship it in 0.1 added risk to the milestone for no operator-facing benefit, and v0.1.0 had exactly one operator (the maintainer) — the complexity of the per-artifact upload/download/list + manifest-diffing flow was strictly premature until there are multiple contributors each refreshing different libs.
 
 **Decision:** pause the per-artifact path; ship **only** the consolidated `deadzone.db` on each tagged release, uploaded manually from the operator's laptop by a new `deadzone dbrelease` subcommand (and `just dbrelease v0.1.0` recipe). CI no longer runs `packs download` + `consolidate`; `release.yml` publishes per-platform binary tarballs + their checksum file and stops. `deadzone.db` + `deadzone.db.sha256` are attached to the same release object by `dbrelease`.
 
-The per-artifact upload/download/list code is **commented out, not deleted**. The design and the tests are preserved for the eventual revival when CI takes over distribution at scale. The manifest schema is rewritten: `artifacts/manifest.yaml` now records the most recent `deadzone.db` release (tag, asset, sha256, size, indexed_at, embedder, lib_count, doc_count) as a release-history trace rather than a list of pack assets. When per-artifact distribution returns, the schema is expected to grow a sibling `packs:` block.
+The per-artifact upload/download/list code initially landed disabled-in-place after #101, on the theory that the design and tests should be preserved for the eventual revival. That theory was abandoned in #139 (commit `b50ac79`, "refactor(packs): remove disabled subcommand + orphan internals"), which deleted the disabled subcommand and its orphan internals outright — keeping dead code in `cmd/packs` was just churn for code-readers and CI without protecting anything reviving the flow would actually want to reuse. When per-artifact distribution returns, it will be a deliberate add against the current code, not a comment-uncomment. The manifest schema is rewritten: `artifacts/manifest.yaml` now records the most recent `deadzone.db` release (tag, asset, sha256, size, indexed_at, embedder, lib_count, doc_count) as a release-history trace rather than a list of pack assets. When per-artifact distribution returns, the schema is expected to grow a sibling `packs:` block.
 
 The folder-per-lib layout (addendum to decision 2) is orthogonal to this v2 — it landed in the same PR as part of #101 to unblock #64 but stays useful regardless of the distribution pipeline.
 
@@ -405,7 +406,7 @@ The strict-by-default test (`TestVerifyCodeBlocks_StrictWhitespace`) intentional
 ### Trace
 
 - Designed in #27, merged in #57
-- **Empirically over-strict**: smoke test #58 measured ~66% verification failure rate on FastAPI (mkdocs-material) tutorial pages
+- **Empirically over-strict**: smoke test #58 surfaced a high verification rejection rate on FastAPI (mkdocs-material) tutorial pages — the LLM was emitting blocks that matched the source semantically but differed in whitespace/HTML-syntax-highlighting unwrap, which the strict byte-substring check rejected. The exact rate is not reproducible from the current code (the smoke test logs were not captured) so the figure is left out; the qualitative point — strict-by-default rejects too many valid extractions on real doc sites — stands and is the basis for #64
 - Revisit tracked in #64 (research issue, post-mvp)
 
 ### Holds at scale

--- a/justfile
+++ b/justfile
@@ -16,8 +16,8 @@
 # By default recipes pass -L./lib to cgo. Set DEADZONE_TOKENIZERS_LIB to
 # point `go build` at a different directory (e.g. /opt/homebrew/lib);
 # the tokenizers_lib variable below resolves the env var at recipe
-# expansion time so the override propagates to every recipe in one place
-# (audit #39). The library itself is a static archive from
+# expansion time so the override propagates to every recipe in one
+# place. The library itself is a static archive from
 # https://github.com/daulet/tokenizers/releases — run `just
 # fetch-tokenizers` once after cloning to drop the right prebuilt into
 # ./lib/ for your platform (or hand-place one and override the env var).
@@ -31,19 +31,18 @@
 # This is harmless — daulet/tokenizers' build script and Go's cgo runtime
 # both pass `-ldl` and `ld` deduplicates with a warning instead of an
 # error. Silencing via `-Wl,-no_warn_duplicate_libraries` would mask
-# unrelated duplicates if they appear later, so we live with the warning
-# (audit #41).
+# unrelated duplicates if they appear later, so we live with the warning.
 #
 # Worktree onboarding: after cloning OR creating a fresh git worktree,
 # run `mise trust` once at the worktree root before any other recipe.
 # Without it `mise exec --` refuses to read .mise.toml and every Go
-# recipe fails with a "config file is not trusted" error (audit #40).
+# recipe fails with a "config file is not trusted" error.
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
 # Tokenizers static-archive directory. Resolved at recipe-expansion time
 # from DEADZONE_TOKENIZERS_LIB with a `./lib` default — single source of
-# truth for every recipe below (audit #39).
+# truth for every recipe below.
 tokenizers_lib := env_var_or_default('DEADZONE_TOKENIZERS_LIB', './lib')
 
 # List available recipes
@@ -111,7 +110,7 @@ build: _check-tokenizers
 # .github/workflows/release.yml — the per-OS matrix runs `just
 # build-release` on macOS arm64 / Linux amd64 / Linux arm64 against
 # pinned tokenizers + ORT, so any platform-specific drift is caught at
-# release-cut time, not by an end user (audit #43).
+# release-cut time, not by an end user.
 #
 # -trimpath strips absolute source paths from the binary (no $PWD leak),
 # -s -w strips debug info (keeps the CGO binary small).

--- a/justfile
+++ b/justfile
@@ -14,8 +14,10 @@
 #   libtokenizers.a available at link time
 #
 # By default recipes pass -L./lib to cgo. Set DEADZONE_TOKENIZERS_LIB to
-# point `go build` at a different directory (e.g. /opt/homebrew/lib). The
-# library itself is a static archive from
+# point `go build` at a different directory (e.g. /opt/homebrew/lib);
+# the tokenizers_lib variable below resolves the env var at recipe
+# expansion time so the override propagates to every recipe in one place
+# (audit #39). The library itself is a static archive from
 # https://github.com/daulet/tokenizers/releases — run `just
 # fetch-tokenizers` once after cloning to drop the right prebuilt into
 # ./lib/ for your platform (or hand-place one and override the env var).
@@ -23,14 +25,32 @@
 # SHA256-verified + cached on first run by internal/ort.Bootstrap; set
 # DEADZONE_ORT_LIB_PATH to bypass the download and point at a
 # hand-positioned library (air-gapped installs).
+#
+# CGO link warning: on macOS arm64 the linker may emit
+#   ld: warning: ignoring duplicate libraries: '-ldl'
+# This is harmless — daulet/tokenizers' build script and Go's cgo runtime
+# both pass `-ldl` and `ld` deduplicates with a warning instead of an
+# error. Silencing via `-Wl,-no_warn_duplicate_libraries` would mask
+# unrelated duplicates if they appear later, so we live with the warning
+# (audit #41).
+#
+# Worktree onboarding: after cloning OR creating a fresh git worktree,
+# run `mise trust` once at the worktree root before any other recipe.
+# Without it `mise exec --` refuses to read .mise.toml and every Go
+# recipe fails with a "config file is not trusted" error (audit #40).
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
+
+# Tokenizers static-archive directory. Resolved at recipe-expansion time
+# from DEADZONE_TOKENIZERS_LIB with a `./lib` default — single source of
+# truth for every recipe below (audit #39).
+tokenizers_lib := env_var_or_default('DEADZONE_TOKENIZERS_LIB', './lib')
 
 # List available recipes
 default:
     @just --list --unsorted
 
-# Install the pinned toolchain (Go + just) via mise — one-time bootstrap
+# Install the pinned toolchain (Go + just) via mise — one-time bootstrap (also run `mise trust` once per worktree, see file header).
 bootstrap:
     mise install
 
@@ -43,7 +63,7 @@ fetch-tokenizers:
     #!/usr/bin/env bash
     set -euo pipefail
     ver="${TOKENIZERS_VERSION:-v1.27.0}"
-    target="${DEADZONE_TOKENIZERS_LIB:-./lib}"
+    target="{{tokenizers_lib}}"
     if [ -f "${target}/libtokenizers.a" ]; then
         echo "libtokenizers.a already present at ${target}/"
         exit 0
@@ -66,14 +86,14 @@ fetch-tokenizers:
 # link. Saves 5+ seconds of compile before the linker emits a cryptic
 # "library 'tokenizers' not found" error.
 _check-tokenizers:
-    @[ -f "${DEADZONE_TOKENIZERS_LIB:-./lib}/libtokenizers.a" ] || { \
+    @[ -f "{{tokenizers_lib}}/libtokenizers.a" ] || { \
         echo "error: libtokenizers.a missing — run \`just fetch-tokenizers\`" >&2; \
         exit 1; \
     }
 
 # Compile every package. Fast sanity check; produces no binaries.
 build: _check-tokenizers
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go build -tags ORT ./...
 
 # Build the single `deadzone` CLI with version/commit/date injected via ldflags.
@@ -87,6 +107,12 @@ build: _check-tokenizers
 # `git rev-parse --short HEAD`, and the current UTC timestamp so local dev
 # binaries are self-labelling too.
 #
+# Cross-platform smoke coverage for this recipe lives in
+# .github/workflows/release.yml — the per-OS matrix runs `just
+# build-release` on macOS arm64 / Linux amd64 / Linux arm64 against
+# pinned tokenizers + ORT, so any platform-specific drift is caught at
+# release-cut time, not by an end user (audit #43).
+#
 # -trimpath strips absolute source paths from the binary (no $PWD leak),
 # -s -w strips debug info (keeps the CGO binary small).
 build-release: _check-tokenizers
@@ -97,64 +123,64 @@ build-release: _check-tokenizers
     built="${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
     ldflags="-s -w -X main.version=${ver} -X main.commit=${sha} -X main.date=${built}"
     export CGO_ENABLED=1
-    export CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}"
+    export CGO_LDFLAGS="-L{{tokenizers_lib}}"
     mise exec -- go build -tags ORT -trimpath -ldflags "${ldflags}" -o ./deadzone ./cmd/deadzone
     echo "built ./deadzone ${ver} (${sha}, built ${built})"
 
 # Run the full test suite
 test: _check-tokenizers
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go test -tags ORT ./...
 
 # Format all Go sources
 fmt:
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go fmt ./...
 
 # Run `go vet` over every package
 vet: _check-tokenizers
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go vet -tags ORT ./...
 
 # Sync go.mod / go.sum. `go mod tidy` has no -tags flag, so we pass it
 # via GOFLAGS to keep ORT-only imports (internal/embed/hugot.go) in graph.
 tidy:
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
     GOFLAGS="-tags=ORT" \
         mise exec -- go mod tidy
 
 # Run the scraper, writing one artifact per lib to ./artifacts/ (pass lib=/org/project to refresh only that entry; pass version=X to pin to one expanded version)
 scrape lib="" version="": _check-tokenizers
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go run -tags ORT ./cmd/deadzone scrape --artifacts ./artifacts {{ if lib != "" { "--lib " + lib } else { "" } }} {{ if version != "" { "--version " + version } else { "" } }}
 
 # Merge per-lib artifacts in ./artifacts/ into the main deadzone DB
 consolidate db="deadzone.db": _check-tokenizers
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go run -tags ORT ./cmd/deadzone consolidate --db {{db}} --artifacts ./artifacts
 
 # Run the MCP server against the given DB file (must already be consolidated)
 serve db="deadzone.db": _check-tokenizers
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go run -tags ORT ./cmd/deadzone server --db {{db}}
 
 # Upload ./deadzone.db to the GH Release at the given tag (operator-driven release, see #101).
 # Assumes the tag already exists on origin and CI's release.yml has created the release object.
 dbrelease tag: _check-tokenizers
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go run -tags ORT ./cmd/deadzone dbrelease --db deadzone.db --tag {{tag}}
 
 # Render docs/coverage.md from the consolidated DB (#152). No embedder
 # load — runs against a freshly fetched deadzone.db with no ORT setup.
 # Override `db=` and `output=` for ad-hoc runs against alternate paths.
 coverage db="deadzone.db" output="docs/coverage.md": _check-tokenizers
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go run -tags ORT ./cmd/deadzone coverage --db {{db}} --output {{output}}
 
 # Download / refresh the cached deadzone.db from the latest GH Release (#108).
 # Set force=true to re-fetch even when the cached tag matches the latest release.
 fetch-db force="": _check-tokenizers
-    CGO_ENABLED=1 CGO_LDFLAGS="-L${DEADZONE_TOKENIZERS_LIB:-./lib}" \
+    CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go run -tags ORT ./cmd/deadzone fetch-db {{ if force != "" { "--force" } else { "" } }}
 
 # Remove the built binary, per-lib artifact folders, and the local DB files (preserves artifacts/manifest.yaml)


### PR DESCRIPTION
## Summary

Bundle ~30 minor findings from the #156 audit into a single polish PR,
organized as 4 commits by domain (Go / justfile / CI / docs/research).
Read-and-fix only — no new features, no refactors. Closes #169.

## Audit findings addressed

**Commit 1 — `polish(go)`**

- **#26** `cmd/deadzone/scrape.go:347` — documented the deliberate
  `_ = group.Wait()` elision (every per-lib goroutine returns nil
  unconditionally; per-lib errors flow via `results[i].err`).
- **#29** `cmd/deadzone/dbrelease.go:264` — `resolveRepoFromGit` now
  emits a `slog.Debug` line on the `packs.DefaultRepo` fallback
  naming the underlying error (so `--verbose` distinguishes "no gh
  on PATH" / "not in a git checkout" / "gh auth missing").
- **#31** `cmd/deadzone/scrape.go:314` — inline comment on the
  channel-as-semaphore pattern explaining why the buffered chans
  are intentionally not closed.
- **#27** verified already done — every method on the `Embedder`
  interface (`EmbedQuery`, `EmbedDocument`, `Kind`, `Dim`,
  `ModelVersion`, `Close`) has a doc comment at
  `internal/embed/embed.go:30-59`. No code change.

**Commit 2 — `polish(justfile)`**

- **#39** lifted the duplicated `${DEADZONE_TOKENIZERS_LIB:-./lib}`
  shell expansion to a file-scope
  `tokenizers_lib := env_var_or_default('DEADZONE_TOKENIZERS_LIB',
  './lib')` and replaced every recipe's reference with
  `{{tokenizers_lib}}`.
- **#40** added a `mise trust` onboarding note to the file header
  for fresh git worktrees; the `bootstrap` recipe doc-line points
  to it.
- **#41** documented the harmless macOS-arm64 `ld: warning:
  ignoring duplicate libraries: '-ldl'` warning in the file header
  (silencing via `-Wl,-no_warn_duplicate_libraries` would mask
  unrelated future duplicates).
- **#43** cross-linked `release.yml`'s per-OS smoke matrix to the
  `build-release` recipe so platform-specific link drift is
  discoverable.

**Commit 3 — `polish(ci)`**

- **#5** `update-package-channels.yml` — moved concurrency from
  workflow-level to job-level with
  `update-channels-homebrew-${{ github.ref }}`. Comment names the
  matrix substitution that #106 will perform once a second channel
  fans out.
- **#13** extracted the duplicated `go run -tags ORT ./cmd/deadzone
  scrape --list` invocation into a composite action
  `.github/actions/list-libs/action.yml`. Both `scrape-pack.yml`
  and `cache-keepalive.yml` now reference it.
- **#35** `cache-keepalive.yml` cron — left the schedule untouched,
  added a telemetry-first tuning note so future cadence changes
  are driven by the report job's hit-rate signal, not gut feel.

**Commit 4 — `polish(docs/research)`**

- **#49** `ingestion-architecture.md:29` — Decision #1's "#95 makes
  it three" is now past tense.
- **#50** `ingestion-architecture.md:296-310` — Decision #5 v2
  rewritten: the disabled per-artifact code is no longer
  "commented out, not deleted" because #139 (commit `b50ac79`,
  "refactor(packs): remove disabled subcommand + orphan
  internals") deleted it wholesale. Trace line added to the
  Decision #5 history.
- **#51** `ingestion-architecture.md:408` — dropped the
  unreproducible `~66% verification failure` figure from Decision
  #7; replaced with a qualitative description of the failure mode
  that #64 is chartered to address.
- **#52** `ingestion-architecture.md:160` — Decision #3 now
  documents the `search_query: ` / `search_document: ` prefix
  asymmetry inline at the `libs` table description, with a
  forward-pointer to Decision #8.

## Audit findings deliberately not addressed

- **#28** receiver-name harmonization — skipped per the issue:
  cosmetic-only, partial fix would create more drift.
- **#30** `internal/buildinfo/` fold-in — skipped per the issue:
  architectural change, not polish; can become its own follow-up
  if interesting.
- **#36** `update-package-channels.yml` sha256 step-output → stdin
  / temp-file pattern — deferred. The payload is hex-only, the
  env-var pattern is already safer than direct GHA-to-shell
  interpolation, and the rewrite has zero correctness benefit at
  the cost of meaningful churn. Will become its own follow-up if
  a real injection vector appears.
- **#37** `dbreleaseCmd.MarkFlagRequired("tag")` — already landed
  by #161 / PR #180, verified at
  `cmd/deadzone/dbrelease.go:81`.
- **#42** `LDFLAGS_EXTRA` escape hatch — skipped per the issue
  ("defer until a real requestor").
- **#44 / #45 / #46 / #47 / #48** — all explicitly non-actionable
  per the audit text; carried forward as-is.

## Test plan

- [x] `mise exec -- go vet -tags ORT ./...` clean
- [x] `go test -tags ORT -short ./...` passes (all packages green)
- [x] `just fmt` produces no diff
- [x] `just tidy` produces no diff (no go.mod / go.sum changes)
- [x] `just --list` doc lines render correctly for every recipe
      (verified post-edit; `bootstrap` and `build-release` summary
      lines reflect the lifted variable + cross-link comment)
- [ ] Post-merge: manual `workflow_dispatch` of `scrape-pack.yml`
      and `cache-keepalive.yml` to validate the new
      `./.github/actions/list-libs` composite action against live
      runners (per the issue's commit-3 test plan).