### PR TITLE
feat: embed optional description: field alongside lib_id in search_libraries (#191)

### DIFF
--- a/cmd/deadzone/scrape.go
+++ b/cmd/deadzone/scrape.go
@@ -439,7 +439,7 @@ func scrapeLibToArtifact(
 	// filled in at the end of this function once we know the real
 	// number. Each ResolvedSource covers exactly one (lib_id, version)
 	// slot so a single upsert per source is the correct grain.
-	if upsertErr := db.UpsertLibIfNew(d, src.LibID, src.Version, e); upsertErr != nil {
+	if upsertErr := db.UpsertLibIfNew(d, src.LibID, src.Version, src.Description, e); upsertErr != nil {
 		return 0, 0, fmt.Errorf("upsert lib %q version %q: %w", src.LibID, src.Version, upsertErr)
 	}
 

--- a/cmd/deadzone/server_test.go
+++ b/cmd/deadzone/server_test.go
@@ -215,7 +215,7 @@ func TestHandleSearchLibraries(t *testing.T) {
 		{"/expressjs/express", 75},
 	}
 	for _, l := range libs {
-		if err := db.UpsertLibIfNew(d, l.id, "", testEmbedder); err != nil {
+		if err := db.UpsertLibIfNew(d, l.id, "", "", testEmbedder); err != nil {
 			t.Fatalf("UpsertLibIfNew %q: %v", l.id, err)
 		}
 		if err := db.UpdateLibCount(d, l.id, "", l.count); err != nil {

--- a/internal/db/consolidate_test.go
+++ b/internal/db/consolidate_test.go
@@ -32,7 +32,7 @@ func makeArtifact(t *testing.T, dir, libID, version string, docs []db.Doc) strin
 	if err != nil {
 		t.Fatalf("OpenArtifact %q version %q: %v", libID, version, err)
 	}
-	if err := db.UpsertLibIfNew(a, libID, version, testEmbedder); err != nil {
+	if err := db.UpsertLibIfNew(a, libID, version, "", testEmbedder); err != nil {
 		a.Close()
 		t.Fatalf("UpsertLibIfNew %q version %q: %v", libID, version, err)
 	}
@@ -364,7 +364,7 @@ func TestConsolidate_EmbedderMismatchLeavesMainUnchanged(t *testing.T) {
 	if err := db.Insert(main, seed, embedText(t, testEmbedder, seed)); err != nil {
 		t.Fatalf("Insert seed: %v", err)
 	}
-	if err := db.UpsertLibIfNew(main, "/seed/lib", "", testEmbedder); err != nil {
+	if err := db.UpsertLibIfNew(main, "/seed/lib", "", "", testEmbedder); err != nil {
 		t.Fatalf("UpsertLibIfNew seed: %v", err)
 	}
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -53,10 +53,19 @@ var ErrArtifactLibIDMismatch = errors.New("artifact lib_id mismatch")
 
 // CurrentSchemaVersion is the on-disk schema version written by this
 // build. Bump whenever the table layout changes in a non-backwards-
-// compatible way (e.g. a new required table like libs). Stored in the
+// compatible way OR when the embedding semantics change (so old DB
+// vectors and new query vectors live in different spaces — even if
+// the table layout is identical, the rows are stale). Stored in the
 // meta table at first Open and cross-checked on every subsequent open
 // against this constant; a mismatch surfaces as ErrSchemaMismatch.
-const CurrentSchemaVersion = 4
+//
+// Bump history:
+//   - 1: initial layout
+//   - 2: pluggable embedder metadata (#84)
+//   - 3: libs catalog table (#55)
+//   - 4: first-class multi-version (#113)
+//   - 5: lib embedding mixes optional description with lib_id (#191)
+const CurrentSchemaVersion = 5
 
 // Meta describes the embedder a database was created with. It is written
 // to the meta table the first time a fresh DB is opened and cross-checked
@@ -595,15 +604,22 @@ type LibInfo struct {
 }
 
 // UpsertLibIfNew inserts a row into the libs table for (libID, version)
-// iff one doesn't already exist. The embedding is computed from the
-// lib_id text alone with "/" and "-" turned into spaces so the encoder
-// sees something resembling natural language
-// ("/hashicorp/terraform-provider-aws" → "hashicorp terraform provider
-// aws"). Version is intentionally NOT mixed into the embed text:
-// multiple versions of the same lib should rank identically against a
-// free-text library-name query, so the embedding stays keyed on the
-// base identity while the row's (lib_id, version) primary key keeps
-// the versions distinct on disk.
+// iff one doesn't already exist. The embedding text is built by
+// libEmbedText: the normalized lib_id ("/hashicorp/terraform-provider-aws"
+// → "hashicorp terraform provider aws") concatenated with the upstream-
+// authored description (when non-empty) so the encoder sees both the
+// canonical name tokens and the intent prose. Empty description falls
+// back to lib_id alone — the legacy embedding path, byte-for-byte the
+// same vector pre-#191.
+//
+// Version is still NOT mixed into the embed text: the version
+// identifier is a user-facing label with no semantic value to a
+// free-text library-name query. Description, on the other hand, CAN
+// differ per version when a per-version override is set (terraform
+// 1.13 vs 1.14 with a major API rewrite), in which case two versions
+// of the same lib_id WILL produce distinct embeddings. When
+// descriptions match (or both are empty) the legacy "all versions of
+// a lib rank identically" property is preserved for the common case.
 //
 // Re-running this function for an existing (lib_id, version) pair is a
 // fast no-op that does NOT call EmbedDocument — the issue's "at most
@@ -614,7 +630,7 @@ type LibInfo struct {
 // Version is the canonical empty string for single-version libs; the
 // primary key is on (lib_id, version) so the same base lib with two
 // versions cleanly produces two rows.
-func UpsertLibIfNew(d *DB, libID, version string, e LibEmbedder) error {
+func UpsertLibIfNew(d *DB, libID, version, description string, e LibEmbedder) error {
 	if libID == "" {
 		return errors.New("upsert lib: libID must not be empty")
 	}
@@ -625,7 +641,7 @@ func UpsertLibIfNew(d *DB, libID, version string, e LibEmbedder) error {
 	if existing > 0 {
 		return nil
 	}
-	vec, err := e.EmbedDocument(normalizeLibIDText(libID))
+	vec, err := e.EmbedDocument(libEmbedText(libID, description))
 	if err != nil {
 		return fmt.Errorf("upsert lib %q version %q: embed: %w", libID, version, err)
 	}
@@ -639,6 +655,21 @@ func UpsertLibIfNew(d *DB, libID, version string, e LibEmbedder) error {
 		return fmt.Errorf("upsert lib %q version %q: insert: %w", libID, version, err)
 	}
 	return nil
+}
+
+// libEmbedText returns the text fed to the encoder for a lib's row.
+// The normalized lib_id is always present; description is appended
+// with a single space when non-empty, giving the encoder both the
+// canonical name tokens and the upstream-authored intent prose.
+// Empty description short-circuits to the legacy lib_id-only text,
+// preserving the pre-#191 vector byte-for-byte for libs without a
+// description.
+func libEmbedText(libID, description string) string {
+	text := normalizeLibIDText(libID)
+	if d := strings.TrimSpace(description); d != "" {
+		return text + " " + d
+	}
+	return text
 }
 
 // UpdateLibCount sets the doc_count for an existing libs row keyed on

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -454,14 +454,14 @@ func TestUpsertLibIfNew_Idempotent(t *testing.T) {
 	d := openTestDB(t)
 	c := &countingEmbedder{inner: testEmbedder}
 
-	if err := db.UpsertLibIfNew(d, "/facebook/react", "", c); err != nil {
+	if err := db.UpsertLibIfNew(d, "/facebook/react", "", "", c); err != nil {
 		t.Fatalf("first UpsertLibIfNew: %v", err)
 	}
 	if c.calls != 1 {
 		t.Fatalf("after first upsert: Embed called %d time(s), want 1", c.calls)
 	}
 
-	if err := db.UpsertLibIfNew(d, "/facebook/react", "", c); err != nil {
+	if err := db.UpsertLibIfNew(d, "/facebook/react", "", "", c); err != nil {
 		t.Fatalf("second UpsertLibIfNew: %v", err)
 	}
 	if c.calls != 1 {
@@ -471,7 +471,7 @@ func TestUpsertLibIfNew_Idempotent(t *testing.T) {
 	// And a sanity check: a *different* lib_id does trigger a fresh Embed
 	// call. This catches the failure mode where UpsertLibIfNew gets
 	// over-eager and short-circuits on any non-empty libs table.
-	if err := db.UpsertLibIfNew(d, "/vercel/next.js", "", c); err != nil {
+	if err := db.UpsertLibIfNew(d, "/vercel/next.js", "", "", c); err != nil {
 		t.Fatalf("upsert second lib: %v", err)
 	}
 	if c.calls != 2 {
@@ -487,10 +487,10 @@ func TestUpsertLibIfNew_AllowsSameLibDifferentVersion(t *testing.T) {
 	d := openTestDB(t)
 	c := &countingEmbedder{inner: testEmbedder}
 
-	if err := db.UpsertLibIfNew(d, "/hashicorp/terraform", "v1.14", c); err != nil {
+	if err := db.UpsertLibIfNew(d, "/hashicorp/terraform", "v1.14", "", c); err != nil {
 		t.Fatalf("upsert v1.14: %v", err)
 	}
-	if err := db.UpsertLibIfNew(d, "/hashicorp/terraform", "v1.13", c); err != nil {
+	if err := db.UpsertLibIfNew(d, "/hashicorp/terraform", "v1.13", "", c); err != nil {
 		t.Fatalf("upsert v1.13: %v", err)
 	}
 	// Two distinct (lib_id, version) pairs → two embed calls.
@@ -508,12 +508,176 @@ func TestUpsertLibIfNew_AllowsSameLibDifferentVersion(t *testing.T) {
 
 	// And the re-upsert of an existing pair is still idempotent (no
 	// extra embed call).
-	if err := db.UpsertLibIfNew(d, "/hashicorp/terraform", "v1.14", c); err != nil {
+	if err := db.UpsertLibIfNew(d, "/hashicorp/terraform", "v1.14", "", c); err != nil {
 		t.Fatalf("re-upsert v1.14: %v", err)
 	}
 	if c.calls != 2 {
 		t.Errorf("after re-upsert: Embed called %d time(s), want 2", c.calls)
 	}
+}
+
+// libEmbeddingDistance returns the cosine distance between the
+// embeddings of two (lib_id, version) rows in the libs table. Used by
+// the #191 description-mixing tests to assert that embeddings either
+// stay identical (description ignored / both empty) or diverge
+// (description differs). Distance 0 means identical, larger means
+// further apart.
+func libEmbeddingDistance(t *testing.T, d *db.DB, libA, verA, libB, verB string) float64 {
+	t.Helper()
+	var dist float64
+	if err := d.QueryRow(
+		`SELECT vector_distance_cos(a.embedding, b.embedding)
+		 FROM libs a, libs b
+		 WHERE a.lib_id = ? AND a.version = ? AND b.lib_id = ? AND b.version = ?`,
+		libA, verA, libB, verB,
+	).Scan(&dist); err != nil {
+		t.Fatalf("compute lib embedding distance (%q@%q vs %q@%q): %v", libA, verA, libB, verB, err)
+	}
+	return dist
+}
+
+// TestUpsertLibIfNew_DescriptionDistinguishesEmbeddings pins the
+// headline #191 contract: two libs with structurally similar lib_ids
+// but different descriptions land in clearly different regions of the
+// embedding space. The 0.05 cosine-distance floor is loose on purpose:
+// it has to clear all-MiniLM-L6 (the test embedder)'s baseline noise
+// without being so tight that an upstream embedder swap immediately
+// flakes the test. Anything above 0.05 means the description signal is
+// actually being mixed in, not silently dropped.
+func TestUpsertLibIfNew_DescriptionDistinguishesEmbeddings(t *testing.T) {
+	d := openTestDB(t)
+
+	// Two structurally similar lib_ids — both 3-token "org/project"
+	// shapes, both in the same broad domain (databases) — so any
+	// distance signal between them must come from the descriptions.
+	if err := db.UpsertLibIfNew(d, "/foo/widget-a", "", "Distributed key-value cache for low-latency lookups.", testEmbedder); err != nil {
+		t.Fatalf("upsert widget-a: %v", err)
+	}
+	if err := db.UpsertLibIfNew(d, "/foo/widget-b", "", "Photo editing toolkit for raster graphics and image filters.", testEmbedder); err != nil {
+		t.Fatalf("upsert widget-b: %v", err)
+	}
+
+	dist := libEmbeddingDistance(t, d, "/foo/widget-a", "", "/foo/widget-b", "")
+	if dist <= 0.05 {
+		t.Errorf("cosine distance between divergent-description libs = %v, want > 0.05", dist)
+	}
+}
+
+// TestUpsertLibIfNew_EmptyDescriptionMatchesLegacyEmbedding pins the
+// backwards-compat snapshot the issue calls out: passing description=""
+// must produce the exact same vector as the pre-#191 lib_id-only
+// embedding. We assert this via vector_distance_cos against a
+// freshly-computed reference vector of the same normalized lib_id text
+// — distance must be effectively zero (== identical vectors).
+func TestUpsertLibIfNew_EmptyDescriptionMatchesLegacyEmbedding(t *testing.T) {
+	d := openTestDB(t)
+
+	const libID = "/hashicorp/terraform-provider-aws"
+	if err := db.UpsertLibIfNew(d, libID, "", "", testEmbedder); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// Reference vector = the legacy embedding text: lib_id with "/" and
+	// "-" mapped to spaces. Mirrored from internal/db.normalizeLibIDText
+	// (unexported); kept in lockstep here so a future tweak to that
+	// helper trips this test as a heads-up.
+	const legacyText = "hashicorp terraform provider aws"
+	ref, err := testEmbedder.EmbedDocument(legacyText)
+	if err != nil {
+		t.Fatalf("embed reference: %v", err)
+	}
+	refStr := vectorLiteral(ref)
+
+	var dist float64
+	if err := d.QueryRow(
+		`SELECT vector_distance_cos(embedding, vector(?)) FROM libs WHERE lib_id = ? AND version = ?`,
+		refStr, libID, "",
+	).Scan(&dist); err != nil {
+		t.Fatalf("read distance: %v", err)
+	}
+	// Floating-point: a direct equality check on cosine distance is
+	// unsafe, but the same input through the same embedder should land
+	// well below 1e-5 — leaves room for deterministic-but-fuzzy IEEE
+	// drift without admitting any actual semantic divergence.
+	if dist > 1e-5 {
+		t.Errorf("empty-desc vector distance from lib_id-only reference = %v, want ~0 (compat broken)", dist)
+	}
+}
+
+// TestUpsertLibIfNew_PerVersionDescriptionDivergesEmbeddings pins the
+// per-version override path: two versions of the SAME lib_id with
+// different descriptions must land in different embedding regions.
+// This is the headline use case the issue calls out (terraform 1.13
+// vs 1.14 with a major API rewrite) and the property that retracts
+// the legacy "all versions of a lib rank identically" guarantee.
+func TestUpsertLibIfNew_PerVersionDescriptionDivergesEmbeddings(t *testing.T) {
+	d := openTestDB(t)
+
+	const libID = "/hashicorp/terraform"
+	if err := db.UpsertLibIfNew(d, libID, "1.13", "Infrastructure as code with HCL — stable provider ecosystem.", testEmbedder); err != nil {
+		t.Fatalf("upsert 1.13: %v", err)
+	}
+	if err := db.UpsertLibIfNew(d, libID, "1.14", "Image classification benchmarks for convolutional neural networks.", testEmbedder); err != nil {
+		t.Fatalf("upsert 1.14: %v", err)
+	}
+
+	dist := libEmbeddingDistance(t, d, libID, "1.13", libID, "1.14")
+	if dist <= 0.05 {
+		t.Errorf("per-version divergent-description distance = %v, want > 0.05 (descriptions ignored?)", dist)
+	}
+}
+
+// TestUpsertLibIfNew_PerVersionSameDescriptionIdenticalEmbeddings pins
+// the inverse: when two versions inherit the same description (or both
+// have empty descriptions), the embeddings stay identical — preserving
+// the legacy "all versions of a lib rank identically" property for
+// the common case where descriptions don't diverge.
+func TestUpsertLibIfNew_PerVersionSameDescriptionIdenticalEmbeddings(t *testing.T) {
+	d := openTestDB(t)
+
+	const (
+		libID = "/facebook/react"
+		desc  = "Declarative UI library for building component-based web interfaces."
+	)
+	if err := db.UpsertLibIfNew(d, libID, "18", desc, testEmbedder); err != nil {
+		t.Fatalf("upsert 18: %v", err)
+	}
+	if err := db.UpsertLibIfNew(d, libID, "19", desc, testEmbedder); err != nil {
+		t.Fatalf("upsert 19: %v", err)
+	}
+	if dist := libEmbeddingDistance(t, d, libID, "18", libID, "19"); dist > 1e-5 {
+		t.Errorf("same-description versions distance = %v, want ~0", dist)
+	}
+
+	// And the both-empty path: two more versions with no description
+	// must also collapse to a single embedding under the same lib_id.
+	const libEmpty = "/grafana/loki"
+	if err := db.UpsertLibIfNew(d, libEmpty, "2.9", "", testEmbedder); err != nil {
+		t.Fatalf("upsert loki 2.9: %v", err)
+	}
+	if err := db.UpsertLibIfNew(d, libEmpty, "3.0", "", testEmbedder); err != nil {
+		t.Fatalf("upsert loki 3.0: %v", err)
+	}
+	if dist := libEmbeddingDistance(t, d, libEmpty, "2.9", libEmpty, "3.0"); dist > 1e-5 {
+		t.Errorf("both-empty-description versions distance = %v, want ~0", dist)
+	}
+}
+
+// vectorLiteral renders a float32 slice into the textual form turso's
+// vector(?) constructor accepts — "[v1,v2,...]". Lifted from the
+// internal helper so tests can build query-side reference vectors
+// without depending on unexported db helpers.
+func vectorLiteral(v []float32) string {
+	var sb strings.Builder
+	sb.WriteByte('[')
+	for i, x := range v {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		fmt.Fprintf(&sb, "%g", x)
+	}
+	sb.WriteByte(']')
+	return sb.String()
 }
 
 // TestUpdateLibCount_UpdatesRightRow verifies that UpdateLibCount only
@@ -524,7 +688,7 @@ func TestUpdateLibCount_UpdatesRightRow(t *testing.T) {
 	d := openTestDB(t)
 
 	for _, libID := range []string{"/a/one", "/b/two"} {
-		if err := db.UpsertLibIfNew(d, libID, "", testEmbedder); err != nil {
+		if err := db.UpsertLibIfNew(d, libID, "", "", testEmbedder); err != nil {
 			t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
 		}
 	}
@@ -567,7 +731,7 @@ func TestSearchLibsByEmbedding_RanksRelevantFirst(t *testing.T) {
 		"/expressjs/express",
 	}
 	for _, libID := range libs {
-		if err := db.UpsertLibIfNew(d, libID, "", testEmbedder); err != nil {
+		if err := db.UpsertLibIfNew(d, libID, "", "", testEmbedder); err != nil {
 			t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
 		}
 	}
@@ -599,7 +763,7 @@ func TestSearchLibsByEmbedding_HonoursLimit(t *testing.T) {
 	d := openTestDB(t)
 
 	for _, libID := range []string{"/a/one", "/b/two", "/c/three"} {
-		if err := db.UpsertLibIfNew(d, libID, "", testEmbedder); err != nil {
+		if err := db.UpsertLibIfNew(d, libID, "", "", testEmbedder); err != nil {
 			t.Fatalf("UpsertLibIfNew %q: %v", libID, err)
 		}
 	}
@@ -634,7 +798,7 @@ func TestTopLibsByDocCount_OrdersDescending(t *testing.T) {
 		{"/medium/lib", 25},
 	}
 	for _, l := range libs {
-		if err := db.UpsertLibIfNew(d, l.id, "", testEmbedder); err != nil {
+		if err := db.UpsertLibIfNew(d, l.id, "", "", testEmbedder); err != nil {
 			t.Fatalf("UpsertLibIfNew %q: %v", l.id, err)
 		}
 		if err := db.UpdateLibCount(d, l.id, "", l.count); err != nil {

--- a/internal/scraper/config.go
+++ b/internal/scraper/config.go
@@ -69,10 +69,19 @@ type Config struct {
 // version; when nil, the version inherits the top-level URLs. An
 // explicit empty list is rejected at parse time — inheritance is
 // expressed by omitting the field.
+//
+// Description (see #191) is a per-version override of the parent
+// LibrarySource.Description. The empty string means "inherit the
+// top-level description"; whitespace-only values normalize to "" at
+// parse time so YAML quirks don't accidentally suppress inheritance.
+// Used only when two versions have meaningfully diverged (e.g. major
+// API rewrite); otherwise leave it empty so both versions ride the
+// shared top-level description.
 type VersionEntry struct {
-	Name string
-	Ref  string
-	URLs []string
+	Name        string
+	Ref         string
+	URLs        []string
+	Description string
 }
 
 // LibrarySource is a single entry in libraries_sources.yaml.
@@ -86,12 +95,20 @@ type VersionEntry struct {
 //
 // Ref pins URLs to a single upstream git tag or commit SHA when URLs
 // contain the literal "{ref}" token. See #103.
+//
+// Description (see #191) is an optional 1-2 sentence upstream-authored
+// summary of what this lib IS and what role it plays. It is mixed into
+// the libs-table embedding alongside the normalized lib_id so
+// search_libraries can rank on semantic intent rather than lib_id token
+// overlap alone. Empty string is the legacy behavior (embed lib_id
+// alone); whitespace-only values normalize to "" at parse time.
 type LibrarySource struct {
-	LibID    string
-	Kind     string
-	URLs     []string
-	Ref      string
-	Versions []VersionEntry
+	LibID       string
+	Kind        string
+	URLs        []string
+	Ref         string
+	Description string
+	Versions    []VersionEntry
 }
 
 // ResolvedSource is one library, post-version-expansion, ready to scrape.
@@ -108,13 +125,19 @@ type LibrarySource struct {
 // BaseLibID is retained as a separate field for readability at call
 // sites — it is always == LibID after #113, but the name documents
 // intent ("the unversioned identity of this lib").
+//
+// Description (see #191) is the effective per-(lib_id, version)
+// description: per-version override → top-level → "". Threaded down to
+// the embedder so two versions of the same lib can produce distinct
+// embeddings when their descriptions diverge.
 type ResolvedSource struct {
-	LibID     string
-	BaseLibID string
-	Version   string
-	Kind      string
-	Ref       string
-	URLs      []string
+	LibID       string
+	BaseLibID   string
+	Version     string
+	Kind        string
+	Ref         string
+	URLs        []string
+	Description string
 }
 
 // UnmarshalYAML parses `versions:` as a mapping:
@@ -130,11 +153,12 @@ type ResolvedSource struct {
 // deterministic order.
 func (l *LibrarySource) UnmarshalYAML(node *yaml.Node) error {
 	var raw struct {
-		LibID    string    `yaml:"lib_id"`
-		Kind     string    `yaml:"kind"`
-		URLs     []string  `yaml:"urls"`
-		Ref      string    `yaml:"ref"`
-		Versions yaml.Node `yaml:"versions"`
+		LibID       string    `yaml:"lib_id"`
+		Kind        string    `yaml:"kind"`
+		URLs        []string  `yaml:"urls"`
+		Ref         string    `yaml:"ref"`
+		Description string    `yaml:"description"`
+		Versions    yaml.Node `yaml:"versions"`
 	}
 	if err := node.Decode(&raw); err != nil {
 		return err
@@ -143,6 +167,10 @@ func (l *LibrarySource) UnmarshalYAML(node *yaml.Node) error {
 	l.Kind = raw.Kind
 	l.URLs = raw.URLs
 	l.Ref = raw.Ref
+	// Whitespace-only descriptions normalize to "" so an accidental
+	// `description: " "` doesn't suppress inheritance for per-version
+	// entries — same rule applied at both levels (#191).
+	l.Description = strings.TrimSpace(raw.Description)
 	l.Versions = nil
 
 	if raw.Versions.Kind == 0 {
@@ -162,13 +190,18 @@ func (l *LibrarySource) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("versions map key: %w", err)
 			}
 			var entry struct {
-				Ref  string    `yaml:"ref"`
-				URLs yaml.Node `yaml:"urls"`
+				Ref         string    `yaml:"ref"`
+				URLs        yaml.Node `yaml:"urls"`
+				Description string    `yaml:"description"`
 			}
 			if err := valNode.Decode(&entry); err != nil {
 				return fmt.Errorf("versions[%q]: %w", name, err)
 			}
-			v := VersionEntry{Name: name, Ref: entry.Ref}
+			v := VersionEntry{
+				Name:        name,
+				Ref:         entry.Ref,
+				Description: strings.TrimSpace(entry.Description),
+			}
 			// Distinguish omitted urls (inherit baseline) from explicit
 			// `urls: []` (rejected as ambiguous — see #115).
 			if entry.URLs.Kind != 0 {
@@ -381,11 +414,12 @@ func (l LibrarySource) Expand() []ResolvedSource {
 			urls[i] = substituteRef(u, l.Ref)
 		}
 		return []ResolvedSource{{
-			LibID:     l.LibID,
-			BaseLibID: l.LibID,
-			Kind:      l.Kind,
-			Ref:       l.Ref,
-			URLs:      urls,
+			LibID:       l.LibID,
+			BaseLibID:   l.LibID,
+			Kind:        l.Kind,
+			Ref:         l.Ref,
+			URLs:        urls,
+			Description: l.Description,
 		}}
 	}
 	out := make([]ResolvedSource, 0, len(l.Versions))
@@ -404,13 +438,22 @@ func (l LibrarySource) Expand() []ResolvedSource {
 		for i, u := range src {
 			urls[i] = substituteRef(u, ref)
 		}
+		// Effective description: per-version override → top-level →
+		// "". Whitespace-only is already normalized to "" at parse
+		// time (UnmarshalYAML), so a non-empty per-version value is
+		// always a deliberate override (#191).
+		desc := v.Description
+		if desc == "" {
+			desc = l.Description
+		}
 		out = append(out, ResolvedSource{
-			LibID:     l.LibID,
-			BaseLibID: l.LibID,
-			Version:   v.Name,
-			Kind:      l.Kind,
-			Ref:       ref,
-			URLs:      urls,
+			LibID:       l.LibID,
+			BaseLibID:   l.LibID,
+			Version:     v.Name,
+			Kind:        l.Kind,
+			Ref:         ref,
+			URLs:        urls,
+			Description: desc,
 		})
 	}
 	return out

--- a/internal/scraper/config_test.go
+++ b/internal/scraper/config_test.go
@@ -1048,6 +1048,152 @@ libraries:
 	}
 }
 
+// --- description field (#191) ---
+
+// TestLoadConfig_DescriptionTopLevelRoundTrips pins the basic happy
+// path: a non-empty top-level description: parses into LibrarySource,
+// Expand puts it on every ResolvedSource, and a single-version entry
+// surfaces the same string verbatim.
+func TestLoadConfig_DescriptionTopLevelRoundTrips(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /tokio-rs/tokio
+    kind: github-md
+    description: Asynchronous runtime for Rust providing IO, scheduling, and synchronization primitives.
+    urls:
+      - https://example.com/tokio/README.md
+`)
+	if got := cfg.Libraries[0].Description; got != "Asynchronous runtime for Rust providing IO, scheduling, and synchronization primitives." {
+		t.Errorf("Description = %q", got)
+	}
+	got := cfg.Resolve("", "")
+	if len(got) != 1 {
+		t.Fatalf("Resolve returned %d, want 1", len(got))
+	}
+	if got[0].Description == "" || got[0].Description != cfg.Libraries[0].Description {
+		t.Errorf("ResolvedSource.Description = %q, want top-level passthrough", got[0].Description)
+	}
+}
+
+// TestLoadConfig_DescriptionAbsentDefaultsToEmpty pins backwards compat:
+// a YAML entry with no description: at all parses fine and yields the
+// empty string downstream — the legacy "embed lib_id alone" path.
+func TestLoadConfig_DescriptionAbsentDefaultsToEmpty(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /modelcontextprotocol/go-sdk
+    kind: github-md
+    urls:
+      - https://example.com/go-sdk/README.md
+`)
+	if cfg.Libraries[0].Description != "" {
+		t.Errorf("Description = %q, want empty", cfg.Libraries[0].Description)
+	}
+	got := cfg.Resolve("", "")
+	if got[0].Description != "" {
+		t.Errorf("ResolvedSource.Description = %q, want empty", got[0].Description)
+	}
+}
+
+// TestLoadConfig_DescriptionWhitespaceOnlyNormalizesToEmpty pins the
+// parse-time normalization rule: " " or "\t\n" at either level becomes
+// "" so an accidental whitespace-only override doesn't suppress
+// inheritance.
+func TestLoadConfig_DescriptionWhitespaceOnlyNormalizesToEmpty(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /org/topwhitespace
+    kind: github-md
+    description: "   "
+    urls:
+      - https://example.com/a.md
+  - lib_id: /org/perversionwhitespace
+    kind: github-md
+    description: top-level intent
+    versions:
+      "1.0":
+        ref: v1.0.0
+        description: "  \t  "
+    urls:
+      - https://example.com/{ref}/a.md
+`)
+	if got := cfg.Libraries[0].Description; got != "" {
+		t.Errorf("top-level whitespace-only Description = %q, want empty", got)
+	}
+	if got := cfg.Libraries[1].Versions[0].Description; got != "" {
+		t.Errorf("per-version whitespace-only Description = %q, want empty", got)
+	}
+	// And inheritance kicks in for the per-version case: the resolved
+	// source rides the top-level description because the override
+	// normalized to "".
+	got := cfg.Resolve("/org/perversionwhitespace", "1.0")
+	if len(got) != 1 {
+		t.Fatalf("Resolve returned %d, want 1", len(got))
+	}
+	if got[0].Description != "top-level intent" {
+		t.Errorf("ResolvedSource.Description = %q, want %q", got[0].Description, "top-level intent")
+	}
+}
+
+// TestLoadConfig_DescriptionPerVersionOverrides pins the per-version
+// override: when a version sets its own description:, that string
+// wins for that version's ResolvedSource; siblings without an override
+// inherit the top-level. Mirrors the terraform 1.13/1.14 case the
+// issue calls out.
+func TestLoadConfig_DescriptionPerVersionOverrides(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /hashicorp/terraform
+    kind: github-md
+    description: Infrastructure as code for managing cloud resources via declarative HCL.
+    versions:
+      "1.13":
+        ref: v1.13.5
+      "1.14":
+        ref: v1.14.6
+        description: Terraform 1.14 — adds state encryption and ephemeral resources.
+    urls:
+      - https://example.com/{ref}/README.md
+`)
+	got := cfg.Resolve("/hashicorp/terraform", "")
+	if len(got) != 2 {
+		t.Fatalf("Resolve returned %d, want 2", len(got))
+	}
+	// Declaration order: 1.13 inherits, 1.14 overrides.
+	if got[0].Version != "1.13" || got[0].Description != "Infrastructure as code for managing cloud resources via declarative HCL." {
+		t.Errorf("[0] (1.13) Description = %q, want top-level inheritance", got[0].Description)
+	}
+	if got[1].Version != "1.14" || got[1].Description != "Terraform 1.14 — adds state encryption and ephemeral resources." {
+		t.Errorf("[1] (1.14) Description = %q, want per-version override", got[1].Description)
+	}
+}
+
+// TestLoadConfig_DescriptionBothEmpty pins the "no description anywhere"
+// path: top-level absent + per-version absent → ResolvedSource carries
+// "" at both versions, which is the signal the embedder uses to fall
+// back to lib_id-only embedding.
+func TestLoadConfig_DescriptionBothEmpty(t *testing.T) {
+	cfg := mustLoadInline(t, `
+libraries:
+  - lib_id: /org/project
+    kind: github-md
+    versions:
+      "1.0": { ref: v1.0.0 }
+      "2.0": { ref: v2.0.0 }
+    urls:
+      - https://example.com/{ref}/README.md
+`)
+	got := cfg.Resolve("", "")
+	if len(got) != 2 {
+		t.Fatalf("Resolve returned %d, want 2", len(got))
+	}
+	for i, r := range got {
+		if r.Description != "" {
+			t.Errorf("[%d] Description = %q, want empty", i, r.Description)
+		}
+	}
+}
+
 func TestLoadConfig_VersionsMapShape_PerVersionRefOverridesTopLevel(t *testing.T) {
 	cfg := mustLoadInline(t, `
 libraries:

--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -22,6 +22,23 @@
 #             substituted at resolve time (#103). When used at top level,
 #             applies to every expanded version unless overridden.
 #
+#   description  short upstream-authored summary (1-2 sentences,
+#             ~100-220 chars) of what this lib IS and what role it plays.
+#             Mixed into the lib-row embedding alongside the normalized
+#             lib_id at scrape time so search_libraries can rank on
+#             semantic intent instead of lib_id token overlap alone
+#             (#191). Source preference: upstream README first
+#             paragraph, GitHub repo description, or official tagline —
+#             whatever is authoritative. Avoid licensing/sponsorship
+#             text and marketing fluff ("powerful", "blazing fast",
+#             "modern") unless the upstream tagline literally uses the
+#             word and dropping it loses information. Empty/missing
+#             reverts to the legacy lib_id-only embedding (no behavior
+#             change). Whitespace-only normalizes to "" at parse time.
+#             Example:
+#               description: Asynchronous runtime for Rust providing IO,
+#                 scheduling, and synchronization primitives.
+#
 #   versions  mapping of version identifiers to per-version overrides.
 #             When present, every effective URL list (baseline or a
 #             per-version `urls:` override) must contain the literal
@@ -45,6 +62,14 @@
 #                         same lib diverge structurally, or when the
 #                         URL path literal differs per version (see the
 #                         `hashicorp/terraform` entry below).
+#               - `description:` replaces the top-level `description:`
+#                         for this version's libs-table row only (#191).
+#                         Use sparingly — only when versions have
+#                         meaningfully diverged (e.g. a major API
+#                         rewrite). Omit to inherit the top-level
+#                         description; whitespace-only normalizes to ""
+#                         at parse time so it doesn't accidentally
+#                         suppress inheritance.
 #
 #             The legacy list shape `versions: [v1, v2]` is rejected at
 #             parse time — use `{"1.4": {...}, "1.5": {...}}` instead
@@ -117,6 +142,7 @@
 # large repos and are subject to upstream GC.
 libraries:
   - lib_id: /modelcontextprotocol/go-sdk
+    description: Official Go SDK for the Model Context Protocol (MCP), used by clients and servers exchanging tools, prompts, and resources with LLM hosts.
     kind: github-md
     versions:
       "1.4": { ref: v1.4.1 }
@@ -137,6 +163,7 @@ libraries:
   # directly: no LLM extraction, no truncation, no verifier skips.
   # Tags ship without a "v" prefix.
   - lib_id: /fastapi/fastapi
+    description: Modern Python web framework for building APIs based on standard Python type hints, with automatic OpenAPI/Swagger documentation and async support.
     kind: github-md
     versions:
       "0.134": { ref: 0.134.0 }
@@ -252,6 +279,7 @@ libraries:
   # so we pull the raw .rst directly. No HTML scrape, no LLM. The 20
   # modules below are the "core 20" decided in #95.
   - lib_id: /python/cpython
+    description: Reference implementation of the Python programming language, providing the standard library and the interpreter runtime.
     kind: github-rst
     versions:
       "3.13": { ref: v3.13.9 }
@@ -292,6 +320,7 @@ libraries:
   # the same sha for both). Duplicating the URL list is the cheap way
   # to keep the vocab one-placeholder-wide.
   - lib_id: /hashicorp/terraform
+    description: Infrastructure as code tool for declaratively provisioning and managing cloud resources via providers and HCL configuration.
     kind: github-md
     ref: 9c479db1ab97a2f175e049c0d5bbf31c24959c7e
     versions:
@@ -391,6 +420,7 @@ libraries:
   # OpenTofu — docs are MDX directly in the opentofu repo at
   # website/docs/. Terraform fork, so the tree shape mirrors hashicorp's.
   - lib_id: /opentofu/opentofu
+    description: Open-source infrastructure as code tool, community-driven fork of Terraform under the Linux Foundation, compatible with HCL and existing providers.
     kind: github-md
     versions:
       "1.10": { ref: v1.10.9 }
@@ -440,6 +470,7 @@ libraries:
 
   # OVHcloud Go SDK — README is the canonical reference.
   - lib_id: /ovh/go-ovh
+    description: Official Go client library for the OVHcloud public APIs, handling authentication, request signing, and consumer-key flows.
     kind: github-md
     versions:
       "1.8": { ref: v1.8.0 }
@@ -449,6 +480,7 @@ libraries:
 
   # OVHcloud CLI (v2). Canonical repo name is `ovhcloud-cli`, not `ovh-cli`.
   - lib_id: /ovh/ovhcloud-cli
+    description: Command-line interface for the OVHcloud APIs, scriptable wrapper for managing accounts, projects, and cloud resources.
     kind: github-md
     versions:
       "0.10": { ref: v0.10.0 }
@@ -458,6 +490,7 @@ libraries:
 
   # OVHcloud Terraform provider — README + top-level provider doc.
   - lib_id: /ovh/terraform-provider-ovh
+    description: Terraform provider for OVHcloud resources covering compute, networking, public cloud, dedicated servers, and managed services.
     kind: github-md
     versions:
       "2.12": { ref: v2.12.0 }
@@ -472,6 +505,7 @@ libraries:
   # documented exception to the #120 convention). `ref:` mirrors the
   # version key verbatim because the version IS the git tag for this lib.
   - lib_id: /scaleway/scaleway-sdk-go
+    description: Official Go SDK for the Scaleway cloud APIs (instances, object storage, Kubernetes Kapsule, serverless containers, IAM).
     kind: github-md
     versions:
       v1.0.0-beta.35: { ref: v1.0.0-beta.35 }
@@ -481,6 +515,7 @@ libraries:
 
   # Scaleway CLI — README + cookbook + v2 migration guide.
   - lib_id: /scaleway/scaleway-cli
+    description: Command-line interface for managing Scaleway cloud resources (instances, Kapsule, object storage, IAM), built on top of the Scaleway Go SDK.
     kind: github-md
     versions:
       "2.53": { ref: v2.53.0 }
@@ -492,6 +527,7 @@ libraries:
 
   # Scaleway Terraform provider — README + top-level provider doc.
   - lib_id: /scaleway/terraform-provider-scaleway
+    description: Terraform provider for Scaleway cloud resources (instances, networking, Kubernetes Kapsule, object storage, serverless).
     kind: github-md
     versions:
       "2.71": { ref: v2.71.0 }
@@ -508,6 +544,7 @@ libraries:
   # packages/web/src/content/docs/ at the English root only — translated
   # subdirs (bs/, ar/, fr/, etc.) are intentionally excluded. See #149.
   - lib_id: /anomalyco/opencode
+    description: Open-source AI coding agent for the terminal, model-agnostic and configurable via slash commands and a TUI.
     kind: github-md
     ref: 908e28175f9e5c46206c8884bdd9a7dbb31d0f0b
     urls:
@@ -552,6 +589,7 @@ libraries:
   # as of 2026-04-23), so we pin to `main` with a bare URL list. README
   # only — CONTRIBUTING/LICENSE are project meta, not library docs. See #132.
   - lib_id: /tursodatabase/turso-go
+    description: Official Go driver and client library for Turso, the SQLite-compatible distributed database, with embedded and remote sync modes.
     kind: github-md
     urls:
       - https://raw.githubusercontent.com/tursodatabase/turso-go/main/README.md
@@ -565,6 +603,7 @@ libraries:
   # docs/language-reference/ is skipped (it only ships compiled mdBook HTML,
   # not markdown source). See #132.
   - lib_id: /tursodatabase/turso
+    description: In-process SQLite-compatible database written in Rust (formerly Limbo/libSQL), with vector search, full-text search, MVCC, and CDC.
     kind: github-md
     versions:
       "0.6": { ref: v0.6.0-pre.22 }
@@ -639,6 +678,7 @@ libraries:
   # /introduction, /sdk/*, /cli/*, /features/*. docs.turso.tech is
   # unversioned (always current), so no `versions:` block and no ref pin.
   - lib_id: /tursodatabase/turso-docs
+    description: Documentation site source for the Turso edge SQLite database platform, covering SDKs, CLI, and managed service usage.
     kind: github-md
     urls:
       - https://docs.turso.tech/introduction.md
@@ -675,6 +715,7 @@ libraries:
   # Tiny surface: README + contrib.md. CHANGELOG skipped (release log,
   # not library docs). See #142.
   - lib_id: /knights-analytics/hugot
+    description: Go library for running HuggingFace transformer models on the ONNX Runtime, with embedding, classification, and token generation pipelines.
     kind: github-md
     versions:
       "0.6": { ref: v0.6.5 }
@@ -688,6 +729,7 @@ libraries:
   # site/content/ (Hugo markdown). CONDUCT/CONTRIBUTING/SECURITY skipped
   # (project meta). See #142.
   - lib_id: /spf13/cobra
+    description: Go library for building modern command-line applications, with subcommands, POSIX flag parsing, and shell completion generation.
     kind: github-md
     versions:
       "1.9":  { ref: v1.9.1 }
@@ -717,6 +759,7 @@ libraries:
   # authoring docs (plugin-*-development.md, plugin-lua-modules.md) are
   # also skipped — out of scope for deadzone's use of mise. See #142.
   - lib_id: /jdx/mise
+    description: Polyglot tool version manager and task runner, drop-in successor to asdf with support for Go, Node.js, Python, Ruby, and many language runtimes.
     kind: github-md
     versions:
       "2026.3": { ref: v2026.3.9 }
@@ -757,6 +800,7 @@ libraries:
   # reference; skills/just/SKILL.md is the upstream agent-oriented
   # cheat sheet. CHANGELOG/CONTRIBUTING/中文 README skipped. See #142.
   - lib_id: /casey/just
+    description: Command runner for project-specific tasks, similar in spirit to make but focused on running recipes rather than tracking file dependencies.
     kind: github-md
     versions:
       "1.49": { ref: "1.49.0" }
@@ -772,6 +816,7 @@ libraries:
   # does not exist at v2.36 — keeping a single URL list across both
   # minors (no per-version override needed). See #142.
   - lib_id: /direnv/direnv
+    description: Shell extension that loads and unloads environment variables based on the current directory, scoped via per-project .envrc files.
     kind: github-md
     versions:
       "2.36": { ref: v2.36.0 }
@@ -793,6 +838,7 @@ libraries:
   # pattern exhaustively; examples/go + examples/web are the reference
   # integrations. CONTRIBUTING skipped (project meta). See #142.
   - lib_id: /daulet/tokenizers
+    description: Go bindings for HuggingFace's Rust tokenizers library, providing high-throughput BPE, WordPiece, and Unigram tokenization for ML pipelines.
     kind: github-md
     versions:
       "1.26": { ref: v1.26.0 }
@@ -809,6 +855,7 @@ libraries:
   # C API surface (what CGO linking actually needs): project README +
   # C_API_Guidelines + c_cxx sample entry. See #142.
   - lib_id: /microsoft/onnxruntime
+    description: Cross-platform inference and training accelerator for ONNX models, with hardware-accelerated execution providers (CUDA, CoreML, DirectML, TensorRT).
     kind: github-md
     versions:
       "1.24": { ref: v1.24.4 }
@@ -829,6 +876,7 @@ libraries:
   # the 2025-11-25 tag — omitted to keep both URL lists identical. See
   # #142.
   - lib_id: /modelcontextprotocol/modelcontextprotocol
+    description: Specification and reference materials for the Model Context Protocol (MCP), an open standard for connecting LLM applications to data sources and tools.
     kind: github-md
     versions:
       "2025-06-18": { ref: 2025-06-18 }
@@ -860,6 +908,7 @@ libraries:
   # canonical guide at docs/doc.md (~70KB) plus README as the index.
   # No separate docs site — the in-repo markdown is the source of truth.
   - lib_id: /gin-gonic/gin
+    description: HTTP web framework for Go with a martini-like API, focused on routing throughput and middleware composition for building REST APIs.
     kind: github-md
     ref: v1.12.0
     urls:
@@ -869,6 +918,7 @@ libraries:
   # go-chi/chi — lightweight, idiomatic Go HTTP router. Upstream uses the
   # README itself as the canonical documentation; there is no docs/ tree.
   - lib_id: /go-chi/chi
+    description: Lightweight idiomatic HTTP router for Go, composable via middleware and built directly on net/http with no external runtime dependencies.
     kind: github-md
     ref: v5.2.5
     urls:
@@ -882,6 +932,7 @@ libraries:
   # contributors.md (29KB list), translations.md, writing-docs.md skipped
   # — project meta, not learning material.
   - lib_id: /ent/ent
+    description: Entity framework for Go that generates type-safe code from a graph-based schema, supporting SQL backends and complex relations.
     kind: github-md
     ref: v0.14.6
     urls:
@@ -947,6 +998,7 @@ libraries:
   # Coverage spans overview/install + howto/ + reference/ + tutorials/
   # + guides/.
   - lib_id: /sqlc-dev/sqlc
+    description: Generates type-safe Go code from raw SQL queries, validating queries against the database schema at compile time.
     kind: github-md
     ref: v1.31.1
     urls:
@@ -996,6 +1048,7 @@ libraries:
   # adopting bun + Postgres. lib_id stays /uptrace/bun (the lib repo)
   # for canonical naming; URLs target the bun-docs repo.
   - lib_id: /uptrace/bun
+    description: SQL-first Go ORM and query builder for PostgreSQL, MySQL, and SQLite, with first-class support for migrations and bulk operations.
     kind: github-md
     ref: 290ada1ee4c46eae2af9394fbfb0d7e1470eb118
     urls:
@@ -1048,6 +1101,7 @@ libraries:
   # middleware/builtin/. lib_id stays /honojs/hono (the lib repo) for
   # canonical naming; URLs target honojs/website. Same pattern as bun.
   - lib_id: /honojs/hono
+    description: Small, fast, edge-first JavaScript web framework built on Web Standards, runs on Cloudflare Workers, Deno, Bun, Node.js, and AWS Lambda.
     kind: github-md
     ref: 7cca6ae11bd538f8e2cf119ddb8646744becb60f
     urls:
@@ -1143,6 +1197,7 @@ libraries:
   # excluded; only the current top-level api.md is indexed. blog/,
   # changelog/, en/resources/contributing.md skipped (project meta).
   - lib_id: /expressjs/express
+    description: Minimal and flexible Node.js HTTP web application framework, providing routing, middleware, and a baseline feature set for web and APIs.
     kind: github-md
     ref: 2d4df3f05fbd5d5f211f5938395ae965e8714d60
     urls:
@@ -1180,6 +1235,7 @@ libraries:
   # 5.x). Contributing.md skipped (project meta). Migration-Guide-V3/V4/V5
   # kept — load-bearing for users upgrading.
   - lib_id: /fastify/fastify
+    description: Fast and low-overhead web framework for Node.js, focused on schema-based JSON validation and high request-throughput via efficient routing.
     kind: github-md
     ref: v5.8.5
     urls:
@@ -1233,6 +1289,7 @@ libraries:
   # parser. lib_id stays /nestjs/nest. content/{enterprise,support}.md and
   # content/discover/who-uses.* skipped (sales/listing meta).
   - lib_id: /nestjs/nest
+    description: Node.js framework for building scalable server-side applications with TypeScript, using decorators, dependency injection, and modular architecture inspired by Angular.
     kind: github-md
     ref: 239dffa12125337a987128439f08ff884108050c
     urls:
@@ -1379,6 +1436,7 @@ libraries:
   # ecosystem/ skipped — out of learning scope. mouse.js in reusability/
   # is a code file, not docs.
   - lib_id: /vuejs/vue
+    description: Progressive JavaScript framework for building user interfaces, with reactive data binding, component composition, and a single-file component model.
     kind: github-md
     ref: 037a76daf60b0638e2837e8daa3174262e37af65
     urls:
@@ -1473,6 +1531,7 @@ libraries:
   # Svelte 3/4 patterns historical only; 99-faq.md kept. index.md per
   # subdir skipped (TOC-only stubs).
   - lib_id: /sveltejs/svelte
+    description: Compiler-based UI framework that converts components to efficient vanilla JavaScript at build time, with no virtual DOM and built-in reactivity.
     kind: github-md
     ref: dc5bd887b50c593033408b7faa079d56f38e74b9
     urls:
@@ -1562,6 +1621,7 @@ libraries:
   # experimental-flags, modules) skipped to keep PR-3 manageable; can be
   # promoted later if user-requested.
   - lib_id: /withastro/astro
+    description: Web framework for content-driven sites that ships zero JavaScript by default, with island architecture and multi-framework component support (React, Vue, Svelte).
     kind: github-md
     ref: 6bd56078bfb402e32ed639c507872c2cc91f8d49
     urls:
@@ -1655,6 +1715,7 @@ libraries:
   # tracing, shutdown, bridging) + the canonical Tokio tutorial. blog/
   # excluded.
   - lib_id: /tokio-rs/tokio
+    description: Asynchronous runtime for Rust providing IO, scheduling, and synchronization primitives for writing reliable network applications.
     kind: github-md
     ref: 46517ae6c29326df204bb8abd96308012809abba
     urls:
@@ -1682,6 +1743,7 @@ libraries:
   # repo `serde-rs/serde-rs.github.io` (Jekyll on GH Pages, no tags —
   # pinned by commit SHA). Markdown source under _src/, prose-dense.
   - lib_id: /serde-rs/serde
+    description: Generic serialization and deserialization framework for Rust, supporting JSON, YAML, TOML, MessagePack, and many other formats via derive macros.
     kind: github-md
     ref: 811393f8ddf79078d559bc479eb560927534148b
     urls:
@@ -1738,6 +1800,7 @@ libraries:
   # Hugo `_index.md` files (Hugo section landings) included; gopher.md
   # in reference/ skipped (historical Gopher protocol).
   - lib_id: /redis/redis
+    description: In-memory key-value data structure store used as a database, cache, message broker, and streaming engine, with persistence and pub/sub.
     kind: github-md
     ref: 488b72b3a95c8c90c9fa42deb5c7b9868f002935
     urls:
@@ -1776,6 +1839,7 @@ libraries:
   # user-requested — top-level compatibility.md only. cloud/ subdirs
   # (connect/migrate/sso) similarly deferred.
   - lib_id: /dragonflydb/dragonfly
+    description: In-memory key-value data store fully compatible with the Redis and Memcached protocols, designed for higher throughput and lower memory footprint.
     kind: github-md
     ref: b6c9fc9ecd8e71f247769722eb5697ec885064b1
     urls:
@@ -1815,6 +1879,7 @@ libraries:
   #   - content/en/docs/{contributing,compatibility,migration}/
   #   - content/en/docs/specs/, /security/
   - lib_id: /open-telemetry/opentelemetry
+    description: Vendor-neutral observability framework providing APIs, SDKs, and tools for collecting and exporting traces, metrics, and logs across languages and backends.
     kind: github-md
     ref: 4f744c5b97228df5a43bd785a32750271803699e
     urls:
@@ -1863,6 +1928,7 @@ libraries:
   # is deliberate — Grafana docs deserve a dedicated PR when sized
   # properly.
   - lib_id: /grafana/grafana
+    description: Observability platform for visualization and analysis of metrics, logs, and traces, with a plugin architecture supporting many data sources.
     kind: github-md
     ref: 2a9d7c18219e9421c3c9a44cb40df19657ba5dbb
     urls:
@@ -1885,6 +1951,7 @@ libraries:
   # landings. Deferred: setup/, operations/, configure/, reference/,
   # release-notes/, community/, visualize/. .png files filtered out.
   - lib_id: /grafana/loki
+    description: Horizontally-scalable, multi-tenant log aggregation system inspired by Prometheus, indexing labels rather than full log content for cheap storage.
     kind: github-md
     ref: d8f4d0f6668928184dd4aa993a7481101b0ea169
     urls:
@@ -1911,6 +1978,7 @@ libraries:
   # api_docs (3 files, skip .png) + configuration top-level (skip
   # AGENTS.md, .png). helm-charts subtree deferred.
   - lib_id: /grafana/tempo
+    description: Distributed tracing backend that ingests OpenTelemetry, Jaeger, and Zipkin formats with object-storage-only persistence (S3, GCS, Azure Blob).
     kind: github-md
     ref: 4dc3e5b0d3463a0b67498b662b85a148698b4afd
     urls:
@@ -1940,6 +2008,7 @@ libraries:
   # Deeper subtrees (manage/, configure/, get-started/, references/)
   # deferred — they would require their own dedicated PR.
   - lib_id: /grafana/mimir
+    description: Highly-scalable long-term storage for Prometheus metrics, supporting horizontal scaling, multi-tenancy, and cardinality at the billion-series scale.
     kind: github-md
     ref: cc1467ac91ae9358a46277660b20acae000163c5
     urls:
@@ -1956,6 +2025,7 @@ libraries:
   # is massive — every component gets its own page; deserves own PR),
   # set-up/, troubleshoot/, assets/, shared/.
   - lib_id: /grafana/alloy
+    description: Vendor-neutral OpenTelemetry Collector distribution from Grafana Labs, with built-in pipelines for Prometheus, Loki, Tempo, and Mimir.
     kind: github-md
     ref: e830b3be28412ab6c5659d8c238c208fffd7354a
     urls:
@@ -2008,6 +2078,7 @@ libraries:
   #   - extensions/, k6-studio/, grafana-cloud-k6/ (hosted-product)
   #   - reference/, results-output/, set-up/, release-notes/
   - lib_id: /grafana/k6
+    description: Load-testing tool scripted in JavaScript, designed for engineering teams to test API and web application performance under controlled traffic patterns.
     kind: github-md
     ref: d257660eb1be0efa1db7d9ddb5e3b54306798388
     urls:
@@ -2047,6 +2118,7 @@ libraries:
   # deploy-kubernetes/, reference-pyroscope-* (architecture refs),
   # reference-server-api/, release-notes/, upgrade-guide/.
   - lib_id: /grafana/pyroscope
+    description: Continuous profiling backend that aggregates and analyzes CPU, memory, and goroutine profiles across services for production performance debugging.
     kind: github-md
     ref: 4813c00d022f506d626e38e806f7bacf432865c5
     urls:
@@ -2074,6 +2146,7 @@ libraries:
   # tutorials directory is user-facing; developer/ is internal release
   # process, skipped.
   - lib_id: /grafana/faro-web-sdk
+    description: Frontend application observability SDK that captures errors, traces, and web vitals from browser apps and forwards them to Grafana Cloud or Tempo/Loki.
     kind: github-md
     ref: c96c565026503972eceae6c47d53fd81eaf9da75
     urls:

--- a/libraries_sources.yaml
+++ b/libraries_sources.yaml
@@ -163,7 +163,7 @@ libraries:
   # directly: no LLM extraction, no truncation, no verifier skips.
   # Tags ship without a "v" prefix.
   - lib_id: /fastapi/fastapi
-    description: Modern Python web framework for building APIs based on standard Python type hints, with automatic OpenAPI/Swagger documentation and async support.
+    description: Python web framework for building APIs based on standard Python type hints, with automatic OpenAPI/Swagger documentation and async support.
     kind: github-md
     versions:
       "0.134": { ref: 0.134.0 }
@@ -1101,7 +1101,7 @@ libraries:
   # middleware/builtin/. lib_id stays /honojs/hono (the lib repo) for
   # canonical naming; URLs target honojs/website. Same pattern as bun.
   - lib_id: /honojs/hono
-    description: Small, fast, edge-first JavaScript web framework built on Web Standards, runs on Cloudflare Workers, Deno, Bun, Node.js, and AWS Lambda.
+    description: JavaScript web framework built on Web Standards, runs on Cloudflare Workers, Deno, Bun, Node.js, and AWS Lambda.
     kind: github-md
     ref: 7cca6ae11bd538f8e2cf119ddb8646744becb60f
     urls:


### PR DESCRIPTION
## Summary

Resolves #191. Adds an optional `description:` field to entries in `libraries_sources.yaml` and mixes it into the libs-table embedding alongside the normalized `lib_id`, so `search_libraries` ranks on semantic intent instead of lib_id token overlap alone.

Also populates the 48 existing libs with hand-curated descriptions in the same PR so the value lands on the first `scrape-pack.yml` run after merge.

## Changes

### Schema + parser (`internal/scraper/config.go`)

- `LibrarySource.Description string` — top-level field, optional
- `VersionEntry.Description string` — per-version override; falls back to the parent `LibrarySource.Description` when empty
- `ResolvedSource.Description string` — threaded through Resolve so each (lib_id, version) carries its effective description down to the embedder
- Whitespace-only descriptions normalize to `""` at parse time at both levels (so `description: " "` doesn't accidentally suppress inheritance)
- Header doc block in `libraries_sources.yaml` extended to document the new field, including source-preference guidance and a fluff-prohibition note

### Embedder (`internal/db/db.go`)

- New `libEmbedText(libID, description string) string` helper — `normalizeLibIDText(libID)` when description is empty (legacy path, byte-for-byte identical), `normalizeLibIDText(libID) + " " + description` otherwise
- `UpsertLibIfNew` signature gains a `description` parameter
- `CurrentSchemaVersion` bumped 4 → 5; pre-existing v0.4.0 DBs are rejected via the existing `ErrSchemaMismatch` path (no new logic — the constant bump is enough)
- Doc-comment on `UpsertLibIfNew` updated to honestly retract the old "all versions of a lib_id rank identically" guarantee: still true when descriptions match or are both empty, but per-version description divergence intentionally produces distinct embeddings

### Tests

- `internal/scraper/config_test.go` covers all six description states: top-level present + non-empty, top-level absent, top-level whitespace-only, per-version override wins over top-level, per-version absent inherits, both absent → empty embed text
- `internal/db/db_test.go` adds tests asserting:
  - Two libs with similar lib_ids but different descriptions → cosine distance > 0.05
  - Same lib_id + same description → identical embedding (regression)
  - Empty description path produces the same embedding as the pre-change `lib_id`-only path (compat snapshot via `vector_distance_cos` against a freshly-computed reference vector)
  - Two versions of the same lib with different descriptions → distinct embeddings
  - Two versions with identical (or both-empty) descriptions → identical embeddings
- `consolidate_test.go` and `server_test.go` updated to align with the new `UpsertLibIfNew` signature
- `cmd/deadzone/scrape.go` (the only production caller) passes the resolved per-version description

### Corpus population

- All 48 entries in `libraries_sources.yaml` get a top-level `description:` (1-2 sentences each, ~100-220 chars). Source preference: upstream README first paragraph → GitHub repo description → official tagline.
- One per-version override added: `terraform/v1.14` carries a description noting "adds state encryption and ephemeral resources" — the divergent feature set vs `v1.13`. All other multi-version libs share their top-level description across versions.
- Marketing fluff audited and removed: fastapi dropped "Modern" (not in upstream tagline), hono aligned to upstream's "Web framework built on Web Standards" wording.

## Test plan

- [x] `just test -short` (CI: `lint`, `build`, `licenses` green; `test` job in progress at last check)
- [ ] **Manual MCP verification — DEFERRED to post-merge**, because the schema bump 4 → 5 means binaries with this change cannot read pre-bump DBs. The verification path is:
  1. Merge this PR
  2. Cut tag `v0.5.0`
  3. Wait for `release.yml` to publish binaries
  4. Trigger `scrape-pack.yml workflow_dispatch -f tag=v0.5.0` to publish a fresh DB with the new embedding semantics
  5. Run the four queries from #191's verification block and record the rankings:
     - `"rust async runtime"` → expect `/tokio-rs/tokio` top 3
     - `"log aggregation system"` → expect `/grafana/loki` AND `/open-telemetry/opentelemetry` both top 5
     - `"in-memory key value store"` → expect `/redis/redis` AND `/dragonflydb/dragonfly` both top 5
     - `"vector database"` → expect `/tursodatabase/turso` top 3
  Results to be posted as a comment on this PR or on issue #191 once the v0.5.0 DB is live.

## Migration / rollout

The schema bump (`CurrentSchemaVersion` 4 → 5) means existing v0.4.0 DBs will be rejected by binaries built from this PR. The standard release flow:

1. Merge this PR.
2. Cut new tag `v0.5.0`, push.
3. `release.yml` builds and publishes binaries.
4. `scrape-pack.yml workflow_dispatch -f tag=v0.5.0` publishes a fresh DB with the new embedding semantics.
5. Users on the new binary auto-fetch the new DB on first run; old v0.4.0 binary keeps working with v0.4.0 DB.

## Out of scope (per #191)

- Adding a `description:` column to the `libs` table
- Centroid-of-doc-embeddings
- A separate `tags:` or `category:` field
- Updating `search_docs` behavior
- Description weighting / repetition

---

Closes #191