### PR TITLE
feat(db): boot-time auto-update probe with JSON sidecar v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,14 @@ The binary itself is CGO-linked (hugot ORT backend + static `libtokenizers.a`). 
 
 Escape hatches for air-gapped boxes:
 
-| Env var                   | Effect                                                      |
-|---------------------------|-------------------------------------------------------------|
-| `DEADZONE_ORT_LIB_PATH`   | Hand-positioned `libonnxruntime` path. Skips the download.  |
-| `DEADZONE_ORT_CACHE`      | Override the ORT library cache dir.                         |
-| `DEADZONE_HUGOT_CACHE`    | Override the model-weights cache dir.                       |
-| `DEADZONE_DB_CACHE`       | Override the `deadzone.db` cache dir.                       |
-| `DEADZONE_DB_OFFLINE=1`   | Refuse any network call. Fails loudly if nothing is cached. |
+| Env var                   | Effect                                                                                  |
+|---------------------------|-----------------------------------------------------------------------------------------|
+| `DEADZONE_ORT_LIB_PATH`   | Hand-positioned `libonnxruntime` path. Skips the download.                              |
+| `DEADZONE_ORT_CACHE`      | Override the ORT library cache dir.                                                     |
+| `DEADZONE_HUGOT_CACHE`    | Override the model-weights cache dir.                                                   |
+| `DEADZONE_DB_CACHE`       | Override the `deadzone.db` cache dir.                                                   |
+| `DEADZONE_DB_OFFLINE=1`   | Refuse any network call. Fails loudly if nothing is cached.                             |
+| `DEADZONE_DB_AUTOUPDATE=0` | Disable the boot-time DB freshness probe (the probe runs by default; `fetch-db` always probes regardless of this flag). |
 
 Default cache paths per platform:
 
@@ -201,7 +202,7 @@ Default cache paths per platform:
 | Linux    | `$XDG_DATA_HOME/deadzone/deadzone.db` (else `~/.local/share/...`) |
 | Windows  | `%LOCALAPPDATA%\deadzone\deadzone.db`                             |
 
-A sibling `deadzone.db.release` text file records the tag the cache was fetched from. Startup compares it against the binary's compiled-in version: match → zero-network; differs → fetch and atomic-swap; dev build → fall back to `/releases/latest` with a `server.db_version_dev_fallback` WARN.
+A sibling `deadzone.db.release` JSON manifest records `{tag, sha256, fetched_at}`. Startup compares the cached tag against the binary's compiled-in version: match → fire a 3-second freshness probe against `deadzone.db.sha256` on the matching GitHub Release, atomic-swap if the remote sha differs (soft-fail to the cache on any network error); differs → fetch the new tag's release and atomic-swap; dev build → fall back to `/releases/latest` with a `server.db_version_dev_fallback` WARN. Pre-#197 binaries wrote a single-line tag-only sidecar; the JSON reader still accepts that format and rewrites it to v1 on first probe.
 
 ---
 

--- a/cmd/deadzone/fetchdb.go
+++ b/cmd/deadzone/fetchdb.go
@@ -36,11 +36,19 @@ var (
 
 var fetchDBCmd = &cobra.Command{
 	Use:   "fetch-db",
-	Short: "Download/refresh the cached deadzone.db from the latest GH Release",
+	Short: "Probe and refresh the cached deadzone.db from the matching GH Release",
 	Long: `Explicit cache-warmup / refresh entry point for the same db.Bootstrap flow
 ` + "`deadzone server`" + ` uses implicitly. The fetched DB is pinned to the binary's
-own version; pass --force to re-fetch the same tag to recover from local
-corruption.`,
+own version.
+
+Behaviour without --force: probes the remote ` + "`deadzone.db.sha256`" + ` for the
+matching tag (3-second budget), downloads + atomic-swaps only if the remote
+sha differs from the cached one. With --force: skips the probe and always
+re-downloads (use to recover from local corruption).
+
+Unlike ` + "`deadzone server`" + `, fetch-db ignores ` + "`DEADZONE_DB_AUTOUPDATE=0`" + ` —
+the env var only governs the implicit server-boot path, not explicit
+user-driven refreshes.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runFetchDB()
 	},
@@ -68,6 +76,10 @@ func runFetchDB() error {
 		Repo:       fetchDBRepo,
 		AppVersion: version,
 		Force:      fetchDBForce,
+		// fetch-db NEVER sets SkipAutoUpdateProbe — DEADZONE_DB_AUTOUPDATE
+		// only opts the implicit server-boot path out. An explicit
+		// `fetch-db` invocation by definition wants the probe.
+		Caller: "fetch-db",
 	})
 	if err != nil {
 		return fmt.Errorf("fetch-db: %w", err)

--- a/cmd/deadzone/server.go
+++ b/cmd/deadzone/server.go
@@ -291,8 +291,9 @@ func runServer() error {
 	//   unset → auto-fetch from the latest GH Release into the
 	//           per-platform data dir, auto-upgrade on subsequent runs
 	//           when a newer release exists. The whole flow is bounded
-	//           by the DEADZONE_DB_OFFLINE / DEADZONE_DB_NO_AUTO_UPGRADE
-	//           env-var escape hatches.
+	//           by the DEADZONE_DB_OFFLINE / DEADZONE_DB_AUTOUPDATE
+	//           env-var escape hatches (#197 added the second one for
+	//           the boot-time freshness probe).
 	//   set   → use the path verbatim. No fetch, no version check.
 	//           Error if missing — the operator opted into a specific
 	//           file and we respect that.
@@ -301,7 +302,14 @@ func runServer() error {
 		// tears down cleanly instead of letting the HTTP client run
 		// to its 15-minute timeout.
 		bootstrapCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-		resolved, upgraded, err := db.Bootstrap(bootstrapCtx, version)
+		resolved, upgraded, err := db.BootstrapWithOptions(bootstrapCtx, db.BootstrapOptions{
+			AppVersion: version,
+			// Server is the implicit-boot caller; DEADZONE_DB_AUTOUPDATE
+			// governs only this path. fetch-db ignores the env var on
+			// purpose (it's a user-driven explicit refresh).
+			SkipAutoUpdateProbe: autoUpdateDisabled(),
+			Caller:              "server",
+		})
 		stop()
 		if err != nil {
 			return fmt.Errorf("bootstrap deadzone.db: %w", err)
@@ -384,4 +392,18 @@ func runServer() error {
 		return fmt.Errorf("mcp run: %w", err)
 	}
 	return nil
+}
+
+// autoUpdateDisabled returns true when DEADZONE_DB_AUTOUPDATE is
+// explicitly set to "0" or "false" (case-insensitive). Anything else
+// — unset, empty, "1", "true", "anything-else" — leaves the boot-time
+// freshness probe enabled. Mirrors the explicit-opt-out convention of
+// DEADZONE_DB_OFFLINE (which uses "1" as opt-in).
+//
+// Lives here rather than in internal/db because the env var only
+// governs the implicit server-boot path. fetch-db deliberately
+// ignores it (the probe IS what fetch-db is for).
+func autoUpdateDisabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(db.EnvAutoUpdate)))
+	return v == "0" || v == "false"
 }

