### PR TITLE
docs: clarify lib_id vs docs source repo convention in YAML header

### DIFF
--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -50,6 +50,36 @@
 #             parse time — use `{"1.4": {...}, "1.5": {...}}` instead
 #             (see #117).
 #
+# lib_id vs docs source repo:
+#   `lib_id` is the canonical identifier — it matches `db.docs.lib_id`
+#   and is what users query through the MCP surface. It is NOT
+#   guaranteed to match the GitHub org/project that hosts the doc URLs.
+#
+#   When upstream splits code and docs into sibling repos (a common JS/
+#   TS pattern, but also seen on Rust + Go ORMs + DBs), the lib_id stays
+#   on the canonical "lib home" repo while the URLs target the docs
+#   sibling. Inspect the URL host to see which repo a scrape actually
+#   reads from.
+#
+#   Sidecar docs repos currently in use (10 of 48 entries):
+#     /uptrace/bun           → uptrace/bun-docs
+#     /honojs/hono           → honojs/website
+#     /expressjs/express     → expressjs/expressjs.com
+#     /nestjs/nest           → nestjs/docs.nestjs.com
+#     /vuejs/vue             → vuejs/docs
+#     /withastro/astro       → withastro/docs
+#     /tokio-rs/tokio        → tokio-rs/website
+#     /serde-rs/serde        → serde-rs/serde-rs.github.io
+#     /dragonflydb/dragonfly → dragonflydb/documentation
+#     /grafana/k6            → grafana/k6-docs
+#
+#   The remaining 38 entries are in-repo (lib_id's repo IS the docs
+#   source). The Grafana stack ships docs in-repo under `docs/sources/`
+#   monorepo-style; most other ecosystems split them out.
+#
+#   Patch is mechanical when needed: bump `ref:` to a new commit on the
+#   docs sibling, not on the lib repo.
+#
 # Version-pinning conventions in this file (#120):
 #   - `versions:` keys are the user-facing IDENTIFIER surfaced by the
 #     MCP surface (`search_libraries`, `search_docs`). They are always


### PR DESCRIPTION
## Summary

Header-only documentation change to `libraries_sources.yaml`. After PRs #184-#188 added 25 libs to the registry, 10 of the 48 entries now use a "sidecar docs repo" pattern where the URLs target a different GitHub org/project than the `lib_id` would suggest. The convention was implicit. This commit makes it explicit.

## What changes

A new section in the YAML header right above "Version-pinning conventions":

```
# lib_id vs docs source repo:
#   `lib_id` is the canonical identifier — it matches `db.docs.lib_id`
#   and is what users query through the MCP surface. It is NOT
#   guaranteed to match the GitHub org/project that hosts the doc URLs.
#   ...
#   Sidecar docs repos currently in use (10 of 48 entries):
#     /uptrace/bun           → uptrace/bun-docs
#     /honojs/hono           → honojs/website
#     ...
```

## Why

Without this note:
- New contributors adding a lib might assume `lib_id` must match the URL host.
- Someone debugging a scrape failure for `/uptrace/bun` has to grep URLs to discover the actual repo to investigate is `uptrace/bun-docs`.
- Tooling that wants to know "where do these docs live" has to parse URLs.

With this note: zero ambiguity, and the 10 current sidecar mappings are listed for quick lookup. The list will need maintenance as the registry grows, but at <50 libs this is cheap.

## What this is NOT

This is **not** a schema change. There is no new `docs_repo:` field. URLs continue to be the source of truth for "which repo gets scraped". The full structural fix (placeholder substitution like `{ref}`) was discussed but deemed premature — most upside hits at 200+ libs scale. See follow-up issue #TBD if/when that bar is hit.

## Out of scope

- Adding a `docs_repo:` field to the YAML schema
- Modifying `internal/scraper/config.go` `Resolve` to support `{docs_repo}` placeholder
- Updating the 10 sidecar entries to use the new placeholder

All deferred until corpus growth justifies the schema work.

## Test plan

- [x] YAML still parses — `python3 yaml.safe_load` → 48 libs (unchanged)
- [x] Comment-only diff (`git diff --stat`: +30 lines, 0 deletions on YAML data)
- [ ] CI green