### PR TITLE
fix: drop 3 dead URLs from /grafana/grafana that 404 at pinned ref

### DIFF
--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -1871,12 +1871,13 @@ libraries:
       - https://raw.githubusercontent.com/grafana/grafana/{ref}/docs/sources/introduction/grafana-cloud.md
       - https://raw.githubusercontent.com/grafana/grafana/{ref}/docs/sources/introduction/grafana-enterprise.md
       - https://raw.githubusercontent.com/grafana/grafana/{ref}/docs/sources/fundamentals/_index.md
-      - https://raw.githubusercontent.com/grafana/grafana/{ref}/docs/sources/dashboards/_index.md
       - https://raw.githubusercontent.com/grafana/grafana/{ref}/docs/sources/datasources/_index.md
       - https://raw.githubusercontent.com/grafana/grafana/{ref}/docs/sources/datasources/troubleshooting.md
-      - https://raw.githubusercontent.com/grafana/grafana/{ref}/docs/sources/explore/_index.md
-      - https://raw.githubusercontent.com/grafana/grafana/{ref}/docs/sources/panels-visualizations/_index.md
       - https://raw.githubusercontent.com/grafana/grafana/{ref}/docs/sources/alerting/_index.md
+      # NOTE: dashboards/_index.md, explore/_index.md, and
+      # panels-visualizations/_index.md don't exist as files at the
+      # top level — content is one level deeper. Skipped here; cover
+      # in a follow-up PR if dashboard/panel docs are user-requested.
 
   # grafana/loki — log aggregation system. docs/sources/ Hugo, in-repo.
   # Coverage: get-started + query (LogQL is the load-bearing query


### PR DESCRIPTION
## Summary

PR-5 (#188) added 3 URLs to `/grafana/grafana` that **don't exist as files** at the pinned commit `2a9d7c182`:

- `docs/sources/dashboards/_index.md`
- `docs/sources/explore/_index.md`
- `docs/sources/panels-visualizations/_index.md`

The strict verifier in deadzone is fail-fast, so these 404s caused scrape-pack run [25263180073](https://github.com/laradji/deadzone/actions/runs/25263180073) to mark `/grafana/grafana` as **failed** (lib ended with 0 docs in consolidated v0.4.0 deadzone.db). Other 47 libs all scraped successfully and the DB asset was attached normally — only `/grafana/grafana` is missing from the corpus right now.

## Root cause

During PR-5 investigation, `gh api repos/grafana/grafana/contents/docs/sources/dashboards` returned a JSON error object (not an array). The jq pipeline `.[]` surfaced that as `Cannot index string with string "type"`. I treated those errors as benign jq quirks and proceeded with the URL anyway, instead of recognizing them as 404 signals.

The smoke-test only sampled `introduction/_index.md` (which is real, returned 200) and missed the 3 dead URLs.

## Verification

```
$ for url in dashboards/_index.md explore/_index.md panels-visualizations/_index.md; do
    curl -I -s -o /dev/null -w "%{http_code}\n" "https://raw.githubusercontent.com/grafana/grafana/2a9d7c182.../docs/sources/$url"
  done
404
404
404
```

The dirs themselves (`docs/sources/dashboards/`, etc.) exist — but the content lives one level deeper, with no top-level `_index.md` landing page. Hugo doesn't require it for these subdirs.

All **8 remaining URLs** verified 200 at the pinned ref.

## What this PR does

- Removes the 3 dead URLs from `/grafana/grafana`
- Adds a NOTE comment in the YAML explaining why dashboards / explore / panels-visualizations don't have `_index.md` at the top, and pointing to the path forward (cover deeper subdirs in a follow-up PR if user-requested)

## Impact

Net change: `/grafana/grafana` goes from 11 URLs → 8 URLs. After this merges and `scrape-pack.yml` is re-run against `tag=v0.4.0`, `/grafana/grafana` will end up in the corpus with content (`_index` landing + introduction + fundamentals + datasources + alerting).

## Out of scope

- Covering the deeper subdirs (`docs/sources/dashboards/build-dashboards/...`, `docs/sources/explore/explore-features/...`, etc.) — these are 50-100 pages each and warrant a dedicated grafana-deep-dive PR if dashboard/panel queries become a user request.
- Re-running `scrape-pack.yml` against `v0.4.0` — that's the operator action after this merges, not part of this PR.

## Lessons (for the agent's memory)

- `gh api .../contents/PATH` returning a non-array means the path is either a single file, doesn't exist (404), or hit a rate-limit. Always check the JSON response shape before piping through `.[]`. Specifically `gh api ... 2>&1 | jq -e 'if type == "array" then . else error("not an array — likely 404") end'` would have caught this.
- Smoke-testing with `curl HEAD` should sample at least 2-3 URLs per lib (one per subdir if the lib has subdirs), not just one.

## Test plan

- [x] YAML parses (8 URLs in /grafana/grafana, total libs = 48)
- [x] All 8 remaining grafana/grafana URLs return 200 via `curl -I` at pinned ref
- [ ] CI pipeline green