--- a/docs/research/ingestion-architecture.md
+++ b/docs/research/ingestion-architecture.md
@@ -319,6 +319,30 @@ The image bakes the binary plus `libonnxruntime` at `/usr/local/lib/` (with `DEA
 
 The image is built in a new `docker` job in `release.yml` between `smoke` and `release`, gated `needs: smoke` (so the binary is already proven to launch) and feeding `release.needs += docker` (so the GH Release object isn't published before the OCI push completes). The `Dockerfile` does no compilation — it `COPY`s the per-arch binaries produced upstream by the existing `build` matrix, plus the pinned `libonnxruntime` archive fetched at job time using `./deadzone ort-meta` (a hidden subcommand that prints the URL/SHA from the same `internal/ort.pinnedReleases` table `Bootstrap` uses), so #70's "native runners only, no goreleaser-cross" decision is unaffected.
 
+### v4 (2026-05-04, #197): boot-time freshness probe refines the match-then-zero-network rule
+
+The PR #110 review locked in a "tag match → zero network" contract for `internal/db.Bootstrap`: a binary at version `vX.Y.Z` with a cached `deadzone.db` whose sidecar tag also reads `vX.Y.Z` was treated as authoritative for life. That rule was correct against the *original* `dbrelease` semantics (one upload per tag, immutable after publish) but became wrong against the *operator-driven* semantics that `just dbrelease v0.X.0` actually uses: the operator re-runs `dbrelease` against the **same tag** every time the corpus is re-scraped, clobbering the asset in place. Within a single binary version, "the matching `deadzone.db`" is therefore not a fixed object — it's whatever the operator pushed last.
+
+Concrete failure mode: a user installs `vX.Y.Z` on day 1, the operator pushes a fresh `deadzone.db` against `vX.Y.Z` on day 14, the user still serves day-1 bytes on day 15 until they manually wipe their cache or upgrade the binary. Freshness window unbounded.
+
+**Decision:** refine the rule to **"match → 3s probe → zero-network-on-soft-fail"**. On every boot where the cached tag matches the binary's `AppVersion`, `BootstrapWithOptions` issues a 78-byte GET on `deadzone.db.sha256` (the asset CDN, not the API JSON — bypasses the 60 req/h unauthenticated rate limit) with a fixed 3-second budget on a dedicated `probeHTTPClient`. Match against the sidecar's recorded sha → return cache; mismatch → atomic-swap via `deadzone.db.new` → sha-verify → rename → rewrite sidecar. **Every** non-success outcome other than a sha-verified corrupt download is a soft-fail logged under `db.update_check_skipped` (`reason ∈ network_timeout, network_error, parse_error, disabled_via_env, offline_mode`); boot continues against the cached DB. Corrupt download is the one fatal path — `.new` deleted, cache intact, `BootstrapWithOptions` returns a non-nil error so we never serve unverified bytes.
+
+The sidecar (`deadzone.db.release`) evolves from a single-line tag to a JSON `{tag, sha256, fetched_at}` object so the probe can compare hashes without rehashing the 50 MB cache file on every boot. Pre-#197 binaries wrote the legacy single-line form; the reader still accepts it and rewrites it to v1 on first probe.
+
+Two scoping decisions tighten the surface:
+
+- **`DEADZONE_DB_AUTOUPDATE=0` opts the implicit server-boot path out** but does NOT govern `deadzone fetch-db`. The env var threads through `BootstrapOptions.SkipAutoUpdateProbe`, set by `cmd/deadzone/server.go` from the env and *never* set by `cmd/deadzone/fetchdb.go` — `fetch-db` is by definition an explicit user-driven refresh, so the probe is precisely what it's for. This makes the env var's contract narrow and predictable: "the steady-state cache-hit boot is allowed to be zero-network if you ask".
+- **`DEADZONE_DB_OFFLINE=1` (existing) hard-overrides** for both callers. Offline mode never reaches out, regardless of the auto-update env var.
+
+What v4 does **not** do:
+
+- No "check at most every N hours" throttling. The probe is small enough (~78 bytes) that a 10-launch-per-day workflow is negligible. Throttling adds state, divergence between callers, and a "is my cache really fresh?" mental model the operator doesn't need.
+- No retry-with-backoff. One attempt, fail-fast, fall back to cache. Retries on every boot would slow down every offline launch.
+- No binary auto-update. The DB is the moving target; binary updates remain a `brew upgrade` / re-pull-image / re-download-tarball user action.
+- No new `update-db` subcommand. `fetch-db` (already shipped in #108) inherits the probe-and-maybe-download behaviour by virtue of going through the same `BootstrapWithOptions` path; adding a second subcommand would just split the surface.
+
+Holds at scale: the probe's cost per boot is one TLS handshake + one ~78-byte response. At a hypothetical 10k-user, 10-launch-per-day deployment that's 100k probes/day — well under GitHub's anonymous CDN limits, and most boots take the no-change branch which logs at DEBUG (zero operator surface in steady state).
+
 ---
 
 ## 6. Reasoning-mode suppression in the agent path (#60)

--- a/internal/db/bootstrap.go
+++ b/internal/db/bootstrap.go
@@ -146,9 +146,13 @@ func BootstrapWithOptions(ctx context.Context, opts BootstrapOptions) (string, b
 	cached := fileExists(dbPath)
 	offline := os.Getenv(EnvOffline) == "1"
 
+	// readSidecar accepts both the v0 single-line tag (legacy binaries)
+	// and the v1 JSON object. We only consume .Tag here — the sha256
+	// and fetched_at fields feed the auto-update probe added in #197,
+	// which is layered on top of this fast-path lookup.
 	cachedTag := ""
-	if b, err := os.ReadFile(tagPath); err == nil {
-		cachedTag = strings.TrimSpace(string(b))
+	if s, err := readSidecar(tagPath); err == nil {
+		cachedTag = s.Tag
 	}
 
 	isDev := isDevVersion(opts.AppVersion)
@@ -417,7 +421,13 @@ func fetchAndInstall(ctx context.Context, meta releaseMeta, dbPath, tagPath stri
 	}
 	cleanup = false
 
-	if err := os.WriteFile(tagPath, []byte(meta.Tag+"\n"), 0o644); err != nil {
+	// We already have the verified sha in `got` from the streaming
+	// hasher, so persisting it costs nothing and saves the next boot's
+	// auto-update probe a 50 MB rehash. Sidecar write failure is
+	// non-fatal: the DB is in place and serving; a missing/stale sidecar
+	// only forces the next boot to re-fetch (wasteful but correct).
+	side := sidecar{Tag: meta.Tag, SHA256: got, FetchedAt: time.Now().UTC()}
+	if err := writeSidecar(tagPath, side); err != nil {
 		slog.Warn("server.db_tag_sidecar_write_failed", "err", err.Error(), "path", tagPath)
 	}
 	return nil

--- a/internal/db/bootstrap.go
+++ b/internal/db/bootstrap.go
@@ -53,6 +53,13 @@ import (
 const (
 	EnvCacheDir = "DEADZONE_DB_CACHE"
 	EnvOffline  = "DEADZONE_DB_OFFLINE"
+	// EnvAutoUpdate gates the boot-time freshness probe added in #197.
+	// Default (unset, or any non-"0"/"false" value) is enabled.
+	// Setting "0" / "false" opts the implicit server-boot path out;
+	// `fetch-db` still probes regardless because the env var only
+	// governs the implicit path — explicit `fetch-db` is by definition
+	// a user-driven refresh.
+	EnvAutoUpdate = "DEADZONE_DB_AUTOUPDATE"
 
 	BootstrapDefaultRepo = "laradji/deadzone"
 
@@ -60,23 +67,43 @@ const (
 	// builds. Bootstrap falls back to /releases/latest on it.
 	DevVersion = "dev"
 
-	dbAssetName     = "deadzone.db"
-	sha256AssetName = "deadzone.db.sha256"
-	tagSidecarName  = "deadzone.db.release"
+	dbAssetName       = "deadzone.db"
+	sha256AssetName   = "deadzone.db.sha256"
+	tagSidecarName    = "deadzone.db.release"
+	dbDownloadNewName = "deadzone.db.new"
+
+	// probeBudget caps the wall-clock spent on the boot-time freshness
+	// probe (#197). Sub-100-byte response, fixed budget — no env
+	// override (issue ADR: "keep the surface small").
+	probeBudget = 3 * time.Second
 )
 
-// Two HTTP clients with different timeouts (PR #110 review item 2):
-// metadata responses are tiny JSON, so a hung API call shouldn't make
-// a user wait 15 minutes before failing. The asset download is the
-// bandwidth-heavy one and keeps the long ceiling.
+// Three HTTP clients with different timeouts (PR #110 review item 2,
+// extended for #197):
+//   - metadata: 30s, sized for the GitHub API JSON responses.
+//   - asset:    15min, sized for the ~50 MB deadzone.db transfer.
+//   - probe:    3s,  sized for the boot-time freshness probe (#197).
+//     The probe's whole point is "fail fast and fall back to cache" —
+//     reusing metadataHTTPClient (30s) would let an offline boot stall
+//     ten times longer than the spec budget.
 var (
 	metadataHTTPClient = &http.Client{Timeout: 30 * time.Second}
 	assetHTTPClient    = &http.Client{Timeout: 15 * time.Minute}
+	probeHTTPClient    = &http.Client{Timeout: probeBudget}
 )
 
 // releasesAPIBase is the GitHub API root. Split out so tests can point
 // Bootstrap at a local httptest server.
 var releasesAPIBase = "https://api.github.com"
+
+// assetDownloadBase is the asset-CDN root. The probe and the
+// version-bump fallback download deadzone.db / deadzone.db.sha256
+// directly from /<repo>/releases/download/<tag>/<asset>, bypassing the
+// API JSON detour. This costs one extra round-trip in the unhappy
+// path (a 404 here means the asset truly doesn't exist on the tag,
+// which the issue treats as a soft-fail) but saves one in the happy
+// path of every boot. Split out so tests can override.
+var assetDownloadBase = "https://github.com"
 
 // gitDescribeBetweenTagsRe recognises `git describe --tags --always`
 // output for commits that aren't themselves a tagged release:
@@ -107,6 +134,16 @@ type BootstrapOptions struct {
 	// fetch-db --force uses this; the server path leaves it false so
 	// a no-op startup stays zero-network.
 	Force bool
+	// SkipAutoUpdateProbe disables the boot-time freshness probe added
+	// in #197 even when the cache is hot and online. The server path
+	// sets this from DEADZONE_DB_AUTOUPDATE=0; fetch-db NEVER sets it
+	// (the probe is precisely what `fetch-db` is for, no-flag).
+	SkipAutoUpdateProbe bool
+	// Caller is a free-form label that flows into the structured logs
+	// the auto-update probe emits (`db.update_*` events). The two
+	// production callers are "server" and "fetch-db"; tests leave it
+	// empty.
+	Caller string
 }
 
 // Bootstrap ensures a deadzone.db is present at the default cache
@@ -147,13 +184,13 @@ func BootstrapWithOptions(ctx context.Context, opts BootstrapOptions) (string, b
 	offline := os.Getenv(EnvOffline) == "1"
 
 	// readSidecar accepts both the v0 single-line tag (legacy binaries)
-	// and the v1 JSON object. We only consume .Tag here — the sha256
-	// and fetched_at fields feed the auto-update probe added in #197,
-	// which is layered on top of this fast-path lookup.
-	cachedTag := ""
+	// and the v1 JSON object. The full sidecar (sha256, fetched_at)
+	// feeds the auto-update probe.
+	var cachedSidecar sidecar
 	if s, err := readSidecar(tagPath); err == nil {
-		cachedTag = s.Tag
+		cachedSidecar = s
 	}
+	cachedTag := cachedSidecar.Tag
 
 	isDev := isDevVersion(opts.AppVersion)
 
@@ -163,6 +200,25 @@ func BootstrapWithOptions(ctx context.Context, opts BootstrapOptions) (string, b
 	// don't nag" is the ergonomic choice for local iteration.
 	if cached && !opts.Force {
 		if isDev || cachedTag == opts.AppVersion {
+			// Auto-update probe (#197). Runs ONLY on a confirmed tag
+			// match (skipping dev fallback — there's no specific
+			// release to probe), and only when not opted out and not
+			// in offline mode. All non-success outcomes other than a
+			// hash-verified corrupt download are soft-fails: the
+			// cached DB serves and the probe error is swallowed.
+			if !isDev && cachedTag == opts.AppVersion && !opts.SkipAutoUpdateProbe && !offline {
+				updated, err := probeAndMaybeSwap(ctx, repo, opts.AppVersion, dbPath, tagPath, cachedSidecar, opts.Caller)
+				if err != nil {
+					return "", false, err
+				}
+				return dbPath, updated, nil
+			}
+			if !isDev && cachedTag == opts.AppVersion && opts.SkipAutoUpdateProbe {
+				slog.Info("db.update_check_skipped", "tag", cachedTag, "reason", "disabled_via_env", "caller", opts.Caller)
+			}
+			if !isDev && cachedTag == opts.AppVersion && offline {
+				slog.Info("db.update_check_skipped", "tag", cachedTag, "reason", "offline_mode", "caller", opts.Caller)
+			}
 			return dbPath, false, nil
 		}
 	}
@@ -471,4 +527,232 @@ func fetchSHA256(ctx context.Context, url string) (string, error) {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// probeAndMaybeSwap is the auto-update probe added in #197. It runs
+// inside the fast-path branch when (a) the cache exists, (b) its tag
+// matches the binary's AppVersion, (c) the caller hasn't opted out
+// via SkipAutoUpdateProbe, and (d) we're not in offline mode.
+//
+// Soft-fail policy (issue ADR): every non-success outcome OTHER than
+// a sha-verified corrupt download is treated as a recoverable
+// transient — the cached DB stays and we return (false, nil). The
+// only error path that propagates is the corrupt-download case:
+// `deadzone.db.new` is deleted and the caller gets a non-nil error
+// so boot does NOT proceed against an unverified DB.
+//
+// Sidecar legacy handling: a v0 sidecar carries no sha256, so we
+// compute it once from the on-disk file and rewrite the sidecar
+// before issuing the probe. Subsequent boots take the cheap path.
+func probeAndMaybeSwap(ctx context.Context, repo, tag, dbPath, tagPath string, side sidecar, caller string) (bool, error) {
+	localSHA := side.SHA256
+	if localSHA == "" {
+		// First boot post-upgrade onto a v0 sidecar. Compute the sha
+		// once so the next boot takes the cheap path. A failure here
+		// (e.g. the cache file vanished between fileExists and now) is
+		// classified as parse_error and soft-fails the probe — boot
+		// continues, the next attempt will retry.
+		h, err := hashFile(dbPath)
+		if err != nil {
+			slog.Info("db.update_check_skipped", "tag", tag, "reason", "parse_error", "caller", caller, "err", err.Error())
+			return false, nil
+		}
+		localSHA = h
+		side.SHA256 = h
+		if side.FetchedAt.IsZero() {
+			// Best-effort: stamp the on-disk mtime so the field has
+			// SOME signal even on the legacy upgrade path. Falls back
+			// to "now" if stat fails.
+			if info, statErr := os.Stat(dbPath); statErr == nil {
+				side.FetchedAt = info.ModTime().UTC()
+			} else {
+				side.FetchedAt = time.Now().UTC()
+			}
+		}
+		if err := writeSidecar(tagPath, side); err != nil {
+			slog.Warn("server.db_tag_sidecar_write_failed", "err", err.Error(), "path", tagPath)
+		}
+	}
+
+	slog.Debug("db.update_check_start", "tag", tag, "local_sha256", localSHA, "caller", caller)
+
+	remoteSHA, reason, err := probeFetchSHA(ctx, repo, tag)
+	if err != nil {
+		slog.Info("db.update_check_skipped", "tag", tag, "reason", reason, "caller", caller, "err", err.Error())
+		return false, nil
+	}
+
+	if remoteSHA == localSHA {
+		slog.Debug("db.update_check_no_change", "tag", tag, "sha256", remoteSHA, "caller", caller)
+		return false, nil
+	}
+
+	slog.Info("db.update_available", "tag", tag, "local_sha256", localSHA, "remote_sha256", remoteSHA, "caller", caller)
+
+	start := time.Now()
+	bytesDL, phase, err := probeDownloadAndSwap(ctx, repo, tag, dbPath, remoteSHA)
+	if err != nil {
+		slog.Error("db.update_failed", "tag", tag, "phase", phase, "err", err.Error(), "caller", caller)
+		// Hash mismatch on the downloaded bytes is the ONE case the
+		// issue says must abort boot. Any other download-phase failure
+		// (network drop mid-stream, disk full) is recoverable on the
+		// next boot, so we soft-fall-back to the cache. The phase
+		// returned by probeDownloadAndSwap distinguishes the two.
+		if phase == "verify" {
+			return false, fmt.Errorf("db: auto-update %w", err)
+		}
+		return false, nil
+	}
+
+	side = sidecar{Tag: tag, SHA256: remoteSHA, FetchedAt: time.Now().UTC()}
+	if err := writeSidecar(tagPath, side); err != nil {
+		slog.Warn("server.db_tag_sidecar_write_failed", "err", err.Error(), "path", tagPath)
+	}
+
+	slog.Info("db.update_applied",
+		"tag", tag,
+		"old_sha256", localSHA,
+		"new_sha256", remoteSHA,
+		"bytes_downloaded", bytesDL,
+		"duration_ms", time.Since(start).Milliseconds(),
+		"caller", caller,
+	)
+	return true, nil
+}
+
+// probeFetchSHA does the cheap GET on the deadzone.db.sha256 asset.
+// Returns (sha, "", nil) on success, ("", reason, err) on every
+// failure mode the issue's structured-log table enumerates.
+//
+// The reason vocabulary maps to slog's `reason` field on
+// db.update_check_skipped: network_timeout, network_error,
+// parse_error.
+func probeFetchSHA(ctx context.Context, repo, tag string) (sha, reason string, err error) {
+	url := fmt.Sprintf("%s/%s/releases/download/%s/%s", assetDownloadBase, repo, tag, sha256AssetName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", "parse_error", err
+	}
+	resp, err := probeHTTPClient.Do(req)
+	if err != nil {
+		// http.Client wraps deadline exceeded inside *url.Error whose
+		// Timeout() reports true. Distinguishing this from a generic
+		// network error matters because the issue's
+		// db.update_check_skipped log surfaces "network_timeout"
+		// specifically (operators want to know "your network is slow"
+		// vs "your network is broken").
+		if errors.Is(err, context.DeadlineExceeded) {
+			return "", "network_timeout", err
+		}
+		var netErr interface{ Timeout() bool }
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return "", "network_timeout", err
+		}
+		return "", "network_error", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "network_error", fmt.Errorf("get %s: status %d", url, resp.StatusCode)
+	}
+	// 4 KiB is generous for a one-line sha256 file; cap defends
+	// against a hostile mirror responding with infinite bytes.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return "", "network_error", fmt.Errorf("read sha256 body: %w", err)
+	}
+	fields := strings.Fields(string(body))
+	if len(fields) == 0 {
+		return "", "parse_error", errors.New("sha256 file is empty")
+	}
+	hash := strings.ToLower(fields[0])
+	if len(hash) != 64 {
+		return "", "parse_error", fmt.Errorf("malformed sha256 %q (want 64 hex chars)", hash)
+	}
+	return hash, "", nil
+}
+
+// probeDownloadAndSwap downloads deadzone.db to a deterministic
+// .new path, sha-verifies against expectedSHA, and atomically renames
+// over the live cache. The deterministic name (deadzone.db.new) was
+// called out by the issue spec; the existing fetchAndInstall uses
+// CreateTemp instead because it has no expected name to coordinate
+// against.
+//
+// Returns (bytesWritten, phase, err) where phase ∈ {download, verify,
+// rename, ""} so the caller can populate the structured-log
+// `db.update_failed.phase` field. An empty phase means success.
+func probeDownloadAndSwap(ctx context.Context, repo, tag, dbPath, expectedSHA string) (int64, string, error) {
+	url := fmt.Sprintf("%s/%s/releases/download/%s/%s", assetDownloadBase, repo, tag, dbAssetName)
+	cacheDir := filepath.Dir(dbPath)
+	newPath := filepath.Join(cacheDir, dbDownloadNewName)
+
+	// Truncate any leftover .new from a torn previous run before we
+	// commit to overwriting it; otherwise a partial download that
+	// died after streaming but before rename would silently corrupt
+	// the next attempt.
+	f, err := os.Create(newPath)
+	if err != nil {
+		return 0, "download", fmt.Errorf("create %s: %w", newPath, err)
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = f.Close()
+			_ = os.Remove(newPath)
+		}
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, "download", fmt.Errorf("new request: %w", err)
+	}
+	// Reuse the long-timeout asset client — the probe budget governs
+	// only the sha sidecar GET, not the multi-MB download.
+	resp, err := assetHTTPClient.Do(req)
+	if err != nil {
+		return 0, "download", fmt.Errorf("get %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, "download", fmt.Errorf("get %s: status %d", url, resp.StatusCode)
+	}
+
+	hasher := sha256.New()
+	n, err := io.Copy(io.MultiWriter(f, hasher), resp.Body)
+	if err != nil {
+		return n, "download", fmt.Errorf("stream %s: %w", url, err)
+	}
+	if err := f.Close(); err != nil {
+		return n, "download", fmt.Errorf("close %s: %w", newPath, err)
+	}
+
+	got := hex.EncodeToString(hasher.Sum(nil))
+	if got != expectedSHA {
+		// "verify" is the one phase the caller MUST treat as fatal —
+		// the cache stays intact and we explicitly leave cleanup=true
+		// so the corrupt .new file is removed.
+		return n, "verify", fmt.Errorf("sha256 mismatch on %s: got %s, want %s", url, got, expectedSHA)
+	}
+
+	if err := os.Rename(newPath, dbPath); err != nil {
+		return n, "rename", fmt.Errorf("rename %s -> %s: %w", newPath, dbPath, err)
+	}
+	cleanup = false
+	return n, "", nil
+}
+
+// hashFile streams path through sha256 and returns the hex digest.
+// Used by the auto-update probe when migrating a v0 sidecar (which
+// has no recorded sha256) to v1.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/db/bootstrap_test.go
+++ b/internal/db/bootstrap_test.go
@@ -7,11 +7,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -818,4 +820,386 @@ func TestBootstrap_Matrix(t *testing.T) {
 			}
 		})
 	}
+}
+
+// =============================================================================
+// Auto-update probe (#197) — test helpers and integration tests.
+// =============================================================================
+
+// capturedRecord is a frozen view of one slog.Record. The auto-update
+// integration tests assert on Msg + a small subset of Attrs (notably
+// `reason` for skipped events and `phase` for failed events) so the
+// capture only flattens what the production code emits.
+type capturedRecord struct {
+	Level slog.Level
+	Msg   string
+	Attrs map[string]any
+}
+
+// captureHandler is a slog.Handler that records every event into an
+// in-memory slice. Replaces slog.Default() for the duration of a
+// subtest so we can assert that probeAndMaybeSwap emits the right
+// db.update_* events with the right `reason`/`phase` labels.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []capturedRecord
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := capturedRecord{Level: r.Level, Msg: r.Message, Attrs: map[string]any{}}
+	r.Attrs(func(a slog.Attr) bool {
+		rec.Attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	h.mu.Lock()
+	h.records = append(h.records, rec)
+	h.mu.Unlock()
+	return nil
+}
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// findRecord returns the first captured record whose Msg equals msg,
+// or nil if none. Used by per-subtest assertions like
+// "db.update_check_skipped was emitted with reason=network_timeout".
+func (h *captureHandler) findRecord(msg string) *capturedRecord {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i := range h.records {
+		if h.records[i].Msg == msg {
+			return &h.records[i]
+		}
+	}
+	return nil
+}
+
+// withCapturedLog swaps slog.Default for a captureHandler for the
+// duration of the test. Restores the original logger on cleanup so
+// subsequent tests in the same binary aren't muted.
+func withCapturedLog(t *testing.T) *captureHandler {
+	t.Helper()
+	h := &captureHandler{}
+	orig := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+	return h
+}
+
+// withProbeTimeout swaps probeHTTPClient for a fresh client with the
+// given timeout. The default 3-second budget makes the timeout-path
+// test slow; production behaviour is preserved (3s is what real boots
+// will see) but unit tests can drop it to 50ms paired with a 200ms
+// fixture hang for a 4-millisecond-ish test runtime.
+func withProbeTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := probeHTTPClient
+	probeHTTPClient = &http.Client{Timeout: d}
+	t.Cleanup(func() { probeHTTPClient = orig })
+}
+
+// seedCacheV1 writes a v1 JSON sidecar carrying a known sha alongside
+// dbBody. Used by probe tests that need the cached sha to be
+// well-defined (vs the legacy seedCache which writes a v0 tag-only
+// line, forcing the probe to recompute the sha on first run).
+func seedCacheV1(t *testing.T, dir, dbBody, tag, sha string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, dbAssetName), []byte(dbBody), 0o644); err != nil {
+		t.Fatalf("seed cache db: %v", err)
+	}
+	side := sidecar{Tag: tag, SHA256: sha, FetchedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	if err := writeSidecar(filepath.Join(dir, tagSidecarName), side); err != nil {
+		t.Fatalf("seed sidecar v1: %v", err)
+	}
+}
+
+// shaOf is a test helper for "the sha256 of this string", used to
+// keep probe-test fixture setups readable.
+func shaOf(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// TestBootstrap_AutoUpdate_NoChange — fixture: cached DB sha == remote
+// sha. Probe fires, sees no change, returns the cached path. No
+// download, sidecar unchanged, no .new file ever exists.
+func TestBootstrap_AutoUpdate_NoChange(t *testing.T) {
+	clearBootstrapEnv(t)
+	logs := withCapturedLog(t)
+
+	const body = "stable-content"
+	rel := newFakeRelease(t, "v1.0.0", body) // fixture sha == cached sha
+	fix := newFixtureServer(t, rel)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	seedCacheV1(t, cacheDir, body, "v1.0.0", shaOf(body))
+
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.0.0",
+		Caller:     "server",
+	})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if upgraded {
+		t.Errorf("upgraded=true on no-change probe, want false")
+	}
+	if got, _ := os.ReadFile(path); string(got) != body {
+		t.Errorf("cached body mutated on no-change probe: %q", got)
+	}
+	if n := fix.probeCalls.Load(); n != 1 {
+		t.Errorf("probeCalls = %d, want 1", n)
+	}
+	if n := fix.probeDLCalls.Load(); n != 0 {
+		t.Errorf("probeDLCalls = %d on no-change, want 0", n)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, dbDownloadNewName)); !os.IsNotExist(err) {
+		t.Errorf("%s left behind on no-change path", dbDownloadNewName)
+	}
+	if logs.findRecord("db.update_check_no_change") == nil {
+		t.Errorf("db.update_check_no_change not logged")
+	}
+}
+
+// TestBootstrap_AutoUpdate_Applied — fixture: cached DB sha != remote
+// sha. Probe fires, downloads, atomic-swaps, rewrites the sidecar.
+// The cached body must be the new content; sidecar.SHA256 must be
+// the new sha.
+func TestBootstrap_AutoUpdate_Applied(t *testing.T) {
+	clearBootstrapEnv(t)
+	logs := withCapturedLog(t)
+
+	const newBody = "fresh-corpus-v2"
+	rel := newFakeRelease(t, "v1.0.0", newBody)
+	fix := newFixtureServer(t, rel)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	const oldBody = "stale-corpus-v1"
+	seedCacheV1(t, cacheDir, oldBody, "v1.0.0", shaOf(oldBody))
+
+	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.0.0",
+		Caller:     "server",
+	})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if !upgraded {
+		t.Errorf("upgraded=false on probe-applied, want true")
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != newBody {
+		t.Errorf("body = %q after probe-apply, want %q", got, newBody)
+	}
+	side, err := readSidecar(filepath.Join(cacheDir, tagSidecarName))
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	if side.SHA256 != shaOf(newBody) {
+		t.Errorf("sidecar SHA256 = %q after apply, want sha of new body", side.SHA256)
+	}
+	if side.Tag != "v1.0.0" {
+		t.Errorf("sidecar Tag = %q, want v1.0.0", side.Tag)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, dbDownloadNewName)); !os.IsNotExist(err) {
+		t.Errorf("%s not cleaned up after successful swap", dbDownloadNewName)
+	}
+	if n := fix.probeDLCalls.Load(); n != 1 {
+		t.Errorf("probeDLCalls = %d, want 1", n)
+	}
+	rec := logs.findRecord("db.update_applied")
+	if rec == nil {
+		t.Fatalf("db.update_applied not logged")
+	}
+	if b, ok := rec.Attrs["bytes_downloaded"].(int64); !ok || b == 0 {
+		t.Errorf("db.update_applied.bytes_downloaded = %v, want non-zero int64", rec.Attrs["bytes_downloaded"])
+	}
+}
+
+// TestBootstrap_AutoUpdate_NetworkTimeout — fixture hangs past the
+// probe budget. The probe must soft-fail with reason=network_timeout,
+// the cached DB stays untouched, BootstrapWithOptions returns nil.
+//
+// Test pacing: we drop the probe client timeout to 50ms and the
+// fixture hang to ~200ms (via the standard probeHang flag, which uses
+// a hardcoded 5×probeBudget hang in the fixture). The fixture's hang
+// is much longer than the test client timeout, so the timeout fires.
+func TestBootstrap_AutoUpdate_NetworkTimeout(t *testing.T) {
+	clearBootstrapEnv(t)
+	withProbeTimeout(t, 50*time.Millisecond)
+	logs := withCapturedLog(t)
+
+	const body = "stable-content"
+	rel := newFakeRelease(t, "v1.0.0", body)
+	fix := newFixtureServer(t, rel)
+	fix.probeHang.Store(true)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	seedCacheV1(t, cacheDir, body, "v1.0.0", shaOf(body))
+
+	_, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.0.0",
+		Caller:     "server",
+	})
+	if err != nil {
+		t.Fatalf("Bootstrap returned err on probe timeout (must soft-fail): %v", err)
+	}
+	if upgraded {
+		t.Errorf("upgraded=true on probe timeout, want false")
+	}
+	if got, _ := os.ReadFile(filepath.Join(cacheDir, dbAssetName)); string(got) != body {
+		t.Errorf("cached body mutated on probe timeout: %q", got)
+	}
+	rec := logs.findRecord("db.update_check_skipped")
+	if rec == nil {
+		t.Fatalf("db.update_check_skipped not logged on timeout")
+	}
+	if r, _ := rec.Attrs["reason"].(string); r != "network_timeout" {
+		t.Errorf("skipped.reason = %q, want network_timeout", r)
+	}
+}
+
+// TestBootstrap_AutoUpdate_CorruptDownload — fixture advertises one
+// sha (probeSHA) but serves bytes that hash to a different one. The
+// download verifier must catch the mismatch, delete the .new file,
+// leave the cache intact, and propagate a non-nil error from
+// BootstrapWithOptions so the boot does NOT proceed against an
+// unverified DB.
+func TestBootstrap_AutoUpdate_CorruptDownload(t *testing.T) {
+	clearBootstrapEnv(t)
+	logs := withCapturedLog(t)
+
+	const cachedBody = "stale-content"
+	const realBody = "actual-served-bytes"
+	rel := newFakeRelease(t, "v1.0.0", realBody)
+	fix := newFixtureServer(t, rel)
+	// Advertise a sha that doesn't match what we'll serve. The probe
+	// will see (advertised != cached) → trigger download → download
+	// streams realBody → hasher produces sha(realBody) ≠ advertised
+	// → verify-phase mismatch.
+	fakeSHA := strings.Repeat("a", 64)
+	fix.probeSHA.Store(fakeSHA)
+	withAPIBase(t, fix.srv.URL)
+
+	cacheDir := t.TempDir()
+	seedCacheV1(t, cacheDir, cachedBody, "v1.0.0", shaOf(cachedBody))
+
+	_, _, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+		CacheDir:   cacheDir,
+		AppVersion: "v1.0.0",
+		Caller:     "server",
+	})
+	if err == nil {
+		t.Fatalf("Bootstrap returned nil error on corrupt download")
+	}
+	if !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Errorf("error %q must mention 'sha256 mismatch' (issue AC: error contains the phrase)", err)
+	}
+	// Cache untouched.
+	if got, _ := os.ReadFile(filepath.Join(cacheDir, dbAssetName)); string(got) != cachedBody {
+		t.Errorf("cached body mutated on corrupt download: %q", got)
+	}
+	// .new cleaned up.
+	if _, err := os.Stat(filepath.Join(cacheDir, dbDownloadNewName)); !os.IsNotExist(err) {
+		t.Errorf("%s not deleted after corrupt download", dbDownloadNewName)
+	}
+	// Sidecar untouched (still has the cached sha, not the fake one).
+	side, _ := readSidecar(filepath.Join(cacheDir, tagSidecarName))
+	if side.SHA256 != shaOf(cachedBody) {
+		t.Errorf("sidecar SHA256 = %q after corrupt download, want unchanged %q", side.SHA256, shaOf(cachedBody))
+	}
+	rec := logs.findRecord("db.update_failed")
+	if rec == nil {
+		t.Fatalf("db.update_failed not logged on corrupt download")
+	}
+	if p, _ := rec.Attrs["phase"].(string); p != "verify" {
+		t.Errorf("failed.phase = %q, want verify", p)
+	}
+}
+
+// TestBootstrap_AutoUpdate_FetchDBIgnoresOptOut pins the env-var
+// scoping contract: with DEADZONE_DB_AUTOUPDATE=0 set in the
+// environment, the explicit `fetch-db` caller (which leaves
+// SkipAutoUpdateProbe at its zero value) STILL runs the probe and
+// applies the update. The implicit server caller (which threads the
+// env var into SkipAutoUpdateProbe) does NOT.
+//
+// We exercise both shapes from inside this single test to keep them
+// adjacent: the contract ("env governs server only, not fetch-db")
+// is one rule, and one test that lives or dies by both halves makes
+// regressions louder than two siblings.
+func TestBootstrap_AutoUpdate_FetchDBIgnoresOptOut(t *testing.T) {
+	clearBootstrapEnv(t)
+	t.Setenv(EnvAutoUpdate, "0")
+	logs := withCapturedLog(t)
+
+	const newBody = "fresh-bytes"
+	rel := newFakeRelease(t, "v1.0.0", newBody)
+	fix := newFixtureServer(t, rel)
+	withAPIBase(t, fix.srv.URL)
+
+	const oldBody = "old-bytes"
+
+	t.Run("server-respects-optout", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		seedCacheV1(t, cacheDir, oldBody, "v1.0.0", shaOf(oldBody))
+
+		_, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+			CacheDir:   cacheDir,
+			AppVersion: "v1.0.0",
+			// SkipAutoUpdateProbe=true is what server.go would set
+			// from autoUpdateDisabled() given DEADZONE_DB_AUTOUPDATE=0.
+			SkipAutoUpdateProbe: true,
+			Caller:              "server",
+		})
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		if upgraded {
+			t.Errorf("upgraded=true under DEADZONE_DB_AUTOUPDATE=0 server boot, want false")
+		}
+		if got, _ := os.ReadFile(filepath.Join(cacheDir, dbAssetName)); string(got) != oldBody {
+			t.Errorf("cached body changed under opt-out: %q", got)
+		}
+		rec := logs.findRecord("db.update_check_skipped")
+		if rec == nil {
+			t.Fatalf("db.update_check_skipped not logged on opt-out")
+		}
+		if r, _ := rec.Attrs["reason"].(string); r != "disabled_via_env" {
+			t.Errorf("skipped.reason = %q, want disabled_via_env", r)
+		}
+	})
+
+	t.Run("fetch-db-ignores-optout", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		seedCacheV1(t, cacheDir, oldBody, "v1.0.0", shaOf(oldBody))
+		probeBefore := fix.probeCalls.Load()
+
+		_, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
+			CacheDir:   cacheDir,
+			AppVersion: "v1.0.0",
+			// SkipAutoUpdateProbe deliberately NOT set — fetchdb.go
+			// leaves it at its zero value regardless of env. The probe
+			// must run and the swap must happen.
+			Caller: "fetch-db",
+		})
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		if !upgraded {
+			t.Errorf("upgraded=false on fetch-db with mismatched cache, want true")
+		}
+		if got, _ := os.ReadFile(filepath.Join(cacheDir, dbAssetName)); string(got) != newBody {
+			t.Errorf("cached body = %q after fetch-db apply, want %q", got, newBody)
+		}
+		if got := fix.probeCalls.Load() - probeBefore; got != 1 {
+			t.Errorf("probeCalls delta = %d on fetch-db, want 1 (env opt-out must NOT apply)", got)
+		}
+	})
 }

--- a/internal/db/bootstrap_test.go
+++ b/internal/db/bootstrap_test.go
@@ -210,12 +210,18 @@ func TestBootstrap_FirstFetch(t *testing.T) {
 	if string(got) != string(rel.dbBody) {
 		t.Errorf("installed body = %q, want %q", got, rel.dbBody)
 	}
-	tag, err := os.ReadFile(filepath.Join(cacheDir, tagSidecarName))
+	side, err := readSidecar(filepath.Join(cacheDir, tagSidecarName))
 	if err != nil {
 		t.Fatalf("read tag sidecar: %v", err)
 	}
-	if strings.TrimSpace(string(tag)) != rel.tag {
-		t.Errorf("tag sidecar = %q, want %q", tag, rel.tag)
+	if side.Tag != rel.tag {
+		t.Errorf("sidecar Tag = %q, want %q", side.Tag, rel.tag)
+	}
+	if side.SHA256 != rel.dbHash {
+		t.Errorf("sidecar SHA256 = %q, want %q", side.SHA256, rel.dbHash)
+	}
+	if side.FetchedAt.IsZero() {
+		t.Errorf("sidecar FetchedAt is zero, want a real timestamp")
 	}
 	if n := fix.dbCalls.Load(); n != 1 {
 		t.Errorf("db asset hit %d times, want 1", n)
@@ -289,9 +295,12 @@ func TestBootstrap_BinaryUpgradeSwapsDB(t *testing.T) {
 	if string(got) != string(relNew.dbBody) {
 		t.Errorf("after upgrade body = %q, want %q", got, relNew.dbBody)
 	}
-	tag, _ := os.ReadFile(filepath.Join(cacheDir, tagSidecarName))
-	if strings.TrimSpace(string(tag)) != relNew.tag {
-		t.Errorf("tag sidecar = %q, want %q", tag, relNew.tag)
+	side, err := readSidecar(filepath.Join(cacheDir, tagSidecarName))
+	if err != nil {
+		t.Fatalf("read tag sidecar: %v", err)
+	}
+	if side.Tag != relNew.tag {
+		t.Errorf("sidecar Tag = %q, want %q", side.Tag, relNew.tag)
 	}
 }
 
@@ -460,9 +469,12 @@ func TestBootstrap_DevFallsBackToLatest(t *testing.T) {
 	if string(got) != string(rel.dbBody) {
 		t.Errorf("dev fallback body = %q, want %q", got, rel.dbBody)
 	}
-	tag, _ := os.ReadFile(filepath.Join(cacheDir, tagSidecarName))
-	if strings.TrimSpace(string(tag)) != rel.tag {
-		t.Errorf("tag sidecar = %q, want %q", tag, rel.tag)
+	side, err := readSidecar(filepath.Join(cacheDir, tagSidecarName))
+	if err != nil {
+		t.Fatalf("read tag sidecar: %v", err)
+	}
+	if side.Tag != rel.tag {
+		t.Errorf("sidecar Tag = %q, want %q", side.Tag, rel.tag)
 	}
 }
 

--- a/internal/db/bootstrap_test.go
+++ b/internal/db/bootstrap_test.go
@@ -14,12 +14,14 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // dbBootstrapEnv lists the env vars Bootstrap reads. Every test
 // neutralizes them via t.Setenv so a developer's local
-// DEADZONE_DB_CACHE / DEADZONE_DB_OFFLINE doesn't bleed in.
-var dbBootstrapEnv = []string{EnvCacheDir, EnvOffline}
+// DEADZONE_DB_CACHE / DEADZONE_DB_OFFLINE / DEADZONE_DB_AUTOUPDATE
+// doesn't bleed in.
+var dbBootstrapEnv = []string{EnvCacheDir, EnvOffline, EnvAutoUpdate}
 
 func clearBootstrapEnv(t *testing.T) {
 	t.Helper()
@@ -48,21 +50,38 @@ func newFakeRelease(t *testing.T, tag, content string) fakeRelease {
 // behind a single httptest server so the fake "browser_download_url"
 // values can point back at the same host.
 //
+// Three URL families are served:
+//
+//  1. /repos/<owner>/<repo>/releases/{tags/<t>,latest} — the JSON API
+//     used by the version-bump fetch path (existing).
+//  2. /dl/<tag>/<asset> — the synthetic "browser_download_url" the
+//     JSON above advertises; lets the API path stay decoupled from
+//     the production asset URL shape.
+//  3. /<owner>/<repo>/releases/download/<tag>/<asset> — mirrors the
+//     real assetDownloadBase URL shape so the auto-update probe
+//     (#197) hits the fixture instead of github.com when withAPIBase
+//     has wired the probe base accordingly.
+//
 // releases maps tag → fakeRelease so a single fixture can serve both
 // /releases/tags/<t> and the synthetic "latest" pick. The tags slice
 // preserves insertion order — latestTag returns the last-added tag so
 // tests that simulate "newer release dropped" can append to it
 // mid-test.
 type fixtureServer struct {
-	srv         *httptest.Server
-	releases    map[string]fakeRelease
-	tagOrder    []string
-	apiCalls    atomic.Int32
-	dbCalls     atomic.Int32
-	sha256Calls atomic.Int32
-	failAPI     atomic.Bool // when true, API endpoints return 500
-	corruptSHA  atomic.Bool // when true, sha256 comes back as zeroes (mismatch)
-	missingDB   atomic.Bool // when true, the JSON omits the deadzone.db asset
+	srv          *httptest.Server
+	releases     map[string]fakeRelease
+	tagOrder     []string
+	apiCalls     atomic.Int32
+	dbCalls      atomic.Int32
+	sha256Calls  atomic.Int32
+	probeCalls   atomic.Int32 // sha256 GETs on the /releases/download path (auto-update probe)
+	probeDLCalls atomic.Int32 // db GETs on the /releases/download path (auto-update applied)
+	failAPI      atomic.Bool  // when true, API endpoints return 500
+	corruptSHA   atomic.Bool  // when true, sha256 comes back as zeroes (mismatch)
+	missingDB    atomic.Bool  // when true, the JSON omits the deadzone.db asset
+	probeHang    atomic.Bool  // when true, /releases/download/<tag>/.sha256 hangs past the probe budget
+	probeSHA     atomic.Value // override remote sha as a string; empty/unset → use rel.dbHash
+	probeBody    atomic.Value // override the bytes served at /releases/download/<tag>/deadzone.db
 }
 
 func (f *fixtureServer) latestTag() string {
@@ -150,19 +169,69 @@ func newFixtureServer(t *testing.T, releases ...fakeRelease) *fixtureServer {
 			http.Error(w, "unknown asset", http.StatusNotFound)
 		}
 	})
+	// Mirror the production asset URL shape so the #197 probe can hit
+	// this fixture: GET /<owner>/<repo>/releases/download/<tag>/<asset>.
+	mux.HandleFunc("/laradji/deadzone/releases/download/", func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/laradji/deadzone/releases/download/"), "/")
+		if len(parts) != 2 {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		tag, asset := parts[0], parts[1]
+		rel, ok := fs.releases[tag]
+		if !ok {
+			http.Error(w, "unknown tag", http.StatusNotFound)
+			return
+		}
+		switch asset {
+		case sha256AssetName:
+			fs.probeCalls.Add(1)
+			if fs.probeHang.Load() {
+				// Hang past the probe budget so the client times out.
+				// 5×budget gives a comfortable margin for slow CI.
+				select {
+				case <-r.Context().Done():
+				case <-time.After(5 * probeBudget):
+				}
+				return
+			}
+			hash := rel.dbHash
+			if v, ok := fs.probeSHA.Load().(string); ok && v != "" {
+				hash = v
+			}
+			fmt.Fprintf(w, "%s  %s\n", hash, dbAssetName)
+		case dbAssetName:
+			fs.probeDLCalls.Add(1)
+			body := rel.dbBody
+			if v, ok := fs.probeBody.Load().([]byte); ok && v != nil {
+				body = v
+			}
+			_, _ = w.Write(body)
+		default:
+			http.Error(w, "unknown asset", http.StatusNotFound)
+		}
+	})
 	fs.srv = httptest.NewServer(mux)
 	t.Cleanup(fs.srv.Close)
 	return fs
 }
 
-// withAPIBase swaps the package-level releasesAPIBase for the duration
-// of the test. The cleanup restores the production value so a failing
-// test can't poison sibling tests in the same binary.
+// withAPIBase swaps both releasesAPIBase AND assetDownloadBase to the
+// fixture URL for the duration of the test. The two are coupled by
+// convention: a test that mocks the GitHub API also mocks the asset
+// CDN, otherwise the auto-update probe (which hits the CDN directly)
+// would leak real github.com requests on every cache-hit test. The
+// cleanup restores both so a failing test can't poison siblings.
 func withAPIBase(t *testing.T, base string) {
 	t.Helper()
-	orig := releasesAPIBase
+	origAPI := releasesAPIBase
+	origAsset := assetDownloadBase
 	releasesAPIBase = base
-	t.Cleanup(func() { releasesAPIBase = orig })
+	assetDownloadBase = base
+	t.Cleanup(func() {
+		releasesAPIBase = origAPI
+		assetDownloadBase = origAsset
+	})
 }
 
 // seedCache writes dbBody + tag sidecar into dir so the tag-match
@@ -228,11 +297,13 @@ func TestBootstrap_FirstFetch(t *testing.T) {
 	}
 }
 
-// TestBootstrap_TagMatchZeroAPICalls is the headline zero-network
-// path for steady-state startup: cache exists, its sidecar tag equals
-// the binary's AppVersion → Bootstrap returns the cached path without
-// any HTTP traffic at all (PR #110 review item 1: must assert zero
-// API calls, not just zero asset downloads).
+// TestBootstrap_TagMatchZeroAPICalls pins the opt-out fast path:
+// cache exists, sidecar tag == AppVersion, AND SkipAutoUpdateProbe is
+// set → Bootstrap returns the cached path without any HTTP traffic at
+// all. Pre-#197 this WAS the steady state; post-#197 the steady state
+// includes a 78-byte probe, so this test specifically asserts the
+// DEADZONE_DB_AUTOUPDATE=0 escape hatch still produces the legacy
+// zero-network behaviour.
 func TestBootstrap_TagMatchZeroAPICalls(t *testing.T) {
 	clearBootstrapEnv(t)
 	rel := newFakeRelease(t, "v1.0.0", "fake-db-content")
@@ -243,8 +314,9 @@ func TestBootstrap_TagMatchZeroAPICalls(t *testing.T) {
 	seedCache(t, cacheDir, "cached-bytes", "v1.0.0")
 
 	path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
-		CacheDir:   cacheDir,
-		AppVersion: "v1.0.0",
+		CacheDir:            cacheDir,
+		AppVersion:          "v1.0.0",
+		SkipAutoUpdateProbe: true,
 	})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
@@ -260,6 +332,9 @@ func TestBootstrap_TagMatchZeroAPICalls(t *testing.T) {
 	}
 	if n := fix.dbCalls.Load(); n != 0 {
 		t.Errorf("db asset hit %d times on tag match, want 0", n)
+	}
+	if n := fix.probeCalls.Load(); n != 0 {
+		t.Errorf("probe hit %d times with SkipAutoUpdateProbe=true, want 0", n)
 	}
 	got, _ := os.ReadFile(path)
 	if string(got) != "cached-bytes" {
@@ -597,6 +672,10 @@ func TestBootstrap_Matrix(t *testing.T) {
 		appVersion string // "v1.0.0" | "v1.1.0" | "dev"
 		cachedTag  string // "" = no cache; otherwise sidecar value
 		offline    bool
+		// skipProbe pins the matrix to the legacy "zero-network on tag
+		// match" contract regardless of the #197 probe default. Probe
+		// behaviour is exercised separately in TestBootstrap_AutoUpdate_*.
+		skipProbe bool
 
 		wantErrSubstr string // "" = expect success
 		wantBody      string // expected installed DB body when success
@@ -608,6 +687,7 @@ func TestBootstrap_Matrix(t *testing.T) {
 			name:        "hit-online-release",
 			appVersion:  "v1.0.0",
 			cachedTag:   "v1.0.0",
+			skipProbe:   true,
 			wantBody:    "cached-bytes",
 			wantAPIHits: 0,
 			wantDBHits:  0,
@@ -691,8 +771,9 @@ func TestBootstrap_Matrix(t *testing.T) {
 			}
 
 			path, upgraded, err := BootstrapWithOptions(context.Background(), BootstrapOptions{
-				CacheDir:   cacheDir,
-				AppVersion: tc.appVersion,
+				CacheDir:            cacheDir,
+				AppVersion:          tc.appVersion,
+				SkipAutoUpdateProbe: tc.skipProbe,
 			})
 
 			if tc.wantErrSubstr != "" {

--- a/internal/db/sidecar.go
+++ b/internal/db/sidecar.go
@@ -1,0 +1,113 @@
+package db
+
+// sidecar.go owns the small JSON manifest that lives next to a cached
+// deadzone.db. The file's sole job is answering, at boot, three
+// questions cheaply:
+//
+//   1. Which release tag does the cached DB belong to? (already needed
+//      by the version-pin contract from #108).
+//   2. What's the sha256 of the cached DB? (needed by the auto-update
+//      probe from #197 — comparing the local sha to the remote
+//      deadzone.db.sha256 must not cost a 50 MB rehash on every boot).
+//   3. When did we last fetch it? (operator visibility / audit).
+//
+// Format evolution: v0 was a single line containing just the tag (e.g.
+// "v0.6.0\n"). v1 is the JSON object below. The reader accepts both,
+// so a binary upgrade onto a v0 cache reads the legacy tag and treats
+// the missing sha256 as "first probe ever — recompute, then rewrite".
+// The writer always emits v1.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// sidecar is the on-disk manifest companion to deadzone.db. JSON tags
+// are snake_case to align with the slog field convention used elsewhere
+// in internal/db.
+type sidecar struct {
+	Tag        string    `json:"tag"`
+	SHA256     string    `json:"sha256,omitempty"`
+	FetchedAt  time.Time `json:"fetched_at,omitempty"`
+}
+
+// readSidecar parses the manifest at path. Order matters: we try JSON
+// first because the v1 format is what the writer emits today; only on
+// JSON parse failure do we fall back to the v0 single-line tag. Doing
+// it the other way around would mis-classify a valid JSON sidecar as a
+// literal tag (the brace would parse as a tag string and never trip
+// the JSON path).
+//
+// A non-existent file returns os.ErrNotExist so callers can use
+// errors.Is to distinguish "no cache yet" from "cache present but
+// unreadable".
+func readSidecar(path string) (sidecar, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return sidecar{}, err
+	}
+	trimmed := strings.TrimSpace(string(b))
+	if trimmed == "" {
+		return sidecar{}, fmt.Errorf("sidecar %s is empty", path)
+	}
+
+	var s sidecar
+	if err := json.Unmarshal([]byte(trimmed), &s); err == nil && s.Tag != "" {
+		return s, nil
+	}
+
+	// Legacy v0: a single non-JSON line that IS the tag. Anything more
+	// complex (multi-line, JSON-like-but-broken) is a corruption we
+	// surface rather than guess at.
+	if strings.ContainsAny(trimmed, "{}\n") {
+		return sidecar{}, fmt.Errorf("sidecar %s: unrecognised format", path)
+	}
+	return sidecar{Tag: trimmed}, nil
+}
+
+// writeSidecar serialises s as pretty-printed JSON and atomically
+// renames it into place. Atomicity matters because the sidecar now
+// carries a sha256 the auto-update probe trusts: a torn write that
+// leaves "tag" set but "sha256" truncated would cause the next boot
+// to compute a fresh sha and rewrite, which is fine functionally but
+// wastes ~50 MB of disk read on the path that's supposed to be cheap.
+//
+// The temp file is created in the destination's directory so os.Rename
+// is a true rename (same filesystem) rather than a cross-device copy.
+func writeSidecar(path string, s sidecar) error {
+	body, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal sidecar: %w", err)
+	}
+	body = append(body, '\n')
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create sidecar tempfile in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(body); err != nil {
+		return fmt.Errorf("write sidecar tempfile: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close sidecar tempfile: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename sidecar %s -> %s: %w", tmpPath, path, err)
+	}
+	cleanup = false
+	return nil
+}

--- a/internal/db/sidecar_test.go
+++ b/internal/db/sidecar_test.go
@@ -1,0 +1,184 @@
+package db
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSidecar_RoundTripV1 is the bread-and-butter case: write a v1
+// JSON sidecar, read it back, all three fields survive the round-trip.
+// FetchedAt is compared via Equal so a marshalled-then-parsed timestamp
+// (which loses monotonic clock and may shift between Local and UTC
+// representations) still matches the original.
+func TestSidecar_RoundTripV1(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deadzone.db.release")
+	want := sidecar{
+		Tag:       "v0.6.0",
+		SHA256:    "3a7f9e2b4c5d6f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f50",
+		FetchedAt: time.Date(2026, 5, 4, 18, 23, 11, 0, time.UTC),
+	}
+	if err := writeSidecar(path, want); err != nil {
+		t.Fatalf("writeSidecar: %v", err)
+	}
+	got, err := readSidecar(path)
+	if err != nil {
+		t.Fatalf("readSidecar: %v", err)
+	}
+	if got.Tag != want.Tag {
+		t.Errorf("Tag = %q, want %q", got.Tag, want.Tag)
+	}
+	if got.SHA256 != want.SHA256 {
+		t.Errorf("SHA256 = %q, want %q", got.SHA256, want.SHA256)
+	}
+	if !got.FetchedAt.Equal(want.FetchedAt) {
+		t.Errorf("FetchedAt = %v, want %v", got.FetchedAt, want.FetchedAt)
+	}
+}
+
+// TestSidecar_LegacyV0Read covers the "binary just upgraded over a v0
+// cache" path: pre-#197 binaries wrote a single-line tag. The new
+// reader must surface the tag with empty SHA256/FetchedAt so the
+// auto-update probe can take the "compute sha local + rewrite" branch.
+func TestSidecar_LegacyV0Read(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deadzone.db.release")
+	if err := os.WriteFile(path, []byte("v0.5.0\n"), 0o644); err != nil {
+		t.Fatalf("seed legacy sidecar: %v", err)
+	}
+	got, err := readSidecar(path)
+	if err != nil {
+		t.Fatalf("readSidecar: %v", err)
+	}
+	if got.Tag != "v0.5.0" {
+		t.Errorf("Tag = %q, want %q", got.Tag, "v0.5.0")
+	}
+	if got.SHA256 != "" {
+		t.Errorf("SHA256 = %q on legacy sidecar, want empty", got.SHA256)
+	}
+	if !got.FetchedAt.IsZero() {
+		t.Errorf("FetchedAt = %v on legacy sidecar, want zero", got.FetchedAt)
+	}
+}
+
+// TestSidecar_LegacyV0NoTrailingNewline covers a hand-crafted legacy
+// sidecar without the trailing newline old binaries wrote. The reader
+// trims whitespace so both forms parse identically.
+func TestSidecar_LegacyV0NoTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deadzone.db.release")
+	if err := os.WriteFile(path, []byte("v0.5.0"), 0o644); err != nil {
+		t.Fatalf("seed legacy sidecar: %v", err)
+	}
+	got, err := readSidecar(path)
+	if err != nil {
+		t.Fatalf("readSidecar: %v", err)
+	}
+	if got.Tag != "v0.5.0" {
+		t.Errorf("Tag = %q, want %q", got.Tag, "v0.5.0")
+	}
+}
+
+// TestSidecar_MissingFieldsTolerated covers a partially-populated v1
+// sidecar (e.g. written by a future binary that drops a field, or a
+// hand-edited file). Missing optional fields fall back to their zero
+// values; missing the required Tag field is an error so we don't end
+// up keying the cache off an empty string.
+func TestSidecar_MissingFieldsTolerated(t *testing.T) {
+	dir := t.TempDir()
+
+	// Tag-only v1 — sha256/fetched_at omitted. Must succeed: the
+	// auto-update probe will treat this as "first probe ever", same
+	// as the legacy v0 path.
+	tagOnly := filepath.Join(dir, "tag-only.json")
+	if err := os.WriteFile(tagOnly, []byte(`{"tag":"v0.6.0"}`), 0o644); err != nil {
+		t.Fatalf("seed tag-only: %v", err)
+	}
+	got, err := readSidecar(tagOnly)
+	if err != nil {
+		t.Fatalf("readSidecar(tag-only): %v", err)
+	}
+	if got.Tag != "v0.6.0" || got.SHA256 != "" || !got.FetchedAt.IsZero() {
+		t.Errorf("tag-only parse = %+v, want only Tag set", got)
+	}
+
+	// Empty object — no Tag means the file can't usefully key the
+	// cache; readSidecar must error rather than return an empty Tag
+	// that the caller might mistake for a cache hit.
+	empty := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(empty, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("seed empty: %v", err)
+	}
+	if _, err := readSidecar(empty); err == nil {
+		t.Errorf("readSidecar(empty object) returned nil error, want error")
+	}
+}
+
+// TestSidecar_CorruptedRejected covers torn-write / hostile-edit
+// scenarios. A truncated JSON object must NOT silently fall back to
+// the legacy parser and get classified as a literal tag — that would
+// poison the cache lookup with a giant unparseable "tag" value. The
+// reader's strict guard refuses anything containing JSON syntax that
+// fails to parse cleanly.
+func TestSidecar_CorruptedRejected(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"truncated-json", `{"tag":"v0.6.0"`},
+		{"multi-line-non-json", "v0.6.0\nextra\n"},
+		{"only-newlines", "\n\n\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name+".release")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			if _, err := readSidecar(path); err == nil {
+				t.Errorf("readSidecar accepted corrupted content %q", tc.content)
+			}
+		})
+	}
+}
+
+// TestSidecar_NonExistent covers the first-fetch path: no sidecar yet.
+// The error must wrap os.ErrNotExist so Bootstrap can errors.Is its way
+// to the "no cache" branch rather than treating it as a corruption.
+func TestSidecar_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+	_, err := readSidecar(filepath.Join(dir, "missing.release"))
+	if err == nil {
+		t.Fatal("readSidecar on missing file returned nil error")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("error %q does not wrap os.ErrNotExist", err)
+	}
+}
+
+// TestSidecar_WriteIsAtomic asserts that no .tmp-* file is left behind
+// after a successful write. This pins the os.Rename pattern: a future
+// refactor that switches to non-atomic write-then-rename or forgets to
+// clean up on the failure path would regress here.
+func TestSidecar_WriteIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deadzone.db.release")
+	s := sidecar{Tag: "v0.6.0", SHA256: strings.Repeat("a", 64), FetchedAt: time.Now().UTC()}
+	if err := writeSidecar(path, s); err != nil {
+		t.Fatalf("writeSidecar: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("tempfile %q left behind after successful write", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a boot-time database freshness probe that auto-updates the local DB when stale, gated by a 3-second budget so server startup stays snappy. Backed by a new JSON sidecar (v2) carrying `sha256` and `fetched_at` for integrity and freshness checks.

## Changes

- **`internal/db/sidecar.go`**: New JSON sidecar v2 format with `sha256` + `fetched_at` fields, plus read/write helpers and tests.
- **`internal/db/bootstrap.go`**: Boot-time auto-update probe with a 3s budget; falls back to the existing DB on timeout or fetch error.
- **`cmd/deadzone/server.go`**: Wires the `DEADZONE_DB_AUTOUPDATE` env var into the server boot path.
- **`cmd/deadzone/fetchdb.go`**: Updated to emit the v2 sidecar on fetch.
- **Tests**: Integration coverage for the probe paths (fresh, stale, timeout, fetch failure) in `bootstrap_test.go`.
- **Docs**: README and `docs/research/ingestion-architecture.md` updated to describe the probe and sidecar.

## Test plan

- [ ] `go test ./internal/db/...`
- [ ] Run `deadzone server` with a stale DB and `DEADZONE_DB_AUTOUPDATE=1`; confirm probe triggers and respects the 3s budget
- [ ] Run with `DEADZONE_DB_AUTOUPDATE=0`; confirm probe is skipped
- [ ] Verify sidecar JSON contains `sha256` and `fetched_at` after a fetch

<!-- emdash-issue-footer:start -->
Fixes #197
<!-- emdash-issue-footer:end -->