### PR TITLE
ci: add chain-image fired breadcrumb + #212 debug notes

### DIFF
--- a/.github/workflows/chain-image.yml
+++ b/.github/workflows/chain-image.yml
@@ -26,6 +26,17 @@
 #
 # Auth: dispatch uses the default GITHUB_TOKEN with `actions: write`
 # scoped to this job. No PAT.
+#
+# Debugging "chain-image stopped firing" (#212): first verify the
+# workflows registry shows chain-image `state: active` and that
+# `workflows: ["scrape-pack"]` below matches scrape-pack.yml's `name:`
+# field exactly (case-sensitive). If both check out, suspect the
+# first-run-after-add gotcha — GitHub does not always register a
+# freshly-landed `workflow_run` trigger in time for the first upstream
+# completion (the v0.7.1 cycle hit this: sibling chain-release fired,
+# chain-image didn't, despite identical trigger shape). The second
+# upstream completion picks up reliably. Manual fallback meanwhile:
+# `gh workflow run docker-publish.yml --ref main -f tag=<tag>`.
 
 name: chain-image
 
@@ -52,6 +63,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Fired
+        # Job-start breadcrumb (#212): grep `chain-image fired` in run
+        # logs to confirm the trigger ran without scanning the
+        # downstream dispatch step (whose notice the skip gates can
+        # swallow). Mirrors chain-release.yml's notice idiom.
+        env:
+          UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id }}
+          UPSTREAM_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        shell: bash
+        run: |
+          echo "::notice::chain-image fired for scrape-pack run #${UPSTREAM_RUN_ID}: ${UPSTREAM_RUN_URL}"
+
       - name: Resolve tag from upstream run
         id: tag
         env:


### PR DESCRIPTION
## Summary

Adds observability and documentation to `.github/workflows/chain-image.yml` after issue #212 (chain-image stopped firing during the v0.7.1 cycle).

## Changes

- **New `Fired` job-start step** — emits a `::notice::chain-image fired` breadcrumb so run logs can be greped to confirm the `workflow_run` trigger executed, without having to scan the downstream dispatch step (whose notices can be swallowed by skip gates). Mirrors the existing idiom in `chain-release.yml`.
- **Header comment block** — documents the #212 debugging playbook: verify registry `state: active`, confirm `workflows: ["scrape-pack"]` matches `scrape-pack.yml`'s `name:` exactly, and notes the first-run-after-add gotcha where GitHub may not register a freshly-landed `workflow_run` trigger in time for the first upstream completion. Includes the manual `gh workflow run docker-publish.yml` fallback.

## Test plan

- [ ] Merge and wait for next `scrape-pack` completion
- [ ] Confirm `chain-image fired for scrape-pack run #...` notice appears in the run logs
- [ ] Verify downstream `docker-publish` dispatch still triggers as before

<!-- emdash-issue-footer:start -->
Fixes #212
<!-- emdash-issue-footer:end -->