### PR TITLE
fix: extract schema-version + embedder-signature as semantic cache-key signals (#193)

### DIFF
--- a/.github/workflows/cache-keepalive.yml
+++ b/.github/workflows/cache-keepalive.yml
@@ -55,13 +55,15 @@ jobs:
     outputs:
       libs: ${{ steps.list.outputs.libs }}
       # Exposed so the `report` job can reconstruct the full cache key
-      # (artifact-<slug>-<version>-<entry_cache_hash>-<hugot_hash>) to
-      # look up post-run hit/miss via the caches REST endpoint. The
-      # entry-level segment is per-row in `libs` (see #153); only the
-      # global trailing embedder hash is snapshotted here, since
-      # hashFiles() is a GHA expression function and cannot be computed
-      # in bash.
-      embedder_hash: ${{ steps.key.outputs.embedder_hash }}
+      # (artifact-<slug>-<version>-<entry_cache_hash>-emb<sig>-schema<n>)
+      # to look up post-run hit/miss via the caches REST endpoint. The
+      # entry-level segment is per-row in `libs` (see #153); the two
+      # global trailing signals are snapshotted here so the report job
+      # can build the same key without re-running the Go binary. Both
+      # come from `deadzone cache-signals` so the workflow stays in
+      # lockstep with the binary's source-of-truth (#193).
+      embedder_signature: ${{ steps.signals.outputs.embedder_signature }}
+      schema_version: ${{ steps.signals.outputs.schema_version }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -74,11 +76,23 @@ jobs:
         # No --lib input: keepalive always touches every resolved
         # (lib, version) pair.
         uses: ./.github/actions/list-libs
-      - name: Snapshot embedder hash
-        id: key
+      - name: Compute cache signals
+        id: signals
+        # Mirror of the same step in scrape-pack.yml — must stay in
+        # lockstep, otherwise the keepalive refreshes keys with a
+        # different shape than the live cache and the LRU evicts the
+        # live entries instead. See #193 for the bug the previous
+        # `hashFiles(internal/embed/hugot.go)` shape exhibited.
         shell: bash
         run: |
-          echo "embedder_hash=${{ hashFiles('internal/embed/hugot.go') }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          out=$(go run -tags ORT ./cmd/deadzone cache-signals)
+          schema=$(echo "$out" | jq -r '.schema_version')
+          sig=$(echo "$out" | jq -r '.embedder_signature')
+          [ -n "$schema" ] && [ "$schema" != "null" ] || { echo "::error::cache-signals output missing schema_version: $out"; exit 1; }
+          [ -n "$sig" ]    && [ "$sig"    != "null" ] || { echo "::error::cache-signals output missing embedder_signature: $out"; exit 1; }
+          echo "schema_version=$schema"     >> "$GITHUB_OUTPUT"
+          echo "embedder_signature=$sig"    >> "$GITHUB_OUTPUT"
 
   refresh:
     name: refresh (${{ matrix.entry.slug }})
@@ -99,11 +113,11 @@ jobs:
         # Mirror of scrape-pack.yml's per-lib cache key — drift breaks
         # the keepalive (different key = different cache entry = no
         # refresh, LRU evicts the live entry instead). Per-entry hash
-        # since #153.
+        # since #153; semantic global signals since #193.
         uses: actions/cache/restore@v5
         with:
           path: artifacts/${{ matrix.entry.slug }}
-          key: artifact-${{ matrix.entry.slug }}-${{ matrix.entry.version }}-${{ matrix.entry.cache_hash }}-${{ hashFiles('internal/embed/hugot.go') }}
+          key: artifact-${{ matrix.entry.slug }}-${{ matrix.entry.version }}-${{ matrix.entry.cache_hash }}-emb${{ needs.expand-libs.outputs.embedder_signature }}-schema${{ needs.expand-libs.outputs.schema_version }}
       - name: Record hit/miss
         # Per-slot summary row — satisfies the per-slot markdown
         # requirement from #128. The aggregated table + totals live in
@@ -141,7 +155,8 @@ jobs:
       - name: Aggregate hit/miss
         env:
           LIBS_JSON: ${{ needs.expand-libs.outputs.libs }}
-          EMBEDDER_HASH: ${{ needs.expand-libs.outputs.embedder_hash }}
+          EMBEDDER_SIGNATURE: ${{ needs.expand-libs.outputs.embedder_signature }}
+          SCHEMA_VERSION: ${{ needs.expand-libs.outputs.schema_version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         shell: bash
@@ -174,7 +189,7 @@ jobs:
           # this job reports phantom misses on entries that are actually
           # alive in the cache.
           while IFS=$'\t' read -r lib_id version slug cache_hash; do
-            expected="artifact-${slug}-${version}-${cache_hash}-${EMBEDDER_HASH}"
+            expected="artifact-${slug}-${version}-${cache_hash}-emb${EMBEDDER_SIGNATURE}-schema${SCHEMA_VERSION}"
             if printf '%s\n' "$caches" | grep -Fxq -- "$expected"; then
               status="hit"; hit=$((hit + 1))
             else

--- a/.github/workflows/scrape-pack.yml
+++ b/.github/workflows/scrape-pack.yml
@@ -107,6 +107,28 @@ jobs:
           key: ort-lib-${{ runner.os }}-${{ hashFiles('internal/ort/ort.go') }}
           restore-keys: |
             ort-lib-${{ runner.os }}-
+      - name: Compute cache signals
+        id: signals
+        # Two semantic invalidation signals emitted as JSON by the Go
+        # side — schema_version (db.CurrentSchemaVersion) and
+        # embedder_signature (hash of hugot.go's vector-space-affecting
+        # constants). Replaces hashFiles('internal/embed/hugot.go'),
+        # which over-invalidated on every refactor, AND covers schema
+        # bumps the file-hash approach missed entirely (#193). Adding
+        # any new vector-space-affecting constant in hugot.go means
+        # updating embed.HugotSignature() — a stability test in
+        # internal/embed/embed_test.go pins the digest so the change is
+        # forced into PR review, not slipped silently.
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(go run -tags ORT ./cmd/deadzone cache-signals)
+          schema=$(echo "$out" | jq -r '.schema_version')
+          sig=$(echo "$out" | jq -r '.embedder_signature')
+          [ -n "$schema" ] && [ "$schema" != "null" ] || { echo "::error::cache-signals output missing schema_version: $out"; exit 1; }
+          [ -n "$sig" ]    && [ "$sig"    != "null" ] || { echo "::error::cache-signals output missing embedder_signature: $out"; exit 1; }
+          echo "schema_version=$schema"     >> "$GITHUB_OUTPUT"
+          echo "embedder_signature=$sig"    >> "$GITHUB_OUTPUT"
       - name: Cache per-lib artifact
         id: artifact-cache
         uses: actions/cache@v5
@@ -115,11 +137,18 @@ jobs:
           # urls) for THIS entry only — emitted by `deadzone scrape --list`
           # in expand-libs above. Replaces the old hashFiles() over the
           # whole registry (#153): a URL edit on one lib now invalidates
-          # only that lib's cache instead of all 40+. Embedder hash stays
-          # global so a vector-space change still forces a rescrape in
-          # lockstep with the embedding model cache above.
+          # only that lib's cache instead of all 40+.
+          #
+          # The two -emb / -schema suffixes are global vector-space and
+          # DB-layout signals (see "Compute cache signals" above): a
+          # schema bump or any vector-space-affecting constant change
+          # invalidates the entire cache fleet in lockstep, in the same
+          # way the embedding model cache above does, but via a
+          # semantic source-of-truth rather than `hashFiles(hugot.go)`
+          # (which over-invalidated on pure refactors and missed schema
+          # bumps entirely — #193).
           path: artifacts/${{ matrix.entry.slug }}
-          key: artifact-${{ matrix.entry.slug }}-${{ matrix.entry.version }}-${{ matrix.entry.cache_hash }}-${{ hashFiles('internal/embed/hugot.go') }}
+          key: artifact-${{ matrix.entry.slug }}-${{ matrix.entry.version }}-${{ matrix.entry.cache_hash }}-emb${{ steps.signals.outputs.embedder_signature }}-schema${{ steps.signals.outputs.schema_version }}
       - name: Scrape (cache miss)
         if: steps.artifact-cache.outputs.cache-hit != 'true'
         shell: bash

--- a/cmd/deadzone/cache_signals.go
+++ b/cmd/deadzone/cache_signals.go
@@ -1,0 +1,77 @@
+package main
+
+// cache-signals is a CI-side hook for the per-lib artifact cache key
+// in scrape-pack.yml and cache-keepalive.yml. It prints a single-line
+// JSON object containing two semantic invalidation signals:
+//
+//   - schema_version    : db.CurrentSchemaVersion. Bumping it means
+//                         existing artifacts are at an incompatible
+//                         schema and must be rescraped.
+//   - embedder_signature: embed.HugotSignature(). Hash over the five
+//                         hugot.go constants that determine the
+//                         vector space — model identity, quantization
+//                         variant, retrieval prefixes. A constant edit
+//                         here means cached vectors live in a
+//                         different space than what the binary
+//                         produces and must be rescraped.
+//
+// Both are extracted directly from the Go side rather than re-derived
+// in bash so the cache key has a single source of truth that the
+// compiler audits at build time. See #193.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/laradji/deadzone/internal/db"
+	"github.com/laradji/deadzone/internal/embed"
+)
+
+var cacheSignalsCmd = &cobra.Command{
+	Use:   "cache-signals",
+	Short: "Print cache-key signals (schema_version, embedder_signature) as JSON for CI workflows",
+	Long: `Emits a single-line JSON object on stdout:
+
+  {"schema_version":N,"embedder_signature":"sha256hex"}
+
+scrape-pack.yml and cache-keepalive.yml consume this output to feed the
+per-lib artifact cache key, so any schema bump or embedder constant
+change invalidates the cache fleet in lockstep with the binary's
+guarantees.
+
+No flags. No model load. Sub-millisecond.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return writeCacheSignals(os.Stdout)
+	},
+}
+
+// writeCacheSignals serialises the two signals to w as a single line
+// of JSON. Split out from RunE so tests can pass a bytes.Buffer
+// without trampling os.Stdout.
+func writeCacheSignals(w io.Writer) error {
+	sig, err := embed.Signature(embed.KindHugot)
+	if err != nil {
+		return fmt.Errorf("compute embedder signature: %w", err)
+	}
+	out := struct {
+		SchemaVersion     int    `json:"schema_version"`
+		EmbedderSignature string `json:"embedder_signature"`
+	}{
+		SchemaVersion:     db.CurrentSchemaVersion,
+		EmbedderSignature: sig,
+	}
+	// json.Encoder appends a single trailing newline, which the
+	// `jq -r` consumers in the workflows expect.
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		return fmt.Errorf("encode cache signals: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(cacheSignalsCmd)
+}

--- a/cmd/deadzone/cache_signals_test.go
+++ b/cmd/deadzone/cache_signals_test.go
@@ -1,0 +1,52 @@
+package main
+
+// Tests for the `deadzone cache-signals` subcommand.
+//
+// The command is a thin glue layer between db.CurrentSchemaVersion and
+// embed.HugotSignature(); these tests assert it (a) emits valid JSON
+// (b) round-trips both fields with the expected types and (c) the
+// values match the underlying constants exactly. The point is to catch
+// drift between the Go source-of-truth and what CI workflows actually
+// see on stdout.
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/laradji/deadzone/internal/db"
+	"github.com/laradji/deadzone/internal/embed"
+)
+
+func TestWriteCacheSignals_OutputShape(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeCacheSignals(&buf); err != nil {
+		t.Fatalf("writeCacheSignals: %v", err)
+	}
+	out := buf.Bytes()
+
+	// Must be a single line of valid JSON ending in newline. Bash
+	// consumers in the workflow pipe through `jq -r '.field'`, which
+	// tolerates the trailing newline but not an extra one.
+	if !bytes.HasSuffix(out, []byte("\n")) {
+		t.Errorf("output should end with a newline; got %q", out)
+	}
+	if got := bytes.Count(out, []byte("\n")); got != 1 {
+		t.Errorf("output should be a single line; got %d newlines in %q", got, out)
+	}
+
+	var got struct {
+		SchemaVersion     int    `json:"schema_version"`
+		EmbedderSignature string `json:"embedder_signature"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if got.SchemaVersion != db.CurrentSchemaVersion {
+		t.Errorf("schema_version = %d, want %d (db.CurrentSchemaVersion)", got.SchemaVersion, db.CurrentSchemaVersion)
+	}
+	wantSig := embed.HugotSignature()
+	if got.EmbedderSignature != wantSig {
+		t.Errorf("embedder_signature = %q, want %q (embed.HugotSignature)", got.EmbedderSignature, wantSig)
+	}
+}

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -73,3 +73,19 @@ func New(kind string) (Embedder, error) {
 		return nil, fmt.Errorf("unknown embedder kind %q (valid: %s)", kind, KindHugot)
 	}
 }
+
+// Signature returns the deterministic vector-space signature for the
+// given embedder kind WITHOUT instantiating it (no model load, no
+// network). Mirrors New(kind) — same valid-kinds set, same error
+// shape on unknown kinds. Used by `deadzone cache-signals` to feed
+// the CI per-lib artifact cache key, so a constant edit in hugot.go
+// (model swap, quantization variant change, prefix tweak) invalidates
+// caches in lockstep without forcing a Hugot init at workflow time.
+func Signature(kind string) (string, error) {
+	switch kind {
+	case KindHugot:
+		return HugotSignature(), nil
+	default:
+		return "", fmt.Errorf("unknown embedder kind %q (valid: %s)", kind, KindHugot)
+	}
+}

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -206,3 +206,44 @@ func TestNew(t *testing.T) {
 		}
 	})
 }
