### PR TITLE
fix(ci): chain-release uses PAT so scrape-pack completion fires chain-image

### DIFF
--- a/.github/workflows/chain-release.yml
+++ b/.github/workflows/chain-release.yml
@@ -23,11 +23,17 @@
 #     want a scrape on a pre-release can dispatch scrape-pack.yml
 #     manually, which remains supported).
 #
-# Auth: dispatch uses the default GITHUB_TOKEN with `actions: write`
-# scoped to this job. workflow_dispatch via the REST API is explicitly
-# allowed for the default token (the anti-recursion gate that blocks
-# `push` events from triggering downstream workflows does NOT apply
-# to direct workflow_dispatch calls). No PAT required.
+# Auth: dispatch uses CHAIN_DISPATCH_TOKEN, a fine-grained PAT scoped
+# to laradji/deadzone with `Actions: read+write` only. The default
+# GITHUB_TOKEN cannot be used here: GitHub's anti-recursion gate
+# allows the dispatch itself (scrape-pack runs successfully) but
+# SUPPRESSES the downstream `workflow_run` trigger on its completion,
+# so chain-image.yml never fires when the dispatching actor is
+# `github-actions[bot]`. A PAT re-enables the chain by making the
+# triggering_actor a real user. Same failure mode that #148 solved
+# for release.yml -> update-package-channels.yml; see #216 for the
+# v0.7.2 diagnostic that confirmed the gate applies on every tag
+# push, not just first-run-after-add.
 
 name: chain-release
 
@@ -84,10 +90,25 @@ jobs:
           echo "tag=$REF" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
+      # Fail fast: a missing/rotated PAT otherwise surfaces as a 401 deep
+      # in `gh workflow run` and looks like a transient dispatch failure.
+      # Mirrors release.yml's RELEASE_PUBLISH_TOKEN check. Gated on
+      # skip != 'true' so pre-release tags don't trip the validation
+      # when no dispatch is needed anyway. See #216.
+      - name: Validate secrets
+        if: steps.tag.outputs.skip != 'true'
+        env:
+          CHAIN_DISPATCH_TOKEN: ${{ secrets.CHAIN_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$CHAIN_DISPATCH_TOKEN" ]; then
+            echo "::error::CHAIN_DISPATCH_TOKEN missing or empty - required PAT (Actions: read+write on this repo) so scrape-pack's completion spawns chain-image.yml. The default GITHUB_TOKEN is anti-recursion-gated and would suppress the workflow_run downstream. See repo settings -> secrets and #216."
+            exit 1
+          fi
+
       - name: Dispatch scrape-pack.yml
         if: steps.tag.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CHAIN_DISPATCH_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
           UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id }}
           UPSTREAM_RUN_URL: ${{ github.event.workflow_run.html_url }}


### PR DESCRIPTION
## Summary

- Replace `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` with `secrets.CHAIN_DISPATCH_TOKEN` on `chain-release.yml`'s `Dispatch scrape-pack.yml` step. The default token's anti-recursion gate allows the dispatch itself but suppresses the downstream `workflow_run` trigger on scrape-pack's completion, so `chain-image.yml` never fires. A user-owned PAT re-enables the chain.
- Rewrite the header comment block — the previous "the anti-recursion gate ... does NOT apply to workflow_dispatch" claim was wrong in the part that matters here (downstream `workflow_run`).
- Add a `Validate secrets` fail-fast step mirroring `release.yml`'s `RELEASE_PUBLISH_TOKEN` check (matches the #148 precedent).

Closes #216. Same anti-recursion class as #148 (which fixed `release.yml -> update-package-channels.yml`).

## Operator action required before this is effective

- [ ] Provision repo secret `CHAIN_DISPATCH_TOKEN`: fine-grained PAT, scope `laradji/deadzone` only, `Actions: Read and write`, no other permissions. Single-purpose secret, easier to audit/rotate than extending `RELEASE_PUBLISH_TOKEN`.
- [ ] Without the secret, chain-release will fail loudly on the next stable tag with a clear error pointing at repo settings → secrets and #216 (intentional — surfaces the missing PAT immediately instead of letting scrape-pack run to no avail).

## Diagnostic recap (from #216)

| scrape-pack run | event | triggering_actor | chain-image fired? |
|---|---|---|---|
| 25505373769 (v0.7.2 tag, dispatched by chain-release.yml) | `workflow_dispatch` | `github-actions[bot]` | ❌ no |
| 25507444431 (manual probe by operator) | `workflow_dispatch` | `laradji` | ✅ yes (run 25507936913) |

Same event, same branch, same successful completion — only the actor differs. PAT swap makes `triggering_actor` a real user.

## Test plan

- [x] YAML lints — `python3 -c "import yaml; yaml.safe_load(...)"` passes.
- [x] No regression: existing gates (`workflow_run.conclusion == 'success'`, tag-push event, `^v[0-9]+\\.[0-9]+\\.[0-9]+$` stable-tag regex) unchanged.
- [x] Pre-release tags still skip dispatch (and skip the PAT validation, so a missing PAT does NOT break pre-release tag pushes).
- [ ] **End-to-end validation on v0.7.3 tag push (operator)** — full chain `release.yml → chain-release → scrape-pack → chain-image → docker-publish` runs without manual `gh workflow run` calls. PR cannot be marked done until this validates.

## Out of scope

Per #216: no changes to `scrape-pack.yml`, `chain-image.yml`, `docker-publish.yml`, or `release.yml`. The break is on the chain-release dispatch hop only.

Note on AC: the issue mentions adding a bullet to `CLAUDE.md` "Release operator secrets". That file is gitignored in this repo (see `.gitignore`); the operator can update their private copy outside the PR.