### PR TITLE
fix(ci): cache-keepalive 0/253 false-positive — SIGPIPE on grep -Fxq under pipefail

### DIFF
--- a/.github/workflows/cache-keepalive.yml
+++ b/.github/workflows/cache-keepalive.yml
@@ -207,9 +207,20 @@ jobs:
           # exactly what scrape-pack.yml's cache step writes, otherwise
           # this job reports phantom misses on entries that are actually
           # alive in the cache.
+          # Pure-bash substring match against a pre-framed haystack so we
+          # never put `caches` through a pipe under `set -o pipefail`.
+          # The earlier `printf '%s\n' "$caches" | grep -Fxq -- "$expected"`
+          # form silently broke once the repo's cache list crossed ~500
+          # entries: grep's `-q` early-exits on first match, SIGPIPEs the
+          # `printf` writer, pipefail surfaces 141 from the pipeline, the
+          # `if` branch goes false, and every probed slot reports `miss`
+          # — exactly the 0/253 false-positive that #163's 0% guard was
+          # meant to catch as drift. The bash glob walks the same
+          # haystack once per slot and stays in-process.
+          haystack=$'\n'"$caches"$'\n'
           while IFS=$'\t' read -r lib_id version slug cache_hash; do
             expected="artifact-${slug}-${version}-${cache_hash}-emb${EMBEDDER_SIGNATURE}-schema${SCHEMA_VERSION}"
-            if printf '%s\n' "$caches" | grep -Fxq -- "$expected"; then
+            if [[ "$haystack" == *$'\n'"$expected"$'\n'* ]]; then
               status="hit"; hit=$((hit + 1))
             else
               status="miss"; miss=$((miss + 1))


### PR DESCRIPTION
## Summary

The `report` job in `cache-keepalive.yml` has been failing every run since the repo's cache list crossed ~500 entries. The `::error::cache-keepalive: 0/253 slots hit — cache key drift suspected (see #153 for past pattern)` message is a **false positive**: the cache keys are intact and the live API returns them; the bug is in how report compares them.

## Root cause

```bash
printf '%s\n' "$caches" | grep -Fxq -- "$expected"
```

Under `set -o pipefail` (set at the script top), with `$caches` now ≥ 75 KB (509 cache keys × ~150 chars), the Linux pipe buffer (~64 KB) fills before `printf` finishes writing. `grep -q` matches the first hit and exits 0 immediately, sending SIGPIPE to the still-writing `printf`. The pipeline's exit code becomes 141 (printf's SIGPIPE exit), `if` evaluates non-zero → else branch → counted as `miss`.

Every one of the 253 probed slots takes the false branch even when the cache key is present, surfacing as the 0% hit-rate that #163's drift guard was meant to catch.

Logs evidence (run 25487032401, manual re-trigger):

```
report.sh: line 30: printf: write error: Broken pipe
[× 253]
##[error]cache-keepalive: 0/253 slots hit — cache key drift suspected
```

## Fix

Replace the pipe with a pure-bash substring match against a pre-framed haystack:

```bash
haystack=$'\n'"$caches"$'\n'
while IFS=$'\t' read -r lib_id version slug cache_hash; do
  expected="artifact-${slug}-${version}-${cache_hash}-emb${EMBEDDER_SIGNATURE}-schema${SCHEMA_VERSION}"
  if [[ "$haystack" == *$'\n'"$expected"$'\n'* ]]; then
    ...
```

Newlines on both ends keep the match line-anchored exactly like `grep -Fx`. No subshell, no pipe, no SIGPIPE. The match stays in-process so the failure mode disappears regardless of how big the cache list grows.

## Verification

- ✅ YAML parses (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- ✅ Bash glob match logic verified locally: `[[ $haystack == *$'\n'"5"$'\n'* ]]` returns hit on a 1000-line haystack with `\n5\n` present
- ✅ I probed the live `gh api` from local: 509 entries returned, 261 with `-emb5355f97...-schema5`, the expected key for `modelcontextprotocol_go-sdk_1.4` is found exactly (so drift was never the issue)
- [ ] After merge, manually trigger `cache-keepalive.yml` and confirm hit-rate is non-zero. Expected ~253/253 since no semantic key change has happened (sig + schema unchanged from v0.7.1).

## Out of scope

- The 0% drift guard from #163 stays — it's the right alarm, just was firing on a phantom condition.
- Per-slot `cache-hit` outputs from `actions/cache/restore` (the authoritative signal) untouched; only the post-run aggregator changes.
- No change to cache key shape, expand-libs, or the per-batch refresh.

Closes the silent-flapping pattern that's been hiding behind a real-looking #153 reference for several runs.