### PR TITLE
fix(ci): chain-image parses tag from scrape-pack run-name

### DIFF
--- a/.github/workflows/chain-image.yml
+++ b/.github/workflows/chain-image.yml
@@ -78,20 +78,25 @@ jobs:
       - name: Resolve tag from upstream run
         id: tag
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id }}
+          UPSTREAM_TITLE: ${{ github.event.workflow_run.display_title }}
         shell: bash
         run: |
           set -euo pipefail
-          # The `inputs` field on the run JSON gives us the
-          # workflow_dispatch inputs the upstream scrape-pack run was
-          # invoked with. scrape-pack runs are always dispatch-mode
-          # (chain-release dispatches it on stable-tag pushes; operators
-          # dispatch it manually for cache-warm or hotfix runs), so
-          # `.inputs.tag` is the authoritative source — empty for the
-          # cache-warm path, populated for everything else.
-          tag=$(gh api "repos/${{ github.repository }}/actions/runs/${UPSTREAM_RUN_ID}" --jq '.inputs.tag // empty')
-          if [[ -z "$tag" ]]; then
+          # scrape-pack.yml encodes its `inputs.tag` value in its
+          # top-level `run-name:`, which surfaces here as
+          # `display_title`: `scrape-pack (v<x.y.z>)` for tagged runs,
+          # `scrape-pack (cache-warm)` for the #126 cache-warm path. We
+          # parse the parenthesized payload back out — the runs REST
+          # endpoint does NOT expose workflow_dispatch inputs (#218), so
+          # the display_title is our only cross-workflow_run channel for
+          # the dispatch tag.
+          if [[ "$UPSTREAM_TITLE" =~ \(([^\)]+)\) ]]; then
+            tag="${BASH_REMATCH[1]}"
+          else
+            tag=""
+          fi
+          if [[ "$tag" == "cache-warm" || -z "$tag" ]]; then
             echo "::notice::scrape-pack run #${UPSTREAM_RUN_ID} had empty tag (cache-warm path); skipping docker-publish"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/scrape-pack.yml
+++ b/.github/workflows/scrape-pack.yml
@@ -20,6 +20,15 @@
 
 name: scrape-pack
 
+# Embed inputs.tag in the run-name so the chain-image consumer can
+# recover it from `github.event.workflow_run.display_title` — the runs
+# REST endpoint does NOT expose workflow_dispatch inputs, and run-name
+# is the established pattern for ferrying dispatch metadata across the
+# workflow_run boundary (#218). Format is locked: chain-image.yml's
+# parser expects exactly one parenthesized payload, either
+# `scrape-pack (v<x.y.z>)` or `scrape-pack (cache-warm)`.
+run-name: ${{ inputs.tag && format('scrape-pack ({0})', inputs.tag) || 'scrape-pack (cache-warm)' }}
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Closes #218.

## Summary

- `chain-image.yml`'s `Resolve tag from upstream run` step was reading `gh api .../runs/<id> --jq '.inputs.tag'`, which always returns `null` — the runs REST endpoint does NOT expose workflow_dispatch inputs. Latent since #209; surfaced after #217 made chain-image fire reliably (every release v0.7.0–v0.7.3 needed a manual `gh workflow run docker-publish.yml` because chain-image's auto-dispatch was always skipped).
- `scrape-pack.yml` gains a top-level `run-name:` that embeds `inputs.tag`: `scrape-pack (v<x.y.z>)` for tagged runs, `scrape-pack (cache-warm)` for empty-tag dispatches.
- `chain-image.yml` parses the tag back out of `github.event.workflow_run.display_title` instead of hitting the runs API. Stable-tag regex (`^v[0-9]+\.[0-9]+\.[0-9]+$`) and cache-warm skip gate preserved exactly. Old misleading comment about "the inputs field on the run JSON" deleted per the issue AC.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scrape-pack.yml'))"` — OK
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/chain-image.yml'))"` — OK
- [x] Regex sanity-checked locally against four inputs: `scrape-pack (v0.7.4)` → tag=v0.7.4, `scrape-pack (cache-warm)` → cache-warm gate, `scrape-pack (v1.2.3-rc1)` → stable-tag-filter skip, bare `scrape-pack` (legacy in-flight runs) → cache-warm gate.
- [ ] After merge: probe with `gh workflow run scrape-pack.yml --ref main -f lib="" -f tag=""` → chain-image's Resolve-tag step should log "cache-warm path; skipping".
- [ ] After merge: probe with `gh workflow run scrape-pack.yml --ref main -f lib="" -f tag=v0.7.3` → chain-image's `Dispatch docker-publish.yml` step conclusion should be `success` (not `skipped`), and a fresh docker-publish run should appear shortly after.
- [ ] **End-to-end validation: tag v0.7.4** — full chain (release → chain-release → scrape-pack → chain-image → docker-publish) must complete with no operator dispatch. This is the issue's Definition of Done.