+
+// TestHugotSignature_Stable pins the current vector-space signature so
+// any constant edit in hugot.go that affects embeddings forces an
+// explicit, diff-visible bump of this expected value. CI's per-lib
+// artifact cache key consumes this digest via `deadzone cache-signals`
+// — silently changing it would silently invalidate every cache in the
+// fleet, which is correct behavior but should be acknowledged in
+// review, not slipped in.
+//
+// If this test fails after a deliberate constant change in hugot.go:
+//  1. Re-run the digest computation (sha256 of NUL-joined parts) and
+//     paste the new value here.
+//  2. Mention the cache invalidation in the PR description.
+func TestHugotSignature_Stable(t *testing.T) {
+	const want = "5355f97f5ab70d53b2f89ab4fe51a284d0ef625e38bd78818362e853b212cdf3"
+	got := embed.HugotSignature()
+	if got != want {
+		t.Fatalf("HugotSignature drift:\n  got:  %s\n  want: %s\n\nIf this is intentional (you bumped a constant in hugot.go that affects the vector space), update the pinned value above and call out the cache invalidation in the PR description.", got, want)
+	}
+}
+
+// TestSignature_DispatchesByKind checks the Signature(kind) wrapper
+// mirrors New(kind) — same valid-kinds set, same error shape on
+// unknown kinds. The Hugot path delegates to HugotSignature, which
+// TestHugotSignature_Stable covers exhaustively.
+func TestSignature_DispatchesByKind(t *testing.T) {
+	t.Run("hugot returns the hugot signature", func(t *testing.T) {
+		got, err := embed.Signature(embed.KindHugot)
+		if err != nil {
+			t.Fatalf("Signature(hugot): %v", err)
+		}
+		if got != embed.HugotSignature() {
+			t.Errorf("Signature(hugot) = %q, want %q (HugotSignature)", got, embed.HugotSignature())
+		}
+	})
+	t.Run("unknown kind errors", func(t *testing.T) {
+		if _, err := embed.Signature("does-not-exist"); err == nil {
+			t.Fatal("expected error for unknown kind, got nil")
+		}
+	})
+}

--- a/internal/embed/hugot.go
+++ b/internal/embed/hugot.go
@@ -2,6 +2,8 @@ package embed
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -15,6 +17,36 @@ import (
 
 	"github.com/laradji/deadzone/internal/ort"
 )
+
+// HugotSignature returns a deterministic sha256-hex digest over every
+// hugot.go constant that affects the vector space the Hugot embedder
+// produces. Used as a CI cache-invalidation signal in scrape-pack.yml
+// so that bumping any one of these constants forces a corpus rescrape
+// in lockstep — independently of pure-refactor edits to hugot.go that
+// don't change the vector space (which a `hashFiles(hugot.go)` cache
+// key would have over-invalidated on).
+//
+// The function is package-level (no Embedder instance) so CI can call
+// it via `deadzone cache-signals` BEFORE the model download / ORT
+// init steps. Loading the actual model just to compute its identity
+// would defeat the cache layer's whole purpose.
+//
+// Adding a new vector-space-affecting constant later (e.g. a pooling
+// mode) means appending it to the parts slice here. The pinned
+// snapshot in TestHugotSignature_Stable fails on any digest change,
+// forcing the contributor to either confirm the cache invalidation is
+// intended or to roll back the change.
+func HugotSignature() string {
+	parts := []string{
+		KindHugot,
+		DefaultHugotModel,
+		onnxFilename,
+		queryPrefix,
+		documentPrefix,
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
 
 // KindHugot is the Kind() value reported by the Hugot embedder, and the only
 // kind currently accepted by New.


### PR DESCRIPTION
## Summary

Resolves #193. Replaces the file-hash cache-key signal in `scrape-pack.yml` and `cache-keepalive.yml` with a semantic source-of-truth emitted by a new `deadzone cache-signals` subcommand. Two latent invariants the previous shape violated:

1. **Schema bumps were invisible to the cache layer.** `db.CurrentSchemaVersion` wasn't part of the key. PR #192's bump 4→5 hit this live: caches HIT, schema-4 artifacts restored, consolidate failed with `validate artifact artifact.db: database schema version mismatch: stored=4 current=5`. v0.5.0 has no DB attached because of this. See run [25279026245](https://github.com/laradji/deadzone/actions/runs/25279026245).

2. **`hashFiles('internal/embed/hugot.go')` over-invalidated.** Hashing the whole file bust the cache on every edit, including refactors and comment fixes that didn't change the vector space. With hugot.go's 6-commit history, ~30-50% of edits triggered avoidable full-fleet rescrapes.

The new shape replaces the hash with two semantic signals:
- `schema_version` — `db.CurrentSchemaVersion` directly. Schema bump → cache invalidated in lockstep.
- `embedder_signature` — sha256-hex of the **five constants** in hugot.go that define the vector space (`KindHugot`, `DefaultHugotModel`, `onnxFilename`, `queryPrefix`, `documentPrefix`). Refactors that don't touch these preserve the cache; constant edits invalidate it.

## What changes

### Go side

- `internal/embed/hugot.go` — `HugotSignature()` free function returns sha256-hex of the five named constants joined by NUL. Sub-millisecond, no Embedder instance, no model load.
- `internal/embed/embed.go` — `Signature(kind string) (string, error)` wrapper mirrors `New(kind)`. Same valid-kinds set, same error shape on unknown kinds.
- `internal/embed/embed_test.go` — `TestHugotSignature_Stable` pins the current digest (`5355f97f5ab70d53b2f89ab4fe51a284d0ef625e38bd78818362e853b212cdf3`). Any future constant edit fails this test until the value is bumped, forcing the contributor to acknowledge cache invalidation in the PR description. `TestSignature_DispatchesByKind` covers the wrapper.
- `cmd/deadzone/cache_signals.go` — new `deadzone cache-signals` subcommand. Single-line JSON output: `{"schema_version":N,"embedder_signature":"<hex>"}`. Logic split into `writeCacheSignals(io.Writer)` so tests can use a `bytes.Buffer`.
- `cmd/deadzone/cache_signals_test.go` — verifies output shape (single line, valid JSON, types correct) and that both fields match the underlying constants exactly.

### Workflow side

- `.github/workflows/scrape-pack.yml` — new "Compute cache signals" step in the matrix scrape job. Per-lib cache key now ends in `-emb<sig>-schema<n>` instead of `-<hashFiles(hugot.go)>`.
- `.github/workflows/cache-keepalive.yml` — same step in the `expand-libs` job. Job outputs renamed `embedder_hash` → `embedder_signature` + new `schema_version`. Both the per-slot cache restore key (line ~106) and the report job's `expected="artifact-..."` bash construction (line ~177) updated to the new shape.

## Cache effect on next run

After this merges:
- All 48 libs **cache-MISS** once (cache key shape literally changed).
- Cold rescrape produces fresh schema-5 artifacts.
- Subsequent schema bumps OR hugot.go constant changes invalidate caches in lockstep automatically.
- Pure refactors in hugot.go that don't touch the five named constants **preserve** the cache (was over-invalidated before).

The mandatory cold-miss is the price of the shape change; from there on, the cache is more precise.

## Validation

- `go test -short ./internal/embed/... ./cmd/deadzone/...` → pass
- `go vet ./...` → clean
- Local smoke: `deadzone cache-signals` →
  ```json
  {"schema_version":5,"embedder_signature":"5355f97f5ab70d53b2f89ab4fe51a284d0ef625e38bd78818362e853b212cdf3"}
  ```

## Test plan

- [x] `TestHugotSignature_Stable` passes (pinned digest matches)
- [x] `TestSignature_DispatchesByKind` passes
- [x] `TestWriteCacheSignals_OutputShape` passes
- [x] `go vet ./...` clean
- [ ] CI green
- [ ] Post-merge: re-trigger `gh workflow run scrape-pack.yml -f tag=v0.5.0`. Expected: full cold rescrape (~10 min), consolidate succeeds, deadzone.db v0.5.0 attached.

## Why this scope (option C, not A or B)

Considered three approaches:

- **A. `hashFiles('internal/db/db.go')` + keep hashFiles(hugot.go)** — quick fix, but db.go is touched ~10x more often than hugot.go, and most edits don't bump the schema. Over-invalidation cost ~10 min CI per false positive on a hot file.
- **B. Bash-grep extracted constants** — precise, but fragile: a future contributor adds a new vector-space-affecting constant and forgets to update the regex → silent cache reuse with mismatched vectors.
- **C. Go-side semantic emit (this PR)** — the source-of-truth lives in the embedder package itself, audited by the compiler. Adding a new constant means updating `HugotSignature()` (one place), and the stability test forces the cache invalidation into PR review. No bash regex to maintain.

C costs ~50 lines more code than A but eliminates both bug classes (over-invalidation AND missed-invalidation) at the source.

## Out of scope

- Adding `Signature()` to the `Embedder` interface as an instance method. Free function suffices since the signature is determined by package-level constants. Promoting to interface method would force every implementation (Hugot today, future embedders tomorrow) to provide one — no current need.
- Removing the runtime `db.Meta` cross-check at `Open` time. The cache-key change makes the CI side correct; the runtime check is a different defense layer.

Closes #193