### PR TITLE
feat: publish multi-arch OCI image to ghcr.io alongside tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,9 +269,183 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # Multi-arch OCI image published to GHCR alongside the existing tarball
+  # / AppImage / Homebrew artifacts (#196). Strictly additive — the
+  # tarball + AppImage paths still ship as today; this job adds a third
+  # install path documented in README.
+  #
+  # The Dockerfile does no compilation; the per-arch binaries from the
+  # `build` matrix are downloaded as artifacts and COPYd in. libonnxruntime
+  # is fetched at job time using `./deadzone ort-meta` to read the pinned
+  # URL/SHA from the binary's own constants (internal/ort.pinnedReleases) —
+  # no parallel YAML copy that could drift on a future ORT bump.
+  #
+  # `needs: smoke` means: only image binaries that already proved they
+  # launch on a clean runner. `release` (below) gains a `needs: docker`
+  # entry so the Release object isn't published until the OCI push has
+  # succeeded — a tag landing without its image is the failure mode we
+  # explicitly avoid.
+  docker:
+    name: docker (ghcr.io)
+    needs: smoke
+    runs-on: ubuntu-24.04
+    # `packages: write` is required for the GHCR push via GITHUB_TOKEN.
+    # `contents: read` is the default; making it explicit signals that
+    # this job reads source (the Dockerfile + actions) and nothing else.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: deadzone-linux-*
+          merge-multiple: true
+          path: dist-tarballs
+
+      - name: Resolve version metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Mirror the build/release jobs: tag push → tag name, dispatch → git describe.
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="$(git describe --tags --dirty --always)"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      # Lay out dist/linux_<arch>/{deadzone, lib/} for both arches so
+      # the Dockerfile's COPY dist/linux_${TARGETARCH}/... finds what it
+      # expects under each buildx platform. The amd64 binary runs on
+      # the runner directly to call ./deadzone ort-meta — single source
+      # of truth for the ORT URL/SHA per arch.
+      - name: Stage build context
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          for arch in amd64 arm64; do
+            tar -xzf "dist-tarballs/deadzone_${VERSION}_linux_${arch}.tar.gz" -C /tmp
+            mkdir -p "dist/linux_${arch}/lib"
+            mv "/tmp/deadzone_${VERSION}_linux_${arch}/deadzone" "dist/linux_${arch}/deadzone"
+            chmod +x "dist/linux_${arch}/deadzone"
+          done
+          # ort-meta is CGO-linked through hugot but only reads the
+          # pinned-constants table — no embedder load, no network. Run
+          # the amd64 binary on the amd64 runner and reuse its JSON
+          # output for both arches.
+          meta=$(./dist/linux_amd64/deadzone ort-meta)
+          echo "${meta}"
+          for arch in amd64 arm64; do
+            url=$(echo "${meta}" | jq -r --arg a "${arch}" '.platforms[] | select(.goarch==$a) | .url')
+            sha=$(echo "${meta}" | jq -r --arg a "${arch}" '.platforms[] | select(.goarch==$a) | .sha256')
+            test -n "${url}" && test -n "${sha}" || { echo "ort-meta missing entry for linux/${arch}" >&2; exit 1; }
+            tmp=$(mktemp -d)
+            curl -fL -o "${tmp}/ort.tgz" "${url}"
+            echo "${sha}  ${tmp}/ort.tgz" | sha256sum -c -
+            tar -C "${tmp}" -xzf "${tmp}/ort.tgz"
+            # Copy both the real ELF (libonnxruntime.so.<version>) and
+            # the unversioned symlink alias — distroless has no
+            # ldconfig so dlopen needs the file present under the
+            # exact name hugot's WithOnnxLibraryPath asks for.
+            find "${tmp}" -maxdepth 4 \( -type f -o -type l \) -name 'libonnxruntime.so*' -exec cp -P {} "dist/linux_${arch}/lib/" \;
+            ls -l "dist/linux_${arch}/lib/"
+            rm -rf "${tmp}"
+          done
+
+      # QEMU is needed for the runtime smoke (`docker run --platform
+      # linux/arm64 …` on an amd64 runner). The buildx build itself
+      # doesn't need it — the Dockerfile only does COPY, no RUN.
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Compute the lowercased image ref so the `latest` and `<tag>`
+      # tags are valid (GHCR rejects mixed-case repo paths). github.repository
+      # carries the canonical owner/name, which may include capitals.
+      - name: Compute image ref
+        id: img
+        shell: bash
+        run: |
+          set -euo pipefail
+          ref="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+      # On a tag push: publish to ghcr with both <tag> and :latest. On
+      # workflow_dispatch (dry-run): build the multi-arch manifest in
+      # the buildx cache without --push so the staging steps and
+      # Dockerfile validity are exercised end-to-end without touching
+      # the registry. Smoke steps below skip when the image isn't
+      # pushed because docker run can't reach a buildx-cached image
+      # by reference.
+      - name: Build + push multi-arch image
+        id: build_push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+          tags: |
+            ${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }}
+            ${{ steps.img.outputs.ref }}:latest
+          labels: |
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      # Four smoke steps, one per (arch, mode) pair. The --version path
+      # short-circuits before DB load and runs with --network none — it
+      # proves libonnxruntime is dlopen-able and the binary boots
+      # inside the distroless rootfs. The server path requires network
+      # so the first run can fetch deadzone.db from the matching GH
+      # Release (this is the same first-launch flow native users get).
+      #
+      # Skipped on dry-run dispatch because the image isn't pushed and
+      # docker run can't address a buildx-only build by name.
+      - name: Smoke amd64 --version (offline)
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        run: docker run --rm --platform linux/amd64 --network none ${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }} --version
+
+      - name: Smoke arm64 --version (offline)
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        run: docker run --rm --platform linux/arm64 --network none ${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }} --version
+
+      - name: Smoke amd64 server (online, fetches DB)
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        shell: bash
+        run: |
+          set -euo pipefail
+          init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"1"}}}'
+          out=$(echo "${init}" | docker run --rm -i --platform linux/amd64 ${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }} server)
+          echo "${out}"
+          echo "${out}" | grep -q '"name":"deadzone"'
+
+      - name: Smoke arm64 server (online, fetches DB)
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        shell: bash
+        run: |
+          set -euo pipefail
+          init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"1"}}}'
+          out=$(echo "${init}" | docker run --rm -i --platform linux/arm64 ${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }} server)
+          echo "${out}"
+          echo "${out}" | grep -q '"name":"deadzone"'
+
   release:
     name: publish release
-    needs: [build, smoke, appimage]
+    needs: [build, smoke, appimage, docker]
     runs-on: ubuntu-24.04
     # The job runs for both tag pushes and workflow_dispatch so the
     # dry-run path can validate the tarball aggregation on a branch.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,85 @@
+# syntax=docker/dockerfile:1.7
+#
+# Deadzone OCI image — packaging only, no compilation. The native
+# binaries (one per linux arch) are produced upstream by release.yml's
+# `build` job from `just build-release` on a real linux runner; this
+# Dockerfile downloads the matching tarball + libonnxruntime, lays them
+# out, and emits a distroless image. Multi-arch via `docker buildx
+# build --platform linux/amd64,linux/arm64` — TARGETARCH selects the
+# right per-arch dist/ subdir at build time.
+#
+# Why distroless: no shell, no package manager, ~25 MB base. Smaller
+# attack surface than debian-slim and the user-facing pitch matches
+# what the brew tap / tarball install give: a single binary + libs, no
+# system packages.
+#
+# Why no DB baked: deadzone.db is fetched on first `server` launch from
+# the GitHub Release matching the binary's compiled-in version (see
+# internal/db/bootstrap.go). Baking it would chain `docker` → `release`
+# → re-tag with a window where :latest points at a binary-only image,
+# and would prevent an out-of-band `dbrelease` re-upload from reaching
+# image users without a fresh image push. Tradeoff: --network none
+# fails on first launch, which is fine for the MCP-client use case
+# where network is the default.
+
+ARG TARGETARCH
+
+# Stage 1 — collect the per-arch payload from the build context. Alpine
+# is the cheapest image with a real `cp`; the staging stage exists so
+# the final image carries no traces of the source paths or unused
+# context files. Each arch reads from dist/linux_${TARGETARCH}/, which
+# CI populates from actions/download-artifact + a curl of the pinned
+# libonnxruntime tarball (see release.yml's `Stage build context` step).
+FROM alpine:3 AS staging
+ARG TARGETARCH
+WORKDIR /staged
+COPY dist/linux_${TARGETARCH}/deadzone /staged/deadzone
+# Both libonnxruntime.so (symlink) and libonnxruntime.so.<version>
+# (real ELF) must land — distroless has no ldconfig, so dlopen
+# resolves whichever name hugot's options.WithOnnxLibraryPath was
+# given against the file directly. Globbing keeps the Dockerfile
+# version-agnostic so an ORT bump only touches internal/ort.
+COPY dist/linux_${TARGETARCH}/lib/ /staged/lib/
+COPY LICENSE NOTICE README.md /staged/
+
+# Stage 2 — final distroless image. cc-debian12 ships glibc + libgcc
+# (libonnxruntime needs both); :nonroot creates uid/gid 65532 with
+# HOME=/home/nonroot and an entrypoint that runs as that uid.
+FROM gcr.io/distroless/cc-debian12:nonroot
+COPY --from=staging /staged/deadzone /usr/local/bin/deadzone
+COPY --from=staging /staged/lib/     /usr/local/lib/
+COPY --from=staging /staged/LICENSE /staged/NOTICE /staged/README.md /
+
+# DEADZONE_ORT_LIB_PATH is a *directory* (see internal/ort/ort.go's
+# Bootstrap — the env var short-circuits to whatever path is given
+# verbatim, and hugot's options.WithOnnxLibraryPath walks it for the
+# right LibName). Pointing at the .so file itself silently breaks
+# resolution. Setting this here means internal/ort.Bootstrap returns
+# from cache without making any network call, which is what makes
+# `docker run --network none ... --version` a meaningful smoke test.
+ENV DEADZONE_ORT_LIB_PATH=/usr/local/lib
+
+# Pin HOME so the XDG fallback in internal/db.DefaultCacheDir lands
+# at /home/nonroot/.local/share/deadzone/deadzone.db (writable by the
+# nonroot user). Distroless sets HOME implicitly via passwd, but being
+# explicit guards against future base-image changes that drop the
+# /etc/passwd entry.
+ENV HOME=/home/nonroot
+
+# OCI labels — image.version is appended at build time via
+# docker/build-push-action's `labels:` input (see release.yml). The
+# rest are stable across releases and live here so a `docker inspect`
+# of any tag carries the provenance even if a future CI change forgets
+# to re-set them.
+LABEL org.opencontainers.image.source="https://github.com/laradji/deadzone"
+LABEL org.opencontainers.image.title="deadzone"
+LABEL org.opencontainers.image.description="Local-first MCP doc server with semantic search"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+# Required by the official MCP Registry to verify ownership when the
+# follow-up registry submission lands. Adding it now means the image
+# is registry-eligible from day one without a re-publish.
+# Source: https://modelcontextprotocol.io/registry/package-types
+LABEL io.modelcontextprotocol.server.name="io.github.laradji/deadzone"
+
+ENTRYPOINT ["/usr/local/bin/deadzone"]
+CMD ["server"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ curl -L "https://github.com/laradji/deadzone/releases/download/${VERSION}/deadzo
 
 Both flavors land a `deadzone` executable in your current directory, so the `./deadzone server` snippet below works as-is.
 
+```sh
+# Container — multi-arch (linux/amd64 + linux/arm64), auto-fetches the DB on first run
+docker pull ghcr.io/laradji/deadzone:latest
+docker run --rm -i ghcr.io/laradji/deadzone:latest server
+```
+
+The image bakes the binary plus `libonnxruntime` and runs as a non-root user out of [distroless](https://github.com/GoogleContainerTools/distroless) (no shell, no package manager). On first launch `deadzone server` downloads `deadzone.db` (~50 MB) from the GitHub Release matching the binary's compiled-in version, SHA256-verifies, and caches it under the container's data dir; subsequent runs are zero-network. To refresh the index, pull a newer tag.
+
 Windows is blocked upstream — no `libtokenizers.a`. Use WSL.
 
 **Verify checksums** (optional but cheap):

--- a/cmd/deadzone/ort_meta.go
+++ b/cmd/deadzone/ort_meta.go
@@ -1,0 +1,83 @@
+package main
+
+// ort-meta is a hidden CI-plumbing subcommand introduced in #196 to keep
+// the OCI image build (release.yml's docker job + the docker-build
+// justfile recipe) reading the pinned onnxruntime URL/SHA256/library
+// filename from the same source of truth Bootstrap uses
+// (internal/ort.pinnedReleases). Without this command the docker job
+// would have to hardcode a parallel copy of those constants in YAML,
+// and a future ORT bump that updated only internal/ort would silently
+// publish images linking against the wrong .so version.
+//
+// Hidden: true keeps it out of `--help` because it is not a user-facing
+// verb — it is plumbing that the build pipeline shells out to. The JSON
+// shape is the contract; treat changes to it as breaking the pipeline.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/laradji/deadzone/internal/ort"
+)
+
+// ortMetaPlatform is one entry in the JSON output. Field tags use the
+// snake_case shape jq one-liners read most cleanly.
+type ortMetaPlatform struct {
+	GOOS    string `json:"goos"`
+	GOARCH  string `json:"goarch"`
+	URL     string `json:"url"`
+	SHA256  string `json:"sha256"`
+	LibName string `json:"lib_name"`
+}
+
+type ortMetaOutput struct {
+	Version   string            `json:"version"`
+	Platforms []ortMetaPlatform `json:"platforms"`
+}
+
+var ortMetaCmd = &cobra.Command{
+	Use:    "ort-meta",
+	Short:  "Print pinned onnxruntime release metadata as JSON (CI plumbing)",
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runOrtMeta(cmd.OutOrStdout())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(ortMetaCmd)
+}
+
+func runOrtMeta(w io.Writer) error {
+	out := ortMetaOutput{Version: ort.Version}
+	for _, plat := range ort.SupportedPlatforms() {
+		// Only the linux arches are stageable into the OCI image;
+		// emitting darwin/windows would tempt callers to bake them too
+		// and surface confusing "no such platform" errors when they
+		// try. Filter here, not at call site.
+		if !strings.HasPrefix(plat, "linux/") {
+			continue
+		}
+		parts := strings.SplitN(plat, "/", 2)
+		url, sum, lib, ok := ort.PinnedRelease(parts[0], parts[1])
+		if !ok {
+			// SupportedPlatforms returned this key, so this branch is
+			// unreachable barring an internal contract violation.
+			return fmt.Errorf("ort-meta: SupportedPlatforms listed %q but PinnedRelease returned ok=false", plat)
+		}
+		out.Platforms = append(out.Platforms, ortMetaPlatform{
+			GOOS:    parts[0],
+			GOARCH:  parts[1],
+			URL:     url,
+			SHA256:  sum,
+			LibName: lib,
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}

--- a/cmd/deadzone/ort_meta_test.go
+++ b/cmd/deadzone/ort_meta_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/laradji/deadzone/internal/ort"
+)
+
+// TestOrtMetaJSONShape locks the JSON contract that release.yml's
+// docker job and the docker-build justfile recipe parse with jq. A
+// breaking change here breaks the OCI image build before it can fail
+// loud at `docker buildx build` time, so the test is the cheapest place
+// to catch it.
+func TestOrtMetaJSONShape(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runOrtMeta(&buf); err != nil {
+		t.Fatalf("runOrtMeta: %v (output: %s)", err, buf.String())
+	}
+
+	var out ortMetaOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode JSON: %v (output: %s)", err, buf.String())
+	}
+
+	if out.Version != ort.Version {
+		t.Errorf("version = %q, want %q", out.Version, ort.Version)
+	}
+
+	// Both linux arches must be present and only linux entries — the
+	// OCI image is Linux-only, and emitting darwin/windows would
+	// tempt callers to bake them.
+	have := map[string]ortMetaPlatform{}
+	for _, p := range out.Platforms {
+		key := p.GOOS + "/" + p.GOARCH
+		have[key] = p
+		if p.GOOS != "linux" {
+			t.Errorf("non-linux platform %q in output (must be filtered out)", key)
+		}
+		if !strings.Contains(p.URL, "/v"+ort.Version+"/") {
+			t.Errorf("%s: url missing /v%s/ segment: %q", key, ort.Version, p.URL)
+		}
+		if len(p.SHA256) != 64 {
+			t.Errorf("%s: sha256 length = %d, want 64", key, len(p.SHA256))
+		}
+		if p.LibName == "" {
+			t.Errorf("%s: lib_name empty", key)
+		}
+	}
+	for _, want := range []string{"linux/amd64", "linux/arm64"} {
+		if _, ok := have[want]; !ok {
+			t.Errorf("output missing platform %q (have: %v)", want, have)
+		}
+	}
+}

--- a/docs/research/ingestion-architecture.md
+++ b/docs/research/ingestion-architecture.md
@@ -311,6 +311,14 @@ The per-artifact upload/download/list code initially landed disabled-in-place af
 
 The folder-per-lib layout (addendum to decision 2) is orthogonal to this v2 — it landed in the same PR as part of #101 to unblock #64 but stays useful regardless of the distribution pipeline.
 
+### v3 (2026-05-04, #196): OCI image on GHCR as an additional channel
+
+A multi-arch (`linux/amd64` + `linux/arm64`) OCI image is now published to `ghcr.io/laradji/deadzone:<tag>` and `:latest` on every release tag, alongside (not in place of) the existing tarball / AppImage / Homebrew tap artifacts. The driver was eligibility for the official MCP Registry (`registry.modelcontextprotocol.io`), which only accepts `npm` / `pypi` / `nuget` / `oci` (Docker Hub or GHCR) packages — raw GitHub Releases binaries are invisible to it. GHCR-only because it reuses the existing `GITHUB_TOKEN` auth path and because Docker Hub adds a second account/secret/namespace for no Tier-1 registry coverage that GHCR doesn't already provide.
+
+The image bakes the binary plus `libonnxruntime` at `/usr/local/lib/` (with `DEADZONE_ORT_LIB_PATH` pointing there so `internal/ort.Bootstrap` returns from cache without any network call), but **does not bake `deadzone.db`**. First `server` launch inside the container fetches the DB from the matching GH Release via the same `internal/db.BootstrapWithOptions` flow as the native binary — one mental model across brew / tarball / image. The tradeoff (no offline first launch inside `--network none`) is acceptable because MCP clients run with full network access by default, and the `--version` short-circuit still works offline (which is what release.yml's per-arch image smoke verifies).
+
+The image is built in a new `docker` job in `release.yml` between `smoke` and `release`, gated `needs: smoke` (so the binary is already proven to launch) and feeding `release.needs += docker` (so the GH Release object isn't published before the OCI push completes). The `Dockerfile` does no compilation — it `COPY`s the per-arch binaries produced upstream by the existing `build` matrix, plus the pinned `libonnxruntime` archive fetched at job time using `./deadzone ort-meta` (a hidden subcommand that prints the URL/SHA from the same `internal/ort.pinnedReleases` table `Bootstrap` uses), so #70's "native runners only, no goreleaser-cross" decision is unaffected.
+
 ---
 
 ## 6. Reasoning-mode suppression in the agent path (#60)

--- a/internal/ort/ort.go
+++ b/internal/ort/ort.go
@@ -31,6 +31,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 )
@@ -228,6 +229,37 @@ func DefaultCacheDir() string {
 func Supported() bool {
 	_, ok := pinnedReleases[runtime.GOOS+"/"+runtime.GOARCH]
 	return ok
+}
+
+// PinnedRelease returns the GitHub-release archive URL, hex SHA256, and
+// expected library filename for the onnxruntime build pinned to Version
+// on the given GOOS+GOARCH. ok is false when no entry exists.
+//
+// Out-of-band stagers (the OCI image build, air-gapped install scripts)
+// use this to fetch the same archive Bootstrap would, without
+// duplicating the URL / SHA256 / filename in their own configs. archiveKind
+// stays unexported because callers operating outside Bootstrap should
+// not branch on it — the on-disk shape after extraction is what matters,
+// not the wrapper format.
+func PinnedRelease(goos, goarch string) (url, sha256, libName string, ok bool) {
+	rel, found := pinnedReleases[goos+"/"+goarch]
+	if !found {
+		return "", "", "", false
+	}
+	archive := strings.ReplaceAll(rel.Archive, "{version}", Version)
+	return releaseBaseURL + "/v" + Version + "/" + archive, rel.SHA256, rel.LibName, true
+}
+
+// SupportedPlatforms returns "goos/goarch" keys with a pinned release,
+// in deterministic alphabetical order so callers (CI, doc generation)
+// get stable output across runs.
+func SupportedPlatforms() []string {
+	out := make([]string, 0, len(pinnedReleases))
+	for k := range pinnedReleases {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // downloadAndExtract streams url through a sha256 hasher while

--- a/internal/ort/ort_test.go
+++ b/internal/ort/ort_test.go
@@ -286,3 +286,55 @@ func buildFakeArchive(t *testing.T, rel release) ([]byte, string) {
 	sum := sha256.Sum256(buf.Bytes())
 	return buf.Bytes(), hex.EncodeToString(sum[:])
 }
+
+// TestPinnedRelease covers the narrow public API the OCI image build
+// reads via `deadzone ort-meta`. We assert that the URL, sha, and lib
+// filename returned by PinnedRelease for each linux arch match the
+// pinnedReleases table verbatim — if a future bump forgets to refresh
+// either side, this test fails before CI ever pushes a broken image.
+func TestPinnedRelease(t *testing.T) {
+	for _, plat := range []string{"linux/amd64", "linux/arm64"} {
+		parts := strings.SplitN(plat, "/", 2)
+		url, sum, lib, ok := PinnedRelease(parts[0], parts[1])
+		if !ok {
+			t.Fatalf("%s: PinnedRelease returned ok=false", plat)
+		}
+		want := pinnedReleases[plat]
+		wantArchive := strings.ReplaceAll(want.Archive, "{version}", Version)
+		wantURL := releaseBaseURL + "/v" + Version + "/" + wantArchive
+		if url != wantURL {
+			t.Errorf("%s: url = %q, want %q", plat, url, wantURL)
+		}
+		if sum != want.SHA256 {
+			t.Errorf("%s: sha256 = %q, want %q", plat, sum, want.SHA256)
+		}
+		if lib != want.LibName {
+			t.Errorf("%s: libName = %q, want %q", plat, lib, want.LibName)
+		}
+	}
+	if _, _, _, ok := PinnedRelease("plan9", "mips"); ok {
+		t.Errorf("PinnedRelease(plan9/mips) returned ok=true, want false")
+	}
+}
+
+// TestSupportedPlatforms guards the contract the ort-meta subcommand
+// relies on: the slice is sorted (deterministic CI output) and contains
+// at least the two linux arches the OCI image targets.
+func TestSupportedPlatforms(t *testing.T) {
+	got := SupportedPlatforms()
+	for i := 1; i < len(got); i++ {
+		if got[i-1] >= got[i] {
+			t.Errorf("SupportedPlatforms not sorted: %v", got)
+			break
+		}
+	}
+	have := map[string]bool{}
+	for _, p := range got {
+		have[p] = true
+	}
+	for _, want := range []string{"linux/amd64", "linux/arm64"} {
+		if !have[want] {
+			t.Errorf("SupportedPlatforms missing %q (got %v)", want, got)
+		}
+	}
+}

--- a/justfile
+++ b/justfile
@@ -182,8 +182,76 @@ fetch-db force="": _check-tokenizers
     CGO_ENABLED=1 CGO_LDFLAGS="-L{{tokenizers_lib}}" \
         mise exec -- go run -tags ORT ./cmd/deadzone fetch-db {{ if force != "" { "--force" } else { "" } }}
 
+# Pipeline of docker-build:
+#   1. `just build-release` — produces ./deadzone for the host arch
+#   2. `./deadzone ort-meta` — emits the pinned ORT URL/SHA for each linux arch
+#   3. curl + sha256 verify the libonnxruntime tarball
+#   4. stage binary + lib into dist/linux_${arch}/
+#   5. docker buildx build --load (single-arch; multi-arch happens only in CI)
+#
+# `--load` brings the image into the local docker daemon so `docker run
+# deadzone:dev` works without a registry push. The CI flow uses --push
+# instead and skips this recipe entirely.
+
+# Build the OCI image locally for the host arch only, tagged `deadzone:dev` (Linux host required; cross-compile from darwin is blocked by #70)
+docker-build: _check-tokenizers
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "$(uname -s)" != "Linux" ]]; then
+        echo "error: docker-build requires a Linux host — the staged binary is embedded into a Linux image and #70 blocks CGO cross-compile from darwin/windows." >&2
+        echo "       Workarounds: run inside a Linux dev container/VM, or rely on the release.yml docker job for end-to-end testing." >&2
+        exit 1
+    fi
+    arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/;s/arm64/arm64/')
+    case "${arch}" in amd64|arm64) ;; *) echo "unsupported host arch: ${arch}" >&2; exit 1 ;; esac
+    just build-release
+    # Pull the pinned ORT URL/SHA/lib name from the binary (single source of truth — internal/ort.pinnedReleases).
+    meta=$(./deadzone ort-meta)
+    url=$(echo "${meta}" | jq -r --arg a "${arch}" '.platforms[] | select(.goarch==$a) | .url')
+    sha=$(echo "${meta}" | jq -r --arg a "${arch}" '.platforms[] | select(.goarch==$a) | .sha256')
+    if [ -z "${url}" ] || [ -z "${sha}" ]; then
+        echo "error: ort-meta returned no entry for linux/${arch}" >&2
+        exit 1
+    fi
+    ctx="dist/linux_${arch}"
+    rm -rf "${ctx}"
+    mkdir -p "${ctx}/lib"
+    cp ./deadzone "${ctx}/deadzone"
+    tmp=$(mktemp -d)
+    trap 'rm -rf "${tmp}"' EXIT
+    echo "fetching ${url}"
+    curl -fL -o "${tmp}/ort.tgz" "${url}"
+    echo "${sha}  ${tmp}/ort.tgz" | sha256sum -c -
+    # Flatten lib/libonnxruntime.so* (real ELF + symlink alias) out of
+    # the upstream */lib/ subdir into our staging dir.
+    tar -C "${tmp}" -xzf "${tmp}/ort.tgz"
+    find "${tmp}" -type f -name 'libonnxruntime.so*' -exec cp -P {} "${ctx}/lib/" \;
+    find "${tmp}" -type l -name 'libonnxruntime.so*' -exec cp -P {} "${ctx}/lib/" \;
+    docker buildx build --platform "linux/${arch}" --load -t deadzone:dev .
+    echo "built deadzone:dev for linux/${arch}"
+
+# Network-enabled because the first `server` launch inside the image
+# fetches deadzone.db from the matching GH Release; subsequent runs
+# reuse the on-disk cache (which is per-container, so every fresh
+# `docker run` re-fetches unless the cache dir is volume-mounted).
+
+# Smoke the local `deadzone:dev` image with an MCP `initialize` handshake (requires `just docker-build` first; network-enabled, see comment above)
+docker-smoke:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"1"}}}'
+    out=$(echo "${init}" | docker run --rm -i deadzone:dev server)
+    echo "${out}"
+    # Two anchors: the server name proves the implementation is wired,
+    # the protocolVersion echo proves the handshake reached a real
+    # initialize handler (not a generic JSON-RPC error response).
+    echo "${out}" | grep -q '"name":"deadzone"' || { echo "smoke FAIL: missing name=deadzone" >&2; exit 1; }
+    echo "${out}" | grep -q '"protocolVersion":"2025-06-18"' || { echo "smoke FAIL: missing protocolVersion=2025-06-18" >&2; exit 1; }
+    echo "docker-smoke OK"
+
 # Remove the built binary, per-lib artifact folders, and the local DB files (preserves artifacts/manifest.yaml)
 clean:
     rm -f deadzone
     rm -f deadzone.db deadzone.db-wal deadzone.db-shm deadzone.db.sha256
     rm -rf artifacts/*/
+    rm -rf dist/


### PR DESCRIPTION
## Summary

Adds a third install channel — a multi-arch (`linux/amd64` + `linux/arm64`) OCI image published to `ghcr.io/laradji/deadzone:<tag>` and `:latest` — strictly additive on top of the existing tarball, AppImage, and Homebrew tap artifacts. Driver: eligibility for the official MCP Registry, which only accepts `npm` / `pypi` / `nuget` / `oci` packages; raw GitHub Releases binaries are invisible to it.

## What lands

- **`Dockerfile`** — distroless (`gcr.io/distroless/cc-debian12:nonroot`), no compilation. `COPY`s the per-arch binary produced by the existing `build` matrix plus the pinned `libonnxruntime` (real ELF + symlink alias) into `/usr/local/lib/`, sets `DEADZONE_ORT_LIB_PATH` so `internal/ort.Bootstrap` short-circuits without a network call, runs as `nonroot`. **DB is not baked** — first `server` launch fetches `deadzone.db` from the matching GH Release via the same `internal/db.BootstrapWithOptions` flow as the native binary (one mental model across brew / tarball / image).
- **`.github/workflows/release.yml`** — new `docker` job between `smoke` and `release`, gated `needs: smoke` and feeding `release.needs += docker` so the GH Release object is never published before the OCI push completes. Uses `docker/build-push-action` with `--push` on tag pushes only; `workflow_dispatch` builds the manifest into the buildx cache for dry-run validation.
- **`cmd/deadzone/ort-meta`** — hidden CI-plumbing subcommand that emits the pinned ORT URL/SHA256/lib-name as JSON, read by both the workflow's `Stage build context` step and the `just docker-build` recipe. Single source of truth: `internal/ort.pinnedReleases`. No parallel YAML copy that could drift on a future ORT bump.
- **`internal/ort`** — exports `PinnedRelease(goos, goarch)` and `SupportedPlatforms()` to back `ort-meta` without leaking the unexported `archiveKind`.
- **`justfile`** — `docker-build` (Linux host only; #70 blocks darwin cross-compile) and `docker-smoke` (MCP `initialize` handshake against `deadzone:dev`).
- **README + `docs/research/ingestion-architecture.md` v3 entry** — install snippet and decision-log entry covering GHCR-only choice and the no-bake-DB tradeoff.

## CI smoke matrix

Four image-level smoke steps run on tag pushes (skipped on dry-run dispatch since `docker run` can't address a buildx-only build by name):

- `amd64 --version` with `--network none` — proves `libonnxruntime` is `dlopen`-able and the binary boots inside distroless.
- `arm64 --version` with `--network none` — same, via QEMU.
- `amd64 server` online — full `initialize` handshake, exercises first-launch DB fetch.
- `arm64 server` online — same, via QEMU.

## Test plan

- [ ] `just docker-build && just docker-smoke` on a Linux host passes
- [ ] `workflow_dispatch` dry-run on a branch builds the multi-arch manifest without pushing
- [ ] On a real tag push, `ghcr.io/laradji/deadzone:<tag>` and `:latest` appear and pull cleanly on both arches
- [ ] `docker run --rm --network none ghcr.io/laradji/deadzone:<tag> --version` exits 0
- [ ] `docker run --rm -i ghcr.io/laradji/deadzone:<tag> server` answers an MCP `initialize` request after fetching the DB
- [ ] `docker inspect` shows `org.opencontainers.image.version=<tag>` and `io.modelcontextprotocol.server.name=io.github.laradji/deadzone`

<!-- emdash-issue-footer:start -->
Fixes #196
<!-- emdash-issue-footer:end